### PR TITLE
handling unsatisfiable int_lin_eq constraint 

### DIFF
--- a/crates/fzn-huub/corpus/int_lin_eq_prop.fzn.json
+++ b/crates/fzn-huub/corpus/int_lin_eq_prop.fzn.json
@@ -1,0 +1,19 @@
+{
+  "variables": {
+    "a" : { "type" : "bool" },
+    "b" : { "type" : "bool" },
+    "x" : { "type" : "int", "domain" : [[0, 1]], "defined" : true },
+    "y" : { "type" : "int", "domain" : [[0, 1]], "defined" : true  }
+  },
+  "arrays": {
+    
+  },
+  "constraints": [
+    { "id" : "int_lin_eq", "args" : [[1, 1], ["x", "y"], -1]},
+    { "id" : "bool2int", "args" : ["a", "x"], "defines" : "x"},
+    { "id" : "bool2int", "args" : ["b", "y"], "defines" : "y"}
+  ],
+  "output": ["x", "y", "a", "b"],
+  "solve": { "method" : "satisfy" },
+  "version": "1.0"
+}

--- a/crates/fzn-huub/tests/flatzinc_tests.rs
+++ b/crates/fzn-huub/tests/flatzinc_tests.rs
@@ -4,6 +4,7 @@ mod helpers;
 mod tests {
 	use crate::helpers::{
 		assert_all_solutions, assert_first_solution, assert_optimal, assert_search_order,
+		assert_unsat,
 	};
 
 	assert_all_solutions!(array_var_int_element);
@@ -14,11 +15,15 @@ mod tests {
 	assert_all_solutions!(unify_with_view_1);
 	assert_all_solutions!(unify_with_view_2);
 
+	assert_first_solution!(seq_search_1);
+	assert_first_solution!(seq_search_2);
+	assert_first_solution!(seq_search_3);
+	assert_first_solution!(seq_search_4);
+
 	assert_optimal!(jobshop);
 
 	assert_search_order!(bool_indomain_max);
 	assert_search_order!(bool_indomain_min);
-
 	assert_search_order!(int_indomain_max_1);
 	assert_search_order!(int_indomain_max_2);
 	assert_search_order!(int_indomain_max_3);
@@ -30,8 +35,5 @@ mod tests {
 	assert_search_order!(int_indomain_min_4);
 	assert_search_order!(int_indomain_min_5);
 
-	assert_first_solution!(seq_search_1);
-	assert_first_solution!(seq_search_2);
-	assert_first_solution!(seq_search_3);
-	assert_first_solution!(seq_search_4);
+	assert_unsat!(int_lin_eq_prop);
 }

--- a/crates/huub/src/model/constraint.rs
+++ b/crates/huub/src/model/constraint.rs
@@ -266,14 +266,14 @@ impl Constraint {
 					BoolViewInner::Const(false) => {
 						slv.add_propagator(IntLinearLessEqBounds::prepare(
 							vars.into_iter().map(|v| -v),
-							-c + 1,
+							-(c + 1),
 						));
 					}
 					BoolViewInner::Lit(r) => {
 						slv.add_propagator(IntLinearLessEqImpBounds::prepare(vars.clone(), *c, r));
 						slv.add_propagator(IntLinearLessEqImpBounds::prepare(
 							vars.into_iter().map(|v| -v),
-							-c + 1,
+							-(c + 1),
 							!r,
 						));
 					}

--- a/crates/huub/src/model/constraint.rs
+++ b/crates/huub/src/model/constraint.rs
@@ -481,6 +481,29 @@ impl Model {
 				}
 				Some(Constraint::IntLinLessEq(args, cons))
 			}
+			Constraint::IntLinEq(args, cons) => {
+				let lb_sum = args
+					.iter()
+					.map(|v| self.get_int_lower_bound(v))
+					.fold(cons, |sum, val| sum - val);
+
+				for v in &args {
+					let ub = lb_sum + self.get_int_lower_bound(v);
+					self.set_int_upper_bound(v, ub, con)?
+				}
+
+				let ub_sum = args
+					.iter()
+					.map(|v| self.get_int_upper_bound(v))
+					.fold(cons, |sum, val| sum - val);
+
+				for v in &args {
+					let lb = ub_sum + self.get_int_upper_bound(v);
+					self.set_int_lower_bound(v, lb, con)?
+				}
+
+				Some(Constraint::IntLinEq(args, cons))
+			}
 			Constraint::IntTimes(x, y, z) => {
 				let x_lb = self.get_int_lower_bound(&x);
 				let x_ub = self.get_int_upper_bound(&x);

--- a/crates/huub/src/solver/engine/propagation_context.rs
+++ b/crates/huub/src/solver/engine/propagation_context.rs
@@ -121,7 +121,7 @@ impl<'a> PropagationContext<'a> {
 			LitMeaning::GreaterEq(i) if i > 1 => {
 				Err(Conflict::new(None, reason, self.current_prop))
 			}
-			LitMeaning::Less(i) if i < 0 => Err(Conflict::new(None, reason, self.current_prop)),
+			LitMeaning::Less(i) if i <= 0 => Err(Conflict::new(None, reason, self.current_prop)),
 			LitMeaning::NotEq(_) | LitMeaning::GreaterEq(_) | LitMeaning::Less(_) => Ok(()),
 		}
 	}


### PR DESCRIPTION
- Fix "propagate_bool_lin" for the case where lit_req is LitMeaning::Less(0) 
- Add "assert_unsat" macro for flatzinc test suites 
- Add model level propagation for int_lin_eq 
- Add a test case with unsatisfiable int_lin_eq constraint 
