### PR TITLE
Make the constructions of Reasons (optionally) lazy

### DIFF
--- a/crates/huub/src/actions/propagation.rs
+++ b/crates/huub/src/actions/propagation.rs
@@ -1,6 +1,9 @@
 use crate::{
 	actions::explanation::ExplanationActions,
-	propagator::{conflict::Conflict, reason::ReasonBuilder},
+	propagator::{
+		conflict::Conflict,
+		reason::{LazyReason, ReasonBuilder},
+	},
 	BoolView, IntVal, IntView,
 };
 
@@ -9,31 +12,33 @@ pub(crate) trait PropagationActions: ExplanationActions {
 		&mut self,
 		bv: BoolView,
 		val: bool,
-		reason: &ReasonBuilder,
+		reason: impl ReasonBuilder<Self>,
 	) -> Result<(), Conflict>;
 
 	fn set_int_lower_bound(
 		&mut self,
 		var: IntView,
 		val: IntVal,
-		reason: &ReasonBuilder,
+		reason: impl ReasonBuilder<Self>,
 	) -> Result<(), Conflict>;
 	fn set_int_upper_bound(
 		&mut self,
 		var: IntView,
 		val: IntVal,
-		reason: &ReasonBuilder,
+		reason: impl ReasonBuilder<Self>,
 	) -> Result<(), Conflict>;
 	fn set_int_val(
 		&mut self,
 		var: IntView,
 		val: IntVal,
-		reason: &ReasonBuilder,
+		reason: impl ReasonBuilder<Self>,
 	) -> Result<(), Conflict>;
 	fn set_int_not_eq(
 		&mut self,
 		var: IntView,
 		val: IntVal,
-		reason: &ReasonBuilder,
+		reason: impl ReasonBuilder<Self>,
 	) -> Result<(), Conflict>;
+
+	fn deferred_reason(&self, data: u64) -> LazyReason;
 }

--- a/crates/huub/src/propagator/all_different_int.rs
+++ b/crates/huub/src/propagator/all_different_int.rs
@@ -3,10 +3,7 @@ use crate::{
 		explanation::ExplanationActions, initialization::InitializationActions,
 		trailing::TrailingActions,
 	},
-	propagator::{
-		conflict::Conflict, int_event::IntEvent, reason::ReasonBuilder, PropagationActions,
-		Propagator,
-	},
+	propagator::{conflict::Conflict, int_event::IntEvent, PropagationActions, Propagator},
 	solver::{
 		engine::{int_var::LitMeaning, queue::PriorityLevel},
 		poster::{BoxedPropagator, Poster, QueuePreferences},
@@ -46,11 +43,11 @@ where
 		while let Some(i) = self.action_list.pop() {
 			let var = self.vars[i as usize];
 			let val = actions.get_int_val(var).unwrap();
-			let reason = ReasonBuilder::Simple(actions.get_int_lit(var, LitMeaning::Eq(val)));
+			let reason = actions.get_int_lit(var, LitMeaning::Eq(val));
 			for (j, &v) in self.vars.iter().enumerate() {
 				let j_val = actions.get_int_val(v);
 				if (j as u32) != i && (j_val.is_none() || j_val.unwrap() == val) {
-					actions.set_int_not_eq(v, val, &reason)?
+					actions.set_int_not_eq(v, val, reason)?
 				}
 			}
 		}

--- a/crates/huub/src/propagator/conflict.rs
+++ b/crates/huub/src/propagator/conflict.rs
@@ -3,8 +3,8 @@ use std::{error::Error, fmt};
 use pindakaas::Lit as RawLit;
 
 use crate::{
+	actions::explanation::ExplanationActions,
 	propagator::reason::{Reason, ReasonBuilder},
-	solver::engine::PropRef,
 };
 
 /// Conflict is an error type returned when a variable is assigned two
@@ -22,8 +22,12 @@ pub(crate) struct Conflict {
 
 impl Conflict {
 	/// Create a new conflict with the given reason
-	pub(crate) fn new(subject: Option<RawLit>, reason: &ReasonBuilder, prop: PropRef) -> Self {
-		match Reason::build_reason(reason, prop) {
+	pub(crate) fn new<A: ExplanationActions>(
+		actions: &mut A,
+		subject: Option<RawLit>,
+		reason: impl ReasonBuilder<A>,
+	) -> Self {
+		match reason.build_reason(actions) {
 			Ok(reason) => Self { subject, reason },
 			Err(true) => {
 				if let Some(subject) = subject {

--- a/crates/huub/src/propagator/reason.rs
+++ b/crates/huub/src/propagator/reason.rs
@@ -1,9 +1,10 @@
-use std::iter::once;
+use std::{iter::once, marker::PhantomData, mem};
 
 use index_vec::IndexVec;
 use pindakaas::Lit as RawLit;
 
 use crate::{
+	actions::explanation::ExplanationActions,
 	solver::{
 		engine::{PropRef, State},
 		poster::BoxedPropagator,
@@ -13,6 +14,19 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// A `ReasonBuilder` whose result is cached so it can be used multiple times
+pub(crate) enum CachedReason<A: ExplanationActions, R: ReasonBuilder<A>> {
+	/// A evaluated reason that can be reused
+	Cached(Result<Reason, bool>),
+	/// A reason that has not yet been evaluated
+	Builder((R, PhantomData<A>)),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct LazyReason(pub(crate) PropRef, pub(crate) u64);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// A conjunction of literals that implies a change in the state
 pub(crate) enum Reason {
 	/// A promise that a given propagator will compute a causation of the change
 	/// when given the attached data
@@ -22,35 +36,19 @@ pub(crate) enum Reason {
 	Simple(RawLit),
 }
 
-impl Reason {
-	pub(crate) fn build_reason(builder: &ReasonBuilder, prop: PropRef) -> Result<Self, bool> {
-		match builder {
-			ReasonBuilder::Lazy(data) => Ok(Self::Lazy(prop, *data)),
-			ReasonBuilder::Eager(views) => {
-				let mut lits = Vec::with_capacity(views.len());
-				for view in views {
-					match view.0 {
-						BoolViewInner::Lit(lit) => lits.push(lit),
-						BoolViewInner::Const(b) => {
-							if !b {
-								return Err(false);
-							}
-						}
-					}
-				}
-				if lits.is_empty() {
-					Err(true)
-				} else {
-					Ok(Self::Eager(lits.into_boxed_slice()))
-				}
-			}
-			ReasonBuilder::Simple(view) => match view.0 {
-				BoolViewInner::Lit(lit) => Ok(Self::Simple(lit)),
-				BoolViewInner::Const(b) => Err(b),
-			},
-		}
-	}
+/// A trait for types that can be used to construct a `Reason`
+pub(crate) trait ReasonBuilder<A: ExplanationActions + ?Sized> {
+	/// Construct a `Reason`, or return a Boolean indicating that the reason is trivial
+	fn build_reason(self, actions: &mut A) -> Result<Reason, bool>;
+}
 
+impl<A: ExplanationActions, R: ReasonBuilder<A>> CachedReason<A, R> {
+	pub(crate) fn new(builder: R) -> Self {
+		CachedReason::Builder((builder, PhantomData))
+	}
+}
+
+impl Reason {
 	pub(crate) fn to_clause<Clause: FromIterator<RawLit>>(
 		&self,
 		props: &mut IndexVec<PropRef, BoxedPropagator>,
@@ -65,11 +63,78 @@ impl Reason {
 			Reason::Simple(l) => once(!l).collect(),
 		}
 	}
+
+	pub(crate) fn from_iter<I: IntoIterator<Item = BoolView>>(iter: I) -> Result<Self, bool> {
+		let lits = Result::<Vec<_>, _>::from_iter(iter.into_iter().filter_map(|v| match v.0 {
+			BoolViewInner::Lit(lit) => Some(Ok(lit)),
+			BoolViewInner::Const(false) => Some(Err(false)),
+			BoolViewInner::Const(true) => None,
+		}))?;
+		match lits.len() {
+			0 => Err(true),
+			1 => Ok(Reason::Simple(lits[0])),
+			_ => Ok(Reason::Eager(lits.into_boxed_slice())),
+		}
+	}
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) enum ReasonBuilder {
-	Lazy(u64),
-	Eager(Conjunction<BoolView>),
-	Simple(BoolView),
+impl<A: ExplanationActions> ReasonBuilder<A> for BoolView {
+	fn build_reason(self, _: &mut A) -> Result<Reason, bool> {
+		match self.0 {
+			BoolViewInner::Lit(lit) => Ok(Reason::Simple(lit)),
+			BoolViewInner::Const(b) => Err(b),
+		}
+	}
+}
+
+impl<A: ExplanationActions> ReasonBuilder<A> for &[BoolView] {
+	fn build_reason(self, _: &mut A) -> Result<Reason, bool> {
+		Reason::from_iter(self.iter().cloned())
+	}
+}
+
+impl<A: ExplanationActions, R: ReasonBuilder<A>> ReasonBuilder<A> for &mut CachedReason<A, R> {
+	fn build_reason(self, actions: &mut A) -> Result<Reason, bool> {
+		match self {
+			CachedReason::Cached(reason) => reason.clone(),
+			CachedReason::Builder(_) => {
+				let tmp = mem::replace(self, CachedReason::Cached(Err(false)));
+				let CachedReason::Builder((builder, _)) = tmp else {
+					unreachable!()
+				};
+				let reason = builder.build_reason(actions);
+				*self = CachedReason::Cached(reason.clone());
+				reason
+			}
+		}
+	}
+}
+
+impl<A: ExplanationActions> ReasonBuilder<A> for Conjunction<BoolView> {
+	fn build_reason(self, _: &mut A) -> Result<Reason, bool> {
+		Reason::from_iter(self)
+	}
+}
+
+impl<A, F, I> ReasonBuilder<A> for F
+where
+	A: ExplanationActions,
+	F: FnOnce(&mut A) -> I,
+	I: IntoIterator<Item = BoolView>,
+{
+	fn build_reason(self, a: &mut A) -> Result<Reason, bool> {
+		Reason::from_iter(self(a))
+	}
+}
+
+impl<A: ExplanationActions> ReasonBuilder<A> for LazyReason {
+	fn build_reason(self, _: &mut A) -> Result<Reason, bool> {
+		Ok(Reason::Lazy(self.0, self.1))
+	}
+}
+
+impl<A: ExplanationActions> ReasonBuilder<A> for Reason {
+	fn build_reason(self, _: &mut A) -> Result<Reason, bool> {
+		Ok(self)
+	}
 }

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -23,10 +23,7 @@ use crate::{
 		explanation::ExplanationActions, inspection::InspectionActions, trailing::TrailingActions,
 	},
 	brancher::Brancher,
-	propagator::{
-		int_event::IntEvent,
-		reason::{Reason, ReasonBuilder},
-	},
+	propagator::{int_event::IntEvent, reason::Reason},
 	solver::{
 		engine::{
 			bool_to_int::BoolToIntMap,
@@ -679,8 +676,8 @@ impl State {
 		}
 	}
 
-	fn register_reason(&mut self, lit: RawLit, builder: &ReasonBuilder, prop: PropRef) {
-		match Reason::build_reason(builder, prop) {
+	fn register_reason(&mut self, lit: RawLit, built_reason: Result<Reason, bool>) {
+		match built_reason {
 			Ok(reason) => {
 				// Insert new reason, possibly overwriting old one (from previous search attempt)
 				let _ = self.reason_map.insert(lit, reason);


### PR DESCRIPTION
Different types can now be used in place of `reason` when propagating,
that will construct the explanation if anything is propagated. This
includes functions and closures, which allow the delay of the retrieval
of literals until the time at which we know for sure that propagator
will happen.

Resolves #28