### PR TITLE
Fix the cohesion of the model when a view is part of unification

### DIFF
--- a/crates/fzn-huub/corpus/unify_with_view.fzn.json
+++ b/crates/fzn-huub/corpus/unify_with_view.fzn.json
@@ -1,0 +1,19 @@
+{
+  "variables": {
+    "x" : { "type" : "bool"},
+    "y" : { "type" : "bool"},
+    "z" : { "type" : "bool"},
+    "ivar" : { "type" : "int", "domain" : [[1, 3]]}
+  },
+  "arrays": {
+
+  },
+  "constraints": [
+    { "id" : "bool_eq", "args" : ["x", "y"], "ann" : ["domain_change_constraint"]},
+    { "id" : "bool_eq", "args" : ["x", "z"], "ann" : ["domain_change_constraint"]}, 
+    { "id" : "int_le_reif", "args" : ["ivar", 2, "x"], "defines" : "x"}
+  ],
+  "output": ["x", "y", "z", "ivar"],
+  "solve": { "method" : "satisfy"},
+  "version": "1.0"
+}

--- a/crates/fzn-huub/corpus/unify_with_view.sol
+++ b/crates/fzn-huub/corpus/unify_with_view.sol
@@ -1,0 +1,16 @@
+x = false;
+y = false;
+z = false;
+ivar = 3;
+----------
+x = true;
+y = true;
+z = true;
+ivar = 1;
+----------
+x = true;
+y = true;
+z = true;
+ivar = 2;
+----------
+==========

--- a/crates/fzn-huub/tests/flatzinc_tests.rs
+++ b/crates/fzn-huub/tests/flatzinc_tests.rs
@@ -11,6 +11,7 @@ mod tests {
 	assert_all_solutions!(unification);
 	assert_all_solutions!(unify_element_1);
 	assert_all_solutions!(unify_element_2);
+	assert_all_solutions!(unify_with_view);
 
 	assert_optimal!(jobshop);
 


### PR DESCRIPTION
This commit changes the order of unification and resolving views. Views
are resolved first and then the view is used multiple times if it is
unified. If multiple view are unified (together), then constraints
are added to the `Model` to ensure they are used together.

Resolves #89 