### PR TITLE
Add array_int_minimum propagator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -284,7 +284,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -306,7 +306,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -317,7 +317,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -577,7 +577,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -676,7 +676,7 @@ checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 [[package]]
 name = "pindakaas"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#d5c43e12c5f46a64fbc7a041c8e57e356d97c665"
+source = "git+https://github.com/pindakaashq/pindakaas.git#e7087d6849feed20a7a297369d17db39c4d5add2"
 dependencies = [
  "cached",
  "iset",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "pindakaas-build-macros"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#d5c43e12c5f46a64fbc7a041c8e57e356d97c665"
+source = "git+https://github.com/pindakaashq/pindakaas.git#e7087d6849feed20a7a297369d17db39c4d5add2"
 dependencies = [
  "cc",
  "paste",
@@ -699,7 +699,7 @@ dependencies = [
 [[package]]
 name = "pindakaas-cadical"
 version = "1.9.5"
-source = "git+https://github.com/pindakaashq/pindakaas.git#d5c43e12c5f46a64fbc7a041c8e57e356d97c665"
+source = "git+https://github.com/pindakaashq/pindakaas.git#e7087d6849feed20a7a297369d17db39c4d5add2"
 dependencies = [
  "cc",
  "pindakaas-build-macros",
@@ -708,18 +708,18 @@ dependencies = [
 [[package]]
 name = "pindakaas-derive"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#d5c43e12c5f46a64fbc7a041c8e57e356d97c665"
+source = "git+https://github.com/pindakaashq/pindakaas.git#e7087d6849feed20a7a297369d17db39c4d5add2"
 dependencies = [
  "darling 0.20.8",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -769,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scopeguard"
@@ -781,29 +781,29 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -909,22 +909,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -956,7 +956,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1212,20 +1212,20 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.33"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087eca3c1eaf8c47b94d02790dd086cd594b912d2043d4de4bfdd466b3befb7c"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.33"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4b6c273f496d8fd4eaf18853e6b448760225dc030ff2c485a786859aea6393"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.61",
 ]

--- a/crates/huub/Cargo.toml
+++ b/crates/huub/Cargo.toml
@@ -20,8 +20,8 @@ pindakaas = { git = "https://github.com/pindakaashq/pindakaas.git", features = [
 thiserror = "1.0.59"
 tracing = "0.1.40"
 
-[lints]
-workspace = true
-
 [dev-dependencies]
 expect-test = "1.5.0"
+
+[lints]
+workspace = true

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -5,8 +5,8 @@ pub(crate) mod solver;
 pub(crate) mod tests;
 
 pub use model::{
-	bool::BoolExpr, flatzinc::FlatZincError, int::IntExpr, reformulate::ReformulationError,
-	Constraint, Model, Variable,
+	bool::BoolExpr, constraint::Constraint, flatzinc::FlatZincError, int::IntExpr,
+	reformulate::ReformulationError, Model, Variable,
 };
 pub use pindakaas::solver::SlvTermSignal;
 use pindakaas::Lit as RawLit;

--- a/crates/huub/src/model/bool.rs
+++ b/crates/huub/src/model/bool.rs
@@ -510,7 +510,7 @@ mod tests {
 	fn test_bool_and() {
 		// Simple Satisfiable test case
 		let mut m = Model::default();
-		let b = m.new_bool_var_range(3);
+		let b = m.new_bool_vars(3);
 
 		m += BoolExpr::And(b.iter().copied().map_into().collect());
 		let (mut slv, map): (Solver, _) = m.to_solver().unwrap();
@@ -519,7 +519,7 @@ mod tests {
 
 		// Simple Unsatisfiable test case
 		let mut m = Model::default();
-		let b = m.new_bool_var_range(3);
+		let b = m.new_bool_vars(3);
 
 		m += BoolExpr::And(b.iter().copied().map_into().collect());
 		m += BoolExpr::from(!b[0]);
@@ -531,7 +531,7 @@ mod tests {
 	fn test_bool_or() {
 		// Simple Satisfiable test case
 		let mut m = Model::default();
-		let b = m.new_bool_var_range(3);
+		let b = m.new_bool_vars(3);
 
 		m += BoolExpr::Or(b.iter().copied().map_into().collect());
 		let (mut slv, map): (Solver, _) = m.to_solver().unwrap();
@@ -550,7 +550,7 @@ mod tests {
 
 		// Simple Unsatisfiable test case
 		let mut m = Model::default();
-		let b = m.new_bool_var_range(3);
+		let b = m.new_bool_vars(3);
 
 		m += BoolExpr::Or(b.iter().copied().map_into().collect());
 		m += BoolExpr::And(b.iter().copied().map(|l| (!l).into()).collect());
@@ -562,7 +562,7 @@ mod tests {
 	fn test_bool_xor() {
 		// Simple Satisfiable test case
 		let mut m = Model::default();
-		let b = m.new_bool_var_range(3);
+		let b = m.new_bool_vars(3);
 
 		m += BoolExpr::Xor(b.iter().copied().map_into().collect());
 		let (mut slv, map): (Solver, _) = m.to_solver().unwrap();
@@ -578,7 +578,7 @@ mod tests {
 
 		// Simple Unsatisfiable test case
 		let mut m = Model::default();
-		let b = m.new_bool_var_range(2);
+		let b = m.new_bool_vars(2);
 
 		m += BoolExpr::Xor(b.iter().copied().map_into().collect());
 		m += BoolExpr::from(!b[0]);
@@ -591,7 +591,7 @@ mod tests {
 	fn test_bool_eq_reif() {
 		// Simple Satisfiable test case
 		let mut m = Model::default();
-		let b = m.new_bool_var_range(3);
+		let b = m.new_bool_vars(3);
 
 		m += BoolExpr::Equiv(vec![
 			b[0].into(),
@@ -613,7 +613,7 @@ mod tests {
 	fn test_bool_and_reif() {
 		// Simple Satisfiable test case
 		let mut m = Model::default();
-		let b = m.new_bool_var_range(3);
+		let b = m.new_bool_vars(3);
 
 		m += BoolExpr::Equiv(vec![
 			b[0].into(),
@@ -635,7 +635,7 @@ mod tests {
 	fn test_bool_clause_reif() {
 		// Simple Satisfiable test case
 		let mut m = Model::default();
-		let b = m.new_bool_var_range(3);
+		let b = m.new_bool_vars(3);
 
 		m += BoolExpr::Equiv(vec![
 			b[0].into(),

--- a/crates/huub/src/model/constraint.rs
+++ b/crates/huub/src/model/constraint.rs
@@ -1,0 +1,178 @@
+use flatzinc_serde::RangeList;
+use itertools::Itertools;
+use pindakaas::{
+	solver::{PropagatorAccess, Solver as SolverTrait},
+	Valuation as SatValuation,
+};
+
+use super::reformulate::{ReifContext, VariableMap};
+use crate::{
+	propagator::{all_different::AllDifferentValue, int_lin_le::LinearLE, minimum::Minimum},
+	solver::SatSolver,
+	BoolExpr, IntExpr, IntVal, Model, ReformulationError, Solver,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Constraint {
+	AllDifferent(Vec<IntExpr>),
+	IntLinEq(Vec<IntVal>, Vec<IntExpr>, IntVal),
+	IntLinLessEq(Vec<IntVal>, Vec<IntExpr>, IntVal),
+	Maximum(Vec<IntExpr>, IntExpr),
+	Minimum(Vec<IntExpr>, IntExpr),
+	SimpleBool(BoolExpr),
+}
+
+impl Constraint {
+	pub(crate) fn to_solver<Sol, Sat>(
+		&self,
+		slv: &mut Solver<Sat>,
+		map: &mut VariableMap,
+	) -> Result<(), ReformulationError>
+	where
+		Sol: PropagatorAccess + SatValuation,
+		Sat: SatSolver + SolverTrait<ValueFn = Sol>,
+	{
+		match self {
+			Constraint::SimpleBool(exp) => exp.constrain(slv, map),
+			Constraint::AllDifferent(v) => {
+				let vars: Vec<_> = v
+					.iter()
+					.map(|v| v.to_arg(ReifContext::Mixed, slv, map))
+					.collect();
+				slv.add_propagator(AllDifferentValue::new(vars));
+				Ok(())
+			}
+			Constraint::IntLinLessEq(coeffs, vars, c) => {
+				let vars: Vec<_> = vars
+					.iter()
+					.zip_eq(coeffs.iter())
+					.map(|(v, &c)| {
+						v.to_arg(
+							if c >= 0 {
+								ReifContext::Pos
+							} else {
+								ReifContext::Neg
+							},
+							slv,
+							map,
+						)
+					})
+					.collect();
+				slv.add_propagator(LinearLE::new(coeffs, vars, *c));
+				Ok(())
+			}
+			Constraint::IntLinEq(coeffs, vars, c) => {
+				let vars: Vec<_> = vars
+					.iter()
+					.map(|v| v.to_arg(ReifContext::Mixed, slv, map))
+					.collect();
+				// coeffs * vars <= c
+				slv.add_propagator(LinearLE::new(coeffs, vars.clone(), *c));
+				// coeffs * vars >= c <=>  -coeffs * vars <= -c
+				slv.add_propagator(LinearLE::new(
+					&coeffs.iter().map(|c| -c).collect_vec(),
+					vars,
+					-c,
+				));
+				Ok(())
+			}
+			Constraint::Minimum(vars, y) => {
+				let vars: Vec<_> = vars
+					.iter()
+					.map(|v| v.to_arg(ReifContext::Mixed, slv, map))
+					.collect();
+				let y = y.to_arg(ReifContext::Mixed, slv, map);
+				slv.add_propagator(Minimum::new(vars, y));
+				Ok(())
+			}
+			Constraint::Maximum(vars, y) => {
+				let vars: Vec<_> = vars
+					.iter()
+					.map(|v| -v.to_arg(ReifContext::Mixed, slv, map))
+					.collect();
+				let y = -y.to_arg(ReifContext::Mixed, slv, map);
+				slv.add_propagator(Minimum::new(vars, y));
+				Ok(())
+			}
+		}
+	}
+}
+
+impl Model {
+	pub(crate) fn propagate(&mut self, con: usize) -> Result<(), ReformulationError> {
+		match self.constraints[con].clone() {
+			Constraint::AllDifferent(vars) => {
+				let (vals, vars): (Vec<_>, Vec<_>) =
+					vars.iter().partition(|v| matches!(v, IntExpr::Val(_)));
+				if vals.is_empty() {
+					return Ok(());
+				}
+				let neg_dom = RangeList::from_iter(vals.iter().map(|i| {
+					let IntExpr::Val(i) = i else { unreachable!() };
+					*i..=*i
+				}));
+				for v in vars {
+					self.diff_int_domain(v, &neg_dom, con)?
+				}
+				Ok(())
+			}
+			Constraint::Maximum(args, m) => {
+				let max_lb = args
+					.iter()
+					.map(|a| self.get_int_lower_bound(a))
+					.max()
+					.unwrap();
+				let max_ub = args
+					.iter()
+					.map(|a| self.get_int_upper_bound(a))
+					.max()
+					.unwrap();
+				self.set_int_lower_bound(&m, max_lb, con)?;
+				self.set_int_upper_bound(&m, max_ub, con)?;
+
+				let ub = self.get_int_upper_bound(&m);
+				for a in args {
+					self.set_int_upper_bound(&a, ub, con)?;
+				}
+				Ok(())
+			}
+			Constraint::Minimum(args, m) => {
+				let min_lb = args
+					.iter()
+					.map(|a| self.get_int_lower_bound(a))
+					.min()
+					.unwrap();
+				let min_ub = args
+					.iter()
+					.map(|a| self.get_int_upper_bound(a))
+					.min()
+					.unwrap();
+				self.set_int_lower_bound(&m, min_lb, con)?;
+				self.set_int_upper_bound(&m, min_ub, con)?;
+
+				let lb = self.get_int_lower_bound(&m);
+				for a in args {
+					self.set_int_lower_bound(&a, lb, con)?;
+				}
+				Ok(())
+			}
+			_ => Ok(()),
+		}
+	}
+
+	pub(crate) fn subscribe(&mut self, con: usize) {
+		match &self.constraints[con] {
+			Constraint::Maximum(args, m) | Constraint::Minimum(args, m) => {
+				for a in args {
+					if let IntExpr::Var(a) = a {
+						self.int_vars[a.0 as usize].constraints.push(con);
+					}
+				}
+				if let IntExpr::Var(m) = m {
+					self.int_vars[m.0 as usize].constraints.push(con);
+				}
+			}
+			_ => {}
+		}
+	}
+}

--- a/crates/huub/src/model/int.rs
+++ b/crates/huub/src/model/int.rs
@@ -10,7 +10,7 @@ use crate::{
 		view::{IntView, IntViewInner, SolverView},
 		SatSolver,
 	},
-	IntVal, Solver, Variable,
+	IntVal, Model, ReformulationError, Solver, Variable,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -46,7 +46,224 @@ impl IntExpr {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct IntVar(pub(crate) u32);
 
-#[derive(Debug)]
+impl From<IntVar> for IntExpr {
+	fn from(value: IntVar) -> Self {
+		IntExpr::Var(value)
+	}
+}
+impl From<IntVal> for IntExpr {
+	fn from(value: IntVal) -> Self {
+		IntExpr::Val(value)
+	}
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct IntVarDef {
 	pub(crate) domain: RangeList<IntVal>,
+	pub(crate) constraints: Vec<usize>,
+}
+
+impl IntVarDef {
+	pub(crate) fn with_domain(dom: RangeList<IntVal>) -> Self {
+		Self {
+			domain: dom,
+			constraints: Vec::new(),
+		}
+	}
+}
+
+impl Model {
+	pub(crate) fn get_int_lower_bound(&self, iv: &IntExpr) -> IntVal {
+		match *iv {
+			IntExpr::Var(v) => {
+				let def = &self.int_vars[v.0 as usize];
+				*def.domain.lower_bound().unwrap()
+			}
+			IntExpr::Val(v) => v,
+		}
+	}
+
+	pub(crate) fn get_int_upper_bound(&self, iv: &IntExpr) -> IntVal {
+		match *iv {
+			IntExpr::Var(v) => {
+				let def = &self.int_vars[v.0 as usize];
+				*def.domain.upper_bound().unwrap()
+			}
+			IntExpr::Val(v) => v,
+		}
+	}
+
+	pub(crate) fn set_int_lower_bound(
+		&mut self,
+		iv: &IntExpr,
+		lb: IntVal,
+		con: usize,
+	) -> Result<(), ReformulationError> {
+		match *iv {
+			IntExpr::Var(v) => {
+				let def = &mut self.int_vars[v.0 as usize];
+				if lb <= *def.domain.lower_bound().unwrap() {
+					return Ok(());
+				} else if lb > *def.domain.upper_bound().unwrap() {
+					return Err(ReformulationError::TrivialUnsatisfiable);
+				}
+				def.domain = RangeList::from_iter((&def.domain).into_iter().filter_map(|r| {
+					if **r.end() < lb {
+						None
+					} else if **r.start() < lb {
+						Some(lb..=**r.end())
+					} else {
+						Some(**r.start()..=**r.end())
+					}
+				}));
+				let constraints = def.constraints.clone();
+				for c in constraints {
+					if c != con {
+						self.enqueue(c);
+					}
+				}
+				Ok(())
+			}
+			IntExpr::Val(v) => {
+				if v < lb {
+					Err(ReformulationError::TrivialUnsatisfiable)
+				} else {
+					Ok(())
+				}
+			}
+		}
+	}
+
+	pub(crate) fn set_int_upper_bound(
+		&mut self,
+		iv: &IntExpr,
+		ub: IntVal,
+		con: usize,
+	) -> Result<(), ReformulationError> {
+		match *iv {
+			IntExpr::Var(v) => {
+				let def = &mut self.int_vars[v.0 as usize];
+				if ub >= *def.domain.lower_bound().unwrap() {
+					return Ok(());
+				} else if ub < *def.domain.lower_bound().unwrap() {
+					return Err(ReformulationError::TrivialUnsatisfiable);
+				}
+				def.domain = RangeList::from_iter((&def.domain).into_iter().filter_map(|r| {
+					if ub < **r.start() {
+						None
+					} else if ub < **r.end() {
+						Some(**r.start()..=ub)
+					} else {
+						Some(**r.start()..=**r.end())
+					}
+				}));
+				let constraints = def.constraints.clone();
+				for c in constraints {
+					if c != con {
+						self.enqueue(c);
+					}
+				}
+				Ok(())
+			}
+			IntExpr::Val(v) => {
+				if v > ub {
+					Err(ReformulationError::TrivialUnsatisfiable)
+				} else {
+					Ok(())
+				}
+			}
+		}
+	}
+
+	pub(crate) fn diff_int_domain(
+		&mut self,
+		iv: &IntExpr,
+		mask: &RangeList<IntVal>,
+		con: usize,
+	) -> Result<(), ReformulationError> {
+		match *iv {
+			IntExpr::Var(v) => {
+				let diff = diff_range_list(&self.int_vars[v.0 as usize].domain, mask);
+				if diff.is_empty() {
+					return Err(ReformulationError::TrivialUnsatisfiable);
+				} else if self.int_vars[v.0 as usize].domain == diff {
+					return Ok(());
+				}
+				self.int_vars[v.0 as usize].domain = diff;
+				let constraints = self.int_vars[v.0 as usize].constraints.clone();
+				for c in constraints {
+					if c != con {
+						self.enqueue(c);
+					}
+				}
+				Ok(())
+			}
+			IntExpr::Val(v) => {
+				if mask.contains(&v) {
+					Err(ReformulationError::TrivialUnsatisfiable)
+				} else {
+					Ok(())
+				}
+			}
+		}
+	}
+}
+
+/// Compute the RangeList that is i diff j
+fn diff_range_list(i: &RangeList<IntVal>, j: &RangeList<IntVal>) -> RangeList<IntVal> {
+	if i.is_empty() {
+		return RangeList::from_iter([]);
+	}
+	let mut i = i.into_iter().map(|r| **r.start()..=**r.end()).peekable();
+	let mut j = j.into_iter().map(|r| **r.start()..=**r.end()).peekable();
+	let mut ranges = Vec::new();
+	let mut max: IntVal = *i.peek().unwrap().start();
+	loop {
+		if i.peek().is_none() {
+			break;
+		}
+		let mut min = max + 1;
+		max = *i.peek().unwrap().end();
+		if min > *i.peek().unwrap().end() {
+			let _ = i.next();
+			if let Some(r) = i.peek() {
+				min = *r.start();
+				max = *r.end();
+			} else {
+				break;
+			}
+		}
+		while let Some(r) = j.peek() {
+			if r.end() < i.peek().unwrap().start() {
+				let _ = j.next();
+			} else {
+				break;
+			}
+		}
+		if let Some(r) = j.peek() {
+			if *r.start() <= max {
+				// Interval min..max must be shurk
+				if min >= *r.start() && max <= *r.end() {
+					// Interval min..max is completely covered by r
+					continue;
+				}
+				if *r.start() <= min {
+					// Interval min..max overlaps on the left
+					min = r.end() + 1;
+					// Search for max
+					let _ = j.next();
+					if let Some(r) = j.peek() {
+						if *r.start() <= max {
+							max = r.start() - 1;
+						}
+					}
+				} else {
+					// Interval overlaps on the right
+					max = r.start() - 1;
+				}
+			}
+		}
+		ranges.push(min..=max);
+	}
+	RangeList::from_iter(ranges)
 }

--- a/crates/huub/src/model/reformulate.rs
+++ b/crates/huub/src/model/reformulate.rs
@@ -60,7 +60,7 @@ impl Not for ReifContext {
 	}
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum ReformulationError {
 	#[error("The expression is trivially unsatisfiable")]
 	TrivialUnsatisfiable,

--- a/crates/huub/src/propagator.rs
+++ b/crates/huub/src/propagator.rs
@@ -142,6 +142,7 @@ pub(crate) trait ExplainActions {
 	fn get_int_less_than_equal_to_lit(&self, var: IntView, val: IntVal) -> BoolView {
 		self.get_int_lit(var, LitMeaning::Less(val + 1))
 	}
+	#[allow(dead_code)]
 	fn get_int_lower_bound_lit(&self, var: IntView) -> BoolView {
 		let lb = self.get_int_lower_bound(var);
 		self.get_int_greater_than_equal_to_lit(var, lb)

--- a/crates/huub/src/propagator.rs
+++ b/crates/huub/src/propagator.rs
@@ -2,6 +2,7 @@ pub(crate) mod all_different;
 pub(crate) mod conflict;
 pub(crate) mod int_event;
 pub(crate) mod int_lin_le;
+pub(crate) mod minimum;
 pub(crate) mod reason;
 
 use std::fmt::Debug;

--- a/crates/huub/src/propagator.rs
+++ b/crates/huub/src/propagator.rs
@@ -136,20 +136,13 @@ pub(crate) trait ExplainActions {
 		self.get_int_val(var)
 			.map(|v| self.get_int_lit(var, LitMeaning::Eq(v)))
 	}
-	fn get_int_greater_than_equal_to_lit(&self, var: IntView, val: IntVal) -> BoolView {
-		self.get_int_lit(var, LitMeaning::GreaterEq(val))
-	}
-	fn get_int_less_than_equal_to_lit(&self, var: IntView, val: IntVal) -> BoolView {
-		self.get_int_lit(var, LitMeaning::Less(val + 1))
-	}
-	#[allow(dead_code)]
 	fn get_int_lower_bound_lit(&self, var: IntView) -> BoolView {
 		let lb = self.get_int_lower_bound(var);
-		self.get_int_greater_than_equal_to_lit(var, lb)
+		self.get_int_lit(var, LitMeaning::GreaterEq(lb))
 	}
 	fn get_int_upper_bound_lit(&self, var: IntView) -> BoolView {
 		let ub = self.get_int_upper_bound(var);
-		self.get_int_less_than_equal_to_lit(var, ub)
+		self.get_int_lit(var, LitMeaning::Less(ub + 1))
 	}
 }
 

--- a/crates/huub/src/propagator.rs
+++ b/crates/huub/src/propagator.rs
@@ -134,14 +134,19 @@ pub(crate) trait ExplainActions {
 		self.get_int_val(var)
 			.map(|v| self.get_int_lit(var, LitMeaning::Eq(v)))
 	}
-	#[allow(dead_code)]
+	fn get_int_greater_than_equal_to_lit(&self, var: IntView, val: IntVal) -> BoolView {
+		self.get_int_lit(var, LitMeaning::GreaterEq(val))
+	}
+	fn get_int_less_than_equal_to_lit(&self, var: IntView, val: IntVal) -> BoolView {
+		self.get_int_lit(var, LitMeaning::Less(val + 1))
+	}
 	fn get_int_lower_bound_lit(&self, var: IntView) -> BoolView {
 		let lb = self.get_int_lower_bound(var);
-		self.get_int_lit(var, LitMeaning::Less(lb + 1))
+		self.get_int_greater_than_equal_to_lit(var, lb)
 	}
 	fn get_int_upper_bound_lit(&self, var: IntView) -> BoolView {
 		let ub = self.get_int_upper_bound(var);
-		self.get_int_lit(var, LitMeaning::GreaterEq(ub))
+		self.get_int_less_than_equal_to_lit(var, ub)
 	}
 }
 

--- a/crates/huub/src/propagator.rs
+++ b/crates/huub/src/propagator.rs
@@ -29,8 +29,9 @@ pub(crate) trait Propagator: Debug + DynPropClone {
 	///
 	/// The [`data`] argument will contain the data that the propagater has set
 	/// when subscribing to an event.
-	fn notify_event(&mut self, data: u32) -> bool {
+	fn notify_event(&mut self, data: u32, event: &IntEvent) -> bool {
 		let _ = data;
+		let _ = event;
 		false
 	}
 

--- a/crates/huub/src/propagator/all_different.rs
+++ b/crates/huub/src/propagator/all_different.rs
@@ -94,9 +94,7 @@ mod tests {
 		let c = IntVar::new_in(&mut slv, RangeList::from_iter([1..=4]), true);
 
 		slv.add_propagator(AllDifferentValue::new(vec![a, b, c]));
-		slv.assert_all_solutions(&[a.into(), b.into(), c.into()], |sol| {
-			sol.iter().all_unique()
-		})
+		slv.assert_all_solutions(&[a, b, c], |sol| sol.iter().all_unique())
 	}
 
 	#[test]

--- a/crates/huub/src/propagator/all_different.rs
+++ b/crates/huub/src/propagator/all_different.rs
@@ -41,7 +41,7 @@ impl Propagator for AllDifferentValue {
 		!self.action_list.is_empty()
 	}
 
-	fn notify_event(&mut self, data: u32) -> bool {
+	fn notify_event(&mut self, data: u32, _: &IntEvent) -> bool {
 		self.action_list.push(data);
 		true
 	}

--- a/crates/huub/src/propagator/conflict.rs
+++ b/crates/huub/src/propagator/conflict.rs
@@ -17,7 +17,7 @@ impl Conflict {
 	pub(crate) fn new(reason: &ReasonBuilder, prop: PropRef) -> Self {
 		match Reason::build_reason(reason, prop) {
 			Ok(reason) => Self { reason },
-			Err(true) => panic!("constructing empty conflict"),
+			Err(true) => Self { reason: Reason::Eager(Box::new([])) },
 			Err(false) => unreachable!("invalid reason"),
 		}
 	}

--- a/crates/huub/src/propagator/conflict.rs
+++ b/crates/huub/src/propagator/conflict.rs
@@ -17,7 +17,9 @@ impl Conflict {
 	pub(crate) fn new(reason: &ReasonBuilder, prop: PropRef) -> Self {
 		match Reason::build_reason(reason, prop) {
 			Ok(reason) => Self { reason },
-			Err(true) => Self { reason: Reason::Eager(Box::new([])) },
+			Err(true) => Self {
+				reason: Reason::Eager(Box::new([])),
+			},
 			Err(false) => unreachable!("invalid reason"),
 		}
 	}

--- a/crates/huub/src/propagator/conflict.rs
+++ b/crates/huub/src/propagator/conflict.rs
@@ -17,9 +17,7 @@ impl Conflict {
 	pub(crate) fn new(reason: &ReasonBuilder, prop: PropRef) -> Self {
 		match Reason::build_reason(reason, prop) {
 			Ok(reason) => Self { reason },
-			Err(true) => Self {
-				reason: Reason::Eager(Box::new([])),
-			},
+			Err(true) => panic!("constructing empty conflict"),
 			Err(false) => unreachable!("invalid reason"),
 		}
 	}

--- a/crates/huub/src/propagator/int_event.rs
+++ b/crates/huub/src/propagator/int_event.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum IntEvent {
 	Fixed,
 	LowerBound,

--- a/crates/huub/src/propagator/int_lin_le.rs
+++ b/crates/huub/src/propagator/int_lin_le.rs
@@ -66,7 +66,7 @@ impl Propagator for LinearLE {
 		!self.action_list.is_empty()
 	}
 
-	fn notify_event(&mut self, _: u32) -> bool {
+	fn notify_event(&mut self, _: u32, _: &IntEvent) -> bool {
 		true
 	}
 

--- a/crates/huub/src/propagator/int_lin_le.rs
+++ b/crates/huub/src/propagator/int_lin_le.rs
@@ -134,7 +134,7 @@ mod tests {
 
 		slv.add_propagator(LinearLE::new(&[2, 1, 1], vec![a, b, c], 10));
 
-		slv.assert_all_solutions(&[a.into(), b.into(), c.into()], |sol: &[Value]| {
+		slv.assert_all_solutions(&[a, b, c], |sol: &[Value]| {
 			sol[0].as_int().unwrap() * 2 + sol[1].as_int().unwrap() + sol[2].as_int().unwrap() <= 10
 		});
 	}
@@ -158,7 +158,7 @@ mod tests {
 		let c = IntVar::new_in(&mut slv, RangeList::from_iter([1..=4]), true);
 
 		slv.add_propagator(LinearLE::new(&[-2, -1, -1], vec![a, b, c], -3));
-		slv.assert_all_solutions(&[a.into(), b.into(), c.into()], |sol: &[Value]| {
+		slv.assert_all_solutions(&[a, b, c], |sol: &[Value]| {
 			sol[0].as_int().unwrap() * 2 + sol[1].as_int().unwrap() + sol[2].as_int().unwrap() >= 3
 		});
 	}

--- a/crates/huub/src/propagator/minimum.rs
+++ b/crates/huub/src/propagator/minimum.rs
@@ -1,0 +1,205 @@
+use super::{reason::ReasonBuilder, InitializationActions, PropagationActions};
+use crate::{
+	propagator::{conflict::Conflict, int_event::IntEvent, Propagator},
+	solver::{engine::queue::PriorityLevel, value::IntVal, view::IntView},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct Minimum {
+	vars: Vec<IntView>,                // Variables in the minimum constraints
+	y: IntView,                        // Variable that stores the minimum value
+	action_list: Vec<(u32, IntEvent)>, // List of x variables that have been modified since the last propagation
+	y_change: bool,                    // Whether the lower bound of y has been changed
+}
+
+impl Minimum {
+	pub(crate) fn new<V: Into<IntView>, VI: IntoIterator<Item = V>>(vars: VI, y: IntView) -> Self {
+		let vars: Vec<IntView> = vars.into_iter().map(Into::into).collect();
+		let sz = vars.len();
+		Self {
+			vars,
+			y,
+			action_list: Vec::with_capacity(sz),
+			y_change: false,
+		}
+	}
+}
+
+impl Propagator for Minimum {
+	fn initialize(&mut self, actions: &mut dyn InitializationActions) -> bool {
+		for (i, v) in self.vars.iter().enumerate() {
+			actions.subscribe_int(*v, IntEvent::UpperBound, i as u32);
+			actions.subscribe_int(*v, IntEvent::LowerBound, i as u32);
+		}
+		actions.subscribe_int(self.y, IntEvent::LowerBound, self.vars.len() as u32);
+		true
+	}
+
+	fn notify_event(&mut self, data: u32, event: &IntEvent) -> bool {
+		if data == self.vars.len() as u32 {
+			self.y_change = true;
+		} else {
+			self.action_list.push((data, event.clone()));
+		}
+		true
+	}
+
+	fn queue_priority_level(&self) -> PriorityLevel {
+		PriorityLevel::Low
+	}
+
+	fn notify_backtrack(&mut self, _new_level: usize) {
+		self.action_list.clear();
+		self.y_change = false;
+	}
+
+	fn propagate(&mut self, actions: &mut dyn PropagationActions) -> Result<(), Conflict> {
+		if !self.action_list.is_empty() {
+			let (min_upper_bound, min_lower_bound) =
+				self.vars
+					.iter()
+					.fold((IntVal::MAX, IntVal::MAX), |(min_ub, min_lb), x| {
+						let x_ub = actions.get_int_upper_bound(*x);
+						let x_lb = actions.get_int_lower_bound(*x);
+						(min_ub.min(x_ub), min_lb.min(x_lb))
+					});
+			// set y to be less than or equal to the minimum of upper bounds of x_i
+			if actions.get_int_upper_bound(self.y) > min_upper_bound {
+				actions.set_int_upper_bound(
+					self.y,
+					min_upper_bound,
+					&ReasonBuilder::Eager(
+						self.vars
+							.iter()
+							.map(|x| actions.get_int_less_than_equal_to_lit(*x, min_upper_bound))
+							.collect(),
+					),
+				)?;
+			}
+
+			// set y to be greater than or equal to the minimum of lower bounds of x_i
+			if actions.get_int_lower_bound(self.y) < min_lower_bound {
+				actions.set_int_lower_bound(
+					self.y,
+					min_lower_bound,
+					&ReasonBuilder::Eager(
+						self.vars
+							.iter()
+							.map(|x| actions.get_int_greater_than_equal_to_lit(*x, min_lower_bound))
+							.collect(),
+					),
+				)?;
+			}
+		}
+
+		// set x_i to be greater than or equal to y.lowerbound
+		if self.y_change {
+			let y_lb = actions.get_int_lower_bound(self.y);
+			for &x in self.vars.iter() {
+				actions.set_int_lower_bound(
+					x,
+					y_lb,
+					&ReasonBuilder::Simple(actions.get_int_upper_bound_lit(self.y)),
+				)?
+			}
+		}
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use flatzinc_serde::RangeList;
+	use pindakaas::{
+		solver::{cadical::Cadical, SolveResult},
+		Cnf,
+	};
+
+	use crate::{propagator::minimum::Minimum, solver::engine::int_var::IntVar, Solver, Value};
+
+	#[test]
+	fn test_minimum_sat() {
+		let mut slv: Solver<Cadical> = Cnf::default().into();
+		let a = IntVar::new_in(&mut slv, RangeList::from_iter([1..=4]), true);
+		let b = IntVar::new_in(&mut slv, RangeList::from_iter([1..=3]), true);
+		let c = IntVar::new_in(&mut slv, RangeList::from_iter([1..=3]), true);
+		let y = IntVar::new_in(&mut slv, RangeList::from_iter([1..=4]), true);
+
+		slv.add_propagator(Minimum::new(vec![a, b, c], y));
+		let result = slv.solve(|val| {
+			let Value::Int(a_val) = val(a.into()).unwrap() else {
+				panic!()
+			};
+			let Value::Int(b_val) = val(b.into()).unwrap() else {
+				panic!()
+			};
+			let Value::Int(c_val) = val(c.into()).unwrap() else {
+				panic!()
+			};
+			let Value::Int(y_val) = val(y.into()).unwrap() else {
+				panic!()
+			};
+
+			assert!(a_val.min(b_val).min(c_val) == y_val)
+		});
+		assert_eq!(result, SolveResult::Sat)
+	}
+
+	#[test]
+	fn test_minimum_unsat() {
+		let mut slv: Solver<Cadical> = Cnf::default().into();
+		let a = IntVar::new_in(&mut slv, RangeList::from_iter([3..=5]), true);
+		let b = IntVar::new_in(&mut slv, RangeList::from_iter([4..=5]), true);
+		let c = IntVar::new_in(&mut slv, RangeList::from_iter([4..=10]), true);
+		let y = IntVar::new_in(&mut slv, RangeList::from_iter([1..=2]), true);
+
+		slv.add_propagator(Minimum::new(vec![a, b, c], y));
+		assert_eq!(slv.solve(|_| {}), SolveResult::Unsat)
+	}
+
+	#[test]
+	fn test_maximum_sat() {
+		let mut slv: Solver<Cadical> = Cnf::default().into();
+		let a = IntVar::new_in(&mut slv, RangeList::from_iter([1..=4]), true);
+		let b = IntVar::new_in(&mut slv, RangeList::from_iter([1..=3]), true);
+		let c = IntVar::new_in(&mut slv, RangeList::from_iter([1..=3]), true);
+		let y = IntVar::new_in(&mut slv, RangeList::from_iter([1..=4]), true);
+
+		slv.add_propagator(Minimum::new(
+			vec![a.negated(), b.negated(), c.negated()],
+			y.negated(),
+		));
+		let result = slv.solve(|val| {
+			let Value::Int(a_val) = val(a.into()).unwrap() else {
+				panic!()
+			};
+			let Value::Int(b_val) = val(b.into()).unwrap() else {
+				panic!()
+			};
+			let Value::Int(c_val) = val(c.into()).unwrap() else {
+				panic!()
+			};
+			let Value::Int(y_val) = val(y.into()).unwrap() else {
+				panic!()
+			};
+
+			assert!(a_val.max(b_val).max(c_val) == y_val)
+		});
+		assert_eq!(result, SolveResult::Sat)
+	}
+
+	#[test]
+	fn test_maximum_unsat() {
+		let mut slv: Solver<Cadical> = Cnf::default().into();
+		let a = IntVar::new_in(&mut slv, RangeList::from_iter([3..=5]), true);
+		let b = IntVar::new_in(&mut slv, RangeList::from_iter([4..=5]), true);
+		let c = IntVar::new_in(&mut slv, RangeList::from_iter([4..=10]), true);
+		let y = IntVar::new_in(&mut slv, RangeList::from_iter([13..=20]), true);
+
+		slv.add_propagator(Minimum::new(
+			vec![a.negated(), b.negated(), c.negated()],
+			y.negated(),
+		));
+		assert_eq!(slv.solve(|_| {}), SolveResult::Unsat)
+	}
+}

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -65,7 +65,9 @@ impl IpasirPropagator for Engine {
 			.into_iter()
 			.flatten()
 		{
-			if self.propagators[prop].notify_event(data) && !self.state.enqueued[prop] {
+			if self.propagators[prop].notify_event(data, &IntEvent::Fixed)
+				&& !self.state.enqueued[prop]
+			{
 				let level = self.propagators[prop].queue_priority_level();
 				self.state.prop_queue.insert(level, prop);
 			}
@@ -75,7 +77,7 @@ impl IpasirPropagator for Engine {
 		if let Some((iv, event)) = self.state.determine_int_event(lit) {
 			for (prop, level, data) in self.state.int_subscribers.get(&iv).into_iter().flatten() {
 				if level.is_activated_by(&event)
-					&& self.propagators[*prop].notify_event(*data)
+					&& self.propagators[*prop].notify_event(*data, &event)
 					&& !self.state.enqueued[*prop]
 				{
 					let level = self.propagators[*prop].queue_priority_level();
@@ -184,7 +186,7 @@ impl IpasirPropagator for Engine {
 				for (prop, level, data) in self.state.int_subscribers.get(&r).into_iter().flatten()
 				{
 					if level.is_activated_by(&IntEvent::Fixed)
-						&& self.propagators[*prop].notify_event(*data)
+						&& self.propagators[*prop].notify_event(*data, &IntEvent::Fixed)
 					{
 						let l = self.propagators[*prop].queue_priority_level();
 						self.state.prop_queue.insert(l, *prop)

--- a/crates/huub/src/solver/view.rs
+++ b/crates/huub/src/solver/view.rs
@@ -1,4 +1,7 @@
-use std::{num::NonZeroI32, ops::Not};
+use std::{
+	num::NonZeroI32,
+	ops::{Neg, Not},
+};
 
 use pindakaas::{
 	solver::{PropagatorAccess, Solver as SolverTrait},
@@ -188,7 +191,11 @@ impl IntView {
 	pub(crate) fn linear_is_integer(val: IntVal, scale: NonZeroIntVal, offset: IntVal) -> bool {
 		(val - offset) % scale.get() == 0
 	}
-	pub(crate) fn negated(&self) -> Self {
+}
+
+impl Neg for IntView {
+	type Output = Self;
+	fn neg(self) -> Self::Output {
 		match self.0 {
 			IntViewInner::VarRef(v) => IntView(IntViewInner::Linear {
 				var: v,

--- a/crates/huub/src/solver/view.rs
+++ b/crates/huub/src/solver/view.rs
@@ -190,8 +190,8 @@ impl IntView {
 	}
 	pub(crate) fn negated(&self) -> Self {
 		match self.0 {
-			IntViewInner::VarRef(v) => IntView(IntViewInner::Linear{
-				var: v, 
+			IntViewInner::VarRef(v) => IntView(IntViewInner::Linear {
+				var: v,
 				scale: NonZeroIntVal::new(-1).unwrap(),
 				offset: 0,
 			}),

--- a/crates/huub/src/solver/view.rs
+++ b/crates/huub/src/solver/view.rs
@@ -188,4 +188,19 @@ impl IntView {
 	pub(crate) fn linear_is_integer(val: IntVal, scale: NonZeroIntVal, offset: IntVal) -> bool {
 		(val - offset) % scale.get() == 0
 	}
+	pub(crate) fn negated(&self) -> Self {
+		match self.0 {
+			IntViewInner::VarRef(v) => IntView(IntViewInner::Linear{
+				var: v, 
+				scale: NonZeroIntVal::new(-1).unwrap(),
+				offset: 0,
+			}),
+			IntViewInner::Const(i) => IntView(IntViewInner::Const(-i)),
+			IntViewInner::Linear { var, scale, offset } => IntView(IntViewInner::Linear {
+				var,
+				scale: NonZeroIntVal::new(-scale.get()).unwrap(),
+				offset: -offset,
+			}),
+		}
+	}
 }

--- a/share/minizinc/huub/redefinitions-2.0.mzn
+++ b/share/minizinc/huub/redefinitions-2.0.mzn
@@ -9,32 +9,16 @@ predicate bool_clause_reif(
 	var bool: b
 ) = huub_bool_clause_reif(as, bs, b);
 
-predicate array_int_maximum(var int: m, array[int] of var int: x) =
-let {
-	int: l = min(index_set(x)),
-	int: u = max(index_set(x)),
-	int: ly = lb_array(x),
-	int: uy = ub_array(x),
-	array[l..u] of var ly..uy: y
-} in
-	y[l] = x[l] /\
-	m = y[u] /\
-	forall (i in l+1 .. u) ( y[i] == max(x[i],y[i-1]) );
+predicate huub_array_int_maximum(var int: m, array[int] of var int: x);
+predicate array_int_maximum(var int: m, array[int] of var int: x)
+= huub_array_int_maximum(m, x);
 
-predicate array_float_maximum(var float: m, array[int] of var float: x) =
-abort("float variables are not supported by huub");
+predicate array_float_maximum(var float: m, array[int] of var float: x)
+= abort("float variables are not supported by huub");
 
-predicate array_int_minimum(var int: m, array[int] of var int: x) =
-let {
-	int: l = min(index_set(x)),
-	int: u = max(index_set(x)),
-	int: ly = lb_array(x),
-	int: uy = ub_array(x),
-	array[l..u] of var ly..uy: y
-} in
-	y[l] = x[l] /\
-	m = y[u] /\
-	forall (i in l+1 .. u) ( y[i] == min(x[i],y[i-1]) );
+predicate huub_array_int_minimum(var int: m, array[int] of var int: x);
+predicate array_int_minimum(var int: m, array[int] of var int: x)
+= huub_array_int_minimum(m, x);
 
-predicate array_float_minimum(var float: m, array[int] of var float: x) =
-abort("float variables are not supported by huub");
+predicate array_float_minimum(var float: m, array[int] of var float: x)
+= abort("float variables are not supported by huub");

--- a/share/minizinc/huub/redefinitions.mzn
+++ b/share/minizinc/huub/redefinitions.mzn
@@ -1,3 +1,5 @@
+include "nosets.mzn";
+
 predicate bool_lt(var bool: a, var bool: b) = not a /\ b;
 predicate bool_lt_imp(var bool: a, var bool: b, var bool: r) = r -> (not a /\ b);
 predicate bool_lt_reif(var bool: a, var bool: b, var bool: r) = r = (not a /\ b);


### PR DESCRIPTION
Add minimum/maximum constraint propagator, and update the following items: 
- add negated view for IntView 
- allow empty conflict for global inconsistency detection (see "test_minimum_unsat" and "test_maximum_unsat" for example) 
- fix getting the literal for upper bound and lower bound of integer variables 
- add int event argument for notify_event function 
