### PR TITLE
Change the meaning of positive order literals to be `x<i`

### DIFF
--- a/crates/fzn-huub/src/trace.rs
+++ b/crates/fzn-huub/src/trace.rs
@@ -291,7 +291,7 @@ impl RecordLazyLits {
 			let meaning = if is_eq {
 				LitMeaning::Eq
 			} else {
-				LitMeaning::GreaterEq
+				LitMeaning::Less
 			}(val);
 			let mut guard = lit_reverse_map.lock().unwrap();
 			let _ = guard.insert(lit, LitName::IntLit(iv, meaning.clone()));

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -51,7 +51,7 @@ macro_rules! trace_new_lit {
 			is_eq = matches!($def.meaning, LitMeaning::Eq(_)),
 			val = match $def.meaning {
 				LitMeaning::Eq(val) => val,
-				LitMeaning::GreaterEq(val) => val,
+				LitMeaning::Less(val) => val,
 				_ => unreachable!(),
 			},
 			"register new literal"

--- a/crates/huub/src/solver/view.rs
+++ b/crates/huub/src/solver/view.rs
@@ -114,9 +114,10 @@ impl IntView {
 					let _ = val_iter.next();
 					for (lit, val) in storage.clone().zip(val_iter) {
 						let i: NonZeroI32 = lit.into();
-						let geq = LitMeaning::GreaterEq(transformer.transform(val));
-						let lt = LitMeaning::Less(transformer.transform(val));
-						lits.extend([(i, geq), (-i, lt)]);
+						let orig = LitMeaning::Less(val);
+						let lt = transformer.transform_lit(orig);
+						let geq = !lt.clone();
+						lits.extend([(i, lt), (-i, geq)]);
 					}
 				}
 
@@ -126,8 +127,9 @@ impl IntView {
 					let _ = val_iter.next_back();
 					for (lit, val) in vars.clone().zip(val_iter) {
 						let i: NonZeroI32 = lit.into();
-						let eq = LitMeaning::Eq(transformer.transform(val));
-						let ne = LitMeaning::NotEq(transformer.transform(val));
+						let orig = LitMeaning::Eq(val);
+						let eq = transformer.transform_lit(orig);
+						let ne = !eq.clone();
 						lits.extend([(i, eq), (-i, ne)]);
 					}
 				}


### PR DESCRIPTION
This better matches the default `true` phase/polarity used by various
SAT solvers. The SAT solver searches by setting the earliest created
variable to `true`. However, when this literal has the meaning `x≥i`,
where `i` is close to the lower bound, this is unlikely to have much
effect on the overall problem.

This change in meaning, makes the literal representation more similar to
Chuffed.
