### PR TITLE
Fix equality views creation for linear integer decisions

### DIFF
--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -497,6 +497,11 @@ impl IntDecision {
 				Ok(IntLitMeaning::Eq(1))  => x,
 				Ok(IntLitMeaning::Eq(0))  => !x,
 				Ok(IntLitMeaning::Eq(_)) /* if val != 0 */ => false.into(),
+				Err(b) => {
+					// After the transformation, the value `v` does not remain an integer.
+					debug_assert!(!b);
+					false.into()
+				}
 				_ => unreachable!(),
 			},
 		}


### PR DESCRIPTION
This change adds the missing case where reversing the transformation on
the value checked for equality does not remain integer and it is thus
known that the decision cannot equal the value.
