### PR TITLE
Lazy Fixed Event

### DIFF
--- a/crates/huub/src/actions.rs
+++ b/crates/huub/src/actions.rs
@@ -147,14 +147,7 @@ pub trait InspectionActions: TrailingActions {
 	}
 
 	/// Get the current value of an integer view, if it has been assigned.
-	fn get_int_val(&self, var: IntView) -> Option<IntVal> {
-		let (lb, ub) = self.get_int_bounds(var);
-		if lb == ub {
-			Some(lb)
-		} else {
-			None
-		}
-	}
+	fn get_int_val(&self, var: IntView) -> Option<IntVal>;
 
 	/// Check whether a given integer view can take a given value (given the
 	/// current search decisions).

--- a/crates/huub/src/reformulate.rs
+++ b/crates/huub/src/reformulate.rs
@@ -368,6 +368,7 @@ impl InspectionActions for ReformulationContext<'_> {
 		to self.slv {
 			fn get_int_lower_bound(&self, var: IntView) -> IntVal;
 			fn get_int_upper_bound(&self, var: IntView) -> IntVal;
+			fn get_int_val(&self, var: IntView) -> Option<IntVal>;
 			fn check_int_in_domain(&self, var: IntView, val: IntVal) -> bool;
 		}
 	}

--- a/crates/huub/src/solver/activation_list.rs
+++ b/crates/huub/src/solver/activation_list.rs
@@ -1,7 +1,7 @@
 //! Module containing data structures for the activation of propagators based on
 //! changes to decision variables.
 
-use std::{mem, ops::Add};
+use std::mem;
 
 use crate::solver::engine::PropRef;
 
@@ -41,8 +41,6 @@ pub(crate) struct ActivationList {
 pub(crate) enum IntEvent {
 	/// The variable has been fixed to a single value.
 	Fixed,
-	/// Both of the bounds of the variable has changed.
-	Bounds,
 	/// The lower bound of the variable has changed.
 	LowerBound,
 	/// The upper bound of the variable has changed.
@@ -59,16 +57,10 @@ pub enum IntPropCond {
 	/// Condition that triggers when the variable is fixed.
 	Fixed,
 	/// Condition that triggers when the lower bound of the variable changes.
-	///
-	/// This includes the case where the variable is fixed.
 	LowerBound,
 	/// Condition that triggers when the upper bound of the variable changes.
-	///
-	/// This includes the case where the variable is fixed.
 	UpperBound,
 	/// Condition that triggers when either of the bounds of the variable change.
-	///
-	/// This includes the case where the variable is fixed.
 	Bounds,
 	/// Condition that triggers for any change in the domain of the variable.
 	Domain,
@@ -77,24 +69,23 @@ pub enum IntPropCond {
 impl ActivationList {
 	/// Get an iterator over the list of propagators to be enqueued.
 	pub(crate) fn activated_by(&self, event: IntEvent) -> impl Iterator<Item = PropRef> + '_ {
-		let r1 = if event == IntEvent::LowerBound {
-			self.lower_bound_idx as usize..self.upper_bound_idx as usize
-		} else {
-			0..0
+		let closed_range = match event {
+			IntEvent::Domain | IntEvent::UpperBound => 0..0,
+			IntEvent::Fixed => 0..self.lower_bound_idx as usize,
+			IntEvent::LowerBound => self.lower_bound_idx as usize..self.upper_bound_idx as usize,
 		};
-		let r2 = match event {
-			IntEvent::Fixed => 0..,
-			// NOTE: Bounds (Event) should trigger both LowerBound and UpperBound conditions
-			IntEvent::Bounds => self.lower_bound_idx as usize..,
-			IntEvent::UpperBound => self.upper_bound_idx as usize..,
-			IntEvent::LowerBound => self.bounds_idx as usize..,
+		let open_range = match event {
 			IntEvent::Domain => self.domain_idx as usize..,
+			IntEvent::Fixed => self.activations.len()..,
+			IntEvent::LowerBound => self.bounds_idx as usize..,
+			IntEvent::UpperBound => self.upper_bound_idx as usize..,
 		};
-		self.activations[r1]
+		self.activations[closed_range]
 			.iter()
 			.copied()
-			.chain(self.activations[r2].iter().copied())
+			.chain(self.activations[open_range].iter().copied())
 	}
+
 	/// Add a propagator to the list of propagators to be enqueued based on the
 	/// given condition.
 	pub(crate) fn add(&mut self, mut prop: PropRef, condition: IntPropCond) {
@@ -153,21 +144,10 @@ impl ActivationList {
 			IntPropCond::Domain => self.activations.push(prop),
 		};
 	}
-}
 
-impl Add<IntEvent> for IntEvent {
-	type Output = IntEvent;
-
-	fn add(self, rhs: IntEvent) -> Self::Output {
-		use IntEvent::*;
-		match (self, rhs) {
-			(Fixed, _) | (_, Fixed) => Fixed,
-			(Bounds, _) | (_, Bounds) => Bounds,
-			(LowerBound, UpperBound) | (UpperBound, LowerBound) => Bounds,
-			(LowerBound, _) | (_, LowerBound) => LowerBound,
-			(UpperBound, _) | (_, UpperBound) => UpperBound,
-			(Domain, Domain) => Domain,
-		}
+	/// Check whether there are any propagators to fixed events
+	pub(crate) fn has_fixed_listeners(&self) -> bool {
+		self.lower_bound_idx > 0
 	}
 }
 
@@ -198,26 +178,7 @@ mod tests {
 				activation_list.add(*prop, *cond);
 			}
 			let fixed: HashSet<_> = activation_list.activated_by(IntEvent::Fixed).collect();
-			assert_eq!(
-				fixed,
-				HashSet::from_iter([
-					PropRef::from(0),
-					PropRef::from(1),
-					PropRef::from(2),
-					PropRef::from(3),
-					PropRef::from(4)
-				])
-			);
-			let bounds: HashSet<_> = activation_list.activated_by(IntEvent::Bounds).collect();
-			assert_eq!(
-				bounds,
-				HashSet::from_iter([
-					PropRef::from(1),
-					PropRef::from(2),
-					PropRef::from(3),
-					PropRef::from(4)
-				])
-			);
+			assert_eq!(fixed, HashSet::from_iter([PropRef::from(0)]));
 			let lower_bound: HashSet<_> =
 				activation_list.activated_by(IntEvent::LowerBound).collect();
 			assert_eq!(

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -41,13 +41,13 @@ use crate::{
 	solver::{
 		activation_list::{ActivationList, IntEvent},
 		bool_to_int::BoolToIntMap,
-		int_var::{IntVar, IntVarRef, OrderStorage},
+		int_var::{DirectStorage, IntVar, IntVarRef, OrderStorage},
 		queue::PropagatorQueue,
 		solving_context::SolvingContext,
 		trail::{Trail, TrailedInt},
 		BoolView, BoolViewInner, IntLitMeaning, IntView, IntViewInner, SolverConfiguration,
 	},
-	Clause, Conjunction, IntVal,
+	Clause, Conjunction, IntVal, LinearTransform,
 };
 
 #[derive(Debug, Default, Clone)]
@@ -205,9 +205,27 @@ impl PropagatorExtension for Engine {
 				}
 				ctx.state.int_vars[r].notify_upper_bound(&mut ctx.state.trail, lb);
 
-				for prop in ctx.state.int_activation[r].activated_by(IntEvent::Fixed) {
-					ctx.state.propagator_queue.enqueue_propagator(prop);
+				ctx.state.propagator_queue.enqueue_propagators(
+					ctx.state.int_activation[r].activated_by(IntEvent::UpperBound),
+				);
+			}
+
+			// Create an (fixed) equality literal if propagators are listening
+			match &ctx.state.int_vars[r].direct_encoding {
+				DirectStorage::Lazy(map)
+					if ctx.state.int_activation[r].has_fixed_listeners()
+						&& !map.contains_key(&lb) =>
+				{
+					let eq_lit = ctx.get_intref_lit(r, IntLitMeaning::Eq(lb));
+					if let BoolViewInner::Lit(eq_lit) = eq_lit.0 {
+						let _ = ctx.state.trail.assign_lit(eq_lit);
+					}
+					ctx.state.int_vars[r].notify_fixed(lb);
+					for prop in ctx.state.int_activation[r].activated_by(IntEvent::Fixed) {
+						ctx.state.propagator_queue.enqueue_propagator(prop);
+					}
 				}
+				_ => {}
 			}
 		}
 
@@ -294,60 +312,56 @@ impl PropagatorExtension for Engine {
 					.unwrap_or_else(|| self.state.int_vars[iv].lit_meaning(lit));
 				// Enact domain changes and determine change event
 				let (lb, ub) = self.state.int_vars[iv].get_bounds(&self.state);
-				let event = match meaning {
-					IntLitMeaning::Eq(i) if i == lb && i == ub => None,
-					IntLitMeaning::Eq(i) if i < lb || i > ub => {
-						// Notified of invalid assignment, do nothing.
-						//
-						// Although we do not expect this to happen, it seems that Cadical
-						// chronological backtracking might send notifications before
-						// additional propagation.
-						trace!(lit = i32::from(lit), lb, ub, "invalid eq notification");
-						None
-					}
-					IntLitMeaning::Eq(i) => {
-						if lb < i {
-							self.state.int_vars[iv].notify_lower_bound(&mut self.state.trail, i);
-						}
-						if ub > i {
-							self.state.int_vars[iv].notify_upper_bound(&mut self.state.trail, i);
-						}
-						debug_assert_eq!(
-							self.state.get_int_val(IntView(IntViewInner::VarRef(iv))),
-							Some(i)
-						);
-						Some(IntEvent::Fixed)
-					}
-					IntLitMeaning::NotEq(i) if i < lb || i > ub => None,
-					IntLitMeaning::NotEq(_) => Some(IntEvent::Domain),
-					IntLitMeaning::GreaterEq(new_lb) if new_lb <= lb => None,
+				let (event, fixed_val) = match meaning {
+					IntLitMeaning::Eq(i) => (None, Some(i)),
+					IntLitMeaning::NotEq(i) if i < lb || i > ub => (None, None),
+					IntLitMeaning::NotEq(_) => (Some(IntEvent::Domain), None),
+					IntLitMeaning::GreaterEq(new_lb) if new_lb <= lb => (None, None),
 					IntLitMeaning::GreaterEq(new_lb) => {
 						self.state.int_vars[iv].notify_lower_bound(&mut self.state.trail, new_lb);
-						Some(if new_lb == ub {
-							IntEvent::Fixed
-						} else {
-							IntEvent::LowerBound
-						})
+						(
+							Some(IntEvent::LowerBound),
+							if new_lb == *self.state.int_vars[iv].domain.upper_bound().unwrap() {
+								Some(new_lb)
+							} else {
+								None
+							},
+						)
 					}
 					IntLitMeaning::Less(i) => {
 						let new_ub = self.state.int_vars[iv].tighten_upper_bound(i - 1);
 						if new_ub < ub {
 							self.state.int_vars[iv]
 								.notify_upper_bound(&mut self.state.trail, new_ub);
-							Some(if new_ub == lb {
-								IntEvent::Fixed
-							} else {
-								IntEvent::UpperBound
-							})
+							(
+								Some(IntEvent::UpperBound),
+								if new_ub == *self.state.int_vars[iv].domain.lower_bound().unwrap()
+								{
+									Some(new_ub)
+								} else {
+									None
+								},
+							)
 						} else {
-							None
+							(None, None)
 						}
 					}
 				};
+				trace!(?event, ?fixed_val, "consequences");
 				if let Some(event) = event {
 					self.state
 						.propagator_queue
 						.enqueue_propagators(self.state.int_activation[iv].activated_by(event));
+				}
+				if let Some(i) = fixed_val {
+					self.state.int_vars[iv].notify_fixed(i);
+					debug_assert_eq!(
+						self.state.get_int_val(IntView(IntViewInner::VarRef(iv))),
+						Some(i)
+					);
+					self.state.propagator_queue.enqueue_propagators(
+						self.state.int_activation[iv].activated_by(IntEvent::Fixed),
+					);
 				}
 			}
 		}
@@ -834,6 +848,43 @@ impl InspectionActions for State {
 				}
 			}
 		}
+	}
+
+	fn get_int_val(&self, var: IntView) -> Option<IntVal> {
+		let transform = match var.0 {
+			IntViewInner::Const(_) | IntViewInner::VarRef(_) => LinearTransform::default(),
+			IntViewInner::Linear {
+				transformer,
+				var: _,
+			}
+			| IntViewInner::Bool {
+				transformer,
+				lit: _,
+			} => transformer,
+		};
+		match var.0 {
+			IntViewInner::Const(c) => Some(c),
+			IntViewInner::Linear {
+				transformer: _,
+				var,
+			}
+			| IntViewInner::VarRef(var) => {
+				let val = self.int_vars[var].last_fixed;
+				let lit = self.int_vars[var]
+					.get_bool_lit(IntLitMeaning::Eq(val))
+					.unwrap();
+				if self.trail.get_bool_val(lit) == Some(true) {
+					Some(val)
+				} else {
+					None
+				}
+			}
+			IntViewInner::Bool {
+				transformer: _,
+				lit,
+			} => self.trail.get_sat_value(lit).map(|b| b as IntVal),
+		}
+		.map(|v| transform.transform(v))
 	}
 }
 

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -347,7 +347,6 @@ impl PropagatorExtension for Engine {
 						}
 					}
 				};
-				trace!(?event, ?fixed_val, "consequences");
 				if let Some(event) = event {
 					self.state
 						.propagator_queue
@@ -870,14 +869,15 @@ impl InspectionActions for State {
 			}
 			| IntViewInner::VarRef(var) => {
 				let val = self.int_vars[var].last_fixed;
-				let lit = self.int_vars[var]
+				self.int_vars[var]
 					.get_bool_lit(IntLitMeaning::Eq(val))
-					.unwrap();
-				if self.trail.get_bool_val(lit) == Some(true) {
-					Some(val)
-				} else {
-					None
-				}
+					.and_then(|lit| {
+						if self.trail.get_bool_val(lit) == Some(true) {
+							Some(val)
+						} else {
+							None
+						}
+					})
 			}
 			IntViewInner::Bool {
 				transformer: _,

--- a/crates/huub/src/solver/int_var.rs
+++ b/crates/huub/src/solver/int_var.rs
@@ -76,6 +76,8 @@ pub(crate) struct IntVar {
 	///
 	/// Note that the lower bound is tracked within [`Self::order_encoding`].
 	upper_bound: TrailedInt,
+	/// Last notified fixed value
+	pub(crate) last_fixed: IntVal,
 }
 
 #[derive(Debug)]
@@ -705,6 +707,7 @@ impl IntVar {
 			domain,
 			order_encoding,
 			upper_bound,
+			last_fixed: lb,
 		});
 		// Create propagator activation list
 		let r = slv
@@ -766,6 +769,11 @@ impl IntVar {
 			_ => {}
 		}
 		(lit, negate)
+	}
+
+	/// Notify that a positive equality has been propagated for the variable.
+	pub(crate) fn notify_fixed(&mut self, val: IntVal) {
+		self.last_fixed = val;
 	}
 
 	/// Notify that a new lower bound has been propagated for the variable,


### PR DESCRIPTION
Since Cadical can change the propagation strength between equality literals and order literals. This PR changes the queuing mechanism to follow exactly when notifications of event come in.