### PR TITLE
Fix Ctl-C catching in fzn-huub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -284,7 +284,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -306,7 +306,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core 0.20.9",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -317,7 +317,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -586,7 +586,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 [[package]]
 name = "pindakaas"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#e7087d6849feed20a7a297369d17db39c4d5add2"
+source = "git+https://github.com/pindakaashq/pindakaas.git#420d429838f5a83976da06a232c208f3b3f710b4"
 dependencies = [
  "cached",
  "iset",
@@ -699,7 +699,7 @@ dependencies = [
 [[package]]
 name = "pindakaas-build-macros"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#e7087d6849feed20a7a297369d17db39c4d5add2"
+source = "git+https://github.com/pindakaashq/pindakaas.git#420d429838f5a83976da06a232c208f3b3f710b4"
 dependencies = [
  "cc",
  "paste",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "pindakaas-cadical"
 version = "1.9.5"
-source = "git+https://github.com/pindakaashq/pindakaas.git#e7087d6849feed20a7a297369d17db39c4d5add2"
+source = "git+https://github.com/pindakaashq/pindakaas.git#420d429838f5a83976da06a232c208f3b3f710b4"
 dependencies = [
  "cc",
  "pindakaas-build-macros",
@@ -717,18 +717,18 @@ dependencies = [
 [[package]]
 name = "pindakaas-derive"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#e7087d6849feed20a7a297369d17db39c4d5add2"
+source = "git+https://github.com/pindakaashq/pindakaas.git#420d429838f5a83976da06a232c208f3b3f710b4"
 dependencies = [
  "darling 0.20.9",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
@@ -805,7 +805,7 @@ checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.64"
+version = "2.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
+checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -933,7 +933,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -965,7 +965,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1236,5 +1236,5 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.65",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,7 @@ unseparated_literal_suffix = "warn"
 unnecessary_safety_doc = "warn"
 wildcard_dependencies = "warn"
 wrong_self_convention = "warn"
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true

--- a/crates/fzn-huub/src/main.rs
+++ b/crates/fzn-huub/src/main.rs
@@ -163,9 +163,9 @@ fn main() -> Result<()> {
 	let interrupted = Arc::new(AtomicBool::new(false));
 	match (interrupt_handling, deadline) {
 		(true, Some(deadline)) => {
-			let int_bool = Arc::clone(&interrupted);
+			let interrupted = Arc::clone(&interrupted);
 			slv.set_terminate_callback(Some(move || {
-				if int_bool.load(Ordering::SeqCst) || Instant::now() >= deadline {
+				if interrupted.load(Ordering::SeqCst) || Instant::now() >= deadline {
 					SlvTermSignal::Terminate
 				} else {
 					SlvTermSignal::Continue
@@ -173,9 +173,9 @@ fn main() -> Result<()> {
 			}));
 		}
 		(true, None) => {
-			let int_bool = Arc::clone(&interrupted);
+			let interrupted = Arc::clone(&interrupted);
 			slv.set_terminate_callback(Some(move || {
-				if int_bool.load(Ordering::SeqCst) {
+				if interrupted.load(Ordering::SeqCst) {
 					SlvTermSignal::Terminate
 				} else {
 					SlvTermSignal::Continue
@@ -214,7 +214,7 @@ fn main() -> Result<()> {
 			} else {
 				// Set up Ctrl-C handler (to allow printing last solution)
 				if let Err(err) = ctrlc::set_handler(move || {
-					interrupted.store(false, Ordering::SeqCst);
+					interrupted.store(true, Ordering::SeqCst);
 				}) {
 					warn!("unable to set Ctrl-C handler: {}", err);
 				}

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -11,7 +11,7 @@ use pindakaas::{
 	solver::{Propagator as IpasirPropagator, SolvingActions},
 	Lit as RawLit, Var as RawVar,
 };
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 
 use self::{
 	bool_to_int::BoolToIntMap,
@@ -135,7 +135,7 @@ impl IpasirPropagator for Engine {
 							for l in &clause {
 								let val = self.state.sat_trail.get(!l);
 								if !val.unwrap_or(false) {
-									error!(lit_prop = i32::from(*lit), lit_reason= i32::from(!l), reason_val = ?val, "invalid reason");
+									tracing::error!(lit_prop = i32::from(*lit), lit_reason= i32::from(!l), reason_val = ?val, "invalid reason");
 								}
 								debug_assert!(
 									val.unwrap_or(false),


### PR DESCRIPTION
- Update pindakaas version to version
- Add release-with-debug compilation profile
- Fix unused import warning when compiling in release mode
- Fix ctrlc setting interruption flag for solver
