### PR TITLE
Enforce branch-and-bound using clauses rather than assumptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 [[package]]
 name = "pindakaas"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#e1c34e1e8921806c8a88148488923d558d63b2cd"
+source = "git+https://github.com/pindakaashq/pindakaas.git#0c8075508b50cba8168a34d8d77a43999647d4f3"
 dependencies = [
  "iset",
  "itertools 0.13.0",
@@ -705,7 +705,7 @@ dependencies = [
 [[package]]
 name = "pindakaas-build-macros"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#e1c34e1e8921806c8a88148488923d558d63b2cd"
+source = "git+https://github.com/pindakaashq/pindakaas.git#0c8075508b50cba8168a34d8d77a43999647d4f3"
 dependencies = [
  "cc",
  "paste",
@@ -714,7 +714,7 @@ dependencies = [
 [[package]]
 name = "pindakaas-cadical"
 version = "2.1.3"
-source = "git+https://github.com/pindakaashq/pindakaas.git#e1c34e1e8921806c8a88148488923d558d63b2cd"
+source = "git+https://github.com/pindakaashq/pindakaas.git#0c8075508b50cba8168a34d8d77a43999647d4f3"
 dependencies = [
  "cc",
  "pindakaas-build-macros",
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "pindakaas-derive"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#e1c34e1e8921806c8a88148488923d558d63b2cd"
+source = "git+https://github.com/pindakaashq/pindakaas.git#0c8075508b50cba8168a34d8d77a43999647d4f3"
 dependencies = [
  "darling",
  "quote",

--- a/crates/fzn-huub/src/lib.rs
+++ b/crates/fzn-huub/src/lib.rs
@@ -363,7 +363,7 @@ where
 			})
 			.collect();
 		// Run the solver!
-		let res = match goal {
+		let (res, stats) = match goal {
 			Some((goal, obj)) => {
 				if self.all_solutions {
 					warn!("--all-solutions is ignored when optimizing, use --intermediate-solutions or --all-optimal instead");
@@ -376,7 +376,13 @@ where
 						0
 					}
 				];
-				let (status, obj_val) = if self.intermediate_solutions {
+				// TODO: Fix statistics
+				let all_opt_slv = if self.all_optimal {
+					Some(slv.clone())
+				} else {
+					None
+				};
+				let (status, stats, obj_val) = if self.intermediate_solutions {
 					slv.branch_and_bound(obj, goal, |value| {
 						output!(
 							self.stdout,
@@ -419,6 +425,7 @@ where
 					res
 				};
 				if status == SolveResult::Complete && self.all_optimal {
+					let mut slv = all_opt_slv.unwrap();
 					// Ensure all following solutions have the same objective value as the
 					// first optimal solution
 					let Some(obj_val) = obj_val else {
@@ -429,10 +436,10 @@ where
 					// Ensure all following solutions are different from the first optimal
 					// solution
 					if slv.add_no_good(&output_vars, &no_good_vals).is_err() {
-						SolveResult::Complete
+						(SolveResult::Complete, stats)
 					} else {
 						// Find remaining optimal solutions
-						slv.all_solutions(&output_vars, |value| {
+						let (res, stats_all) = slv.all_solutions(&output_vars, |value| {
 							output!(
 								self.stdout,
 								"{}",
@@ -442,10 +449,11 @@ where
 									var_map: &var_map
 								}
 							);
-						})
+						});
+						(res, stats + stats_all)
 					}
 				} else {
-					status
+					(status, stats)
 				}
 			}
 			None if self.all_solutions => slv.all_solutions(&output_vars, |value| {
@@ -459,21 +467,23 @@ where
 					}
 				);
 			}),
-			None => slv.solve(|value| {
-				output!(
-					self.stdout,
-					"{}",
-					Solution {
-						value,
-						fzn: &fzn,
-						var_map: &var_map
-					}
-				);
-			}),
+			None => {
+				let res = slv.solve(|value| {
+					output!(
+						self.stdout,
+						"{}",
+						Solution {
+							value,
+							fzn: &fzn,
+							var_map: &var_map
+						}
+					);
+				});
+				(res, slv.search_statistics())
+			}
 		};
 		// output solving statistics
 		if self.statistics {
-			let stats = slv.search_statistics();
 			print_statistics_block(
 				&mut self.stdout,
 				"complete",
@@ -481,7 +491,7 @@ where
 					("solveTime", &(Instant::now() - start_solve).as_secs_f64()),
 					("failures", &stats.conflicts()),
 					("peakDepth", &stats.peak_depth()),
-					("propagations", &stats.propagations()),
+					("propagations", &stats.cp_propagations()),
 					("restarts", &stats.restarts()),
 					("oracleDecisions", &stats.oracle_decisions()),
 					("userDecisions", &stats.user_decisions()),

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -12,7 +12,7 @@ use std::{
 	fmt::{self, Debug, Display, Formatter},
 	hash::Hash,
 	num::NonZeroI32,
-	ops::{Add, Deref, Mul, Neg, Not},
+	ops::{Add, AddAssign, Deref, Mul, Neg, Not},
 };
 
 use delegate::delegate;
@@ -40,7 +40,7 @@ use crate::{
 	reformulate::InitConfig,
 	solver::{
 		activation_list::IntPropCond,
-		engine::{trace_new_lit, Engine, PropRef, SearchStatistics},
+		engine::{trace_new_lit, Engine, PropRef},
 		int_var::{DirectStorage, IntVarRef, LazyLitDef, OrderStorage},
 		queue::{PriorityLevel, PropagatorInfo},
 		trail::TrailedInt,
@@ -145,6 +145,24 @@ pub(crate) enum IntViewInner {
 ///
 /// Note that this checker will always return false.
 pub(crate) struct NoAssumptions;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+/// Structure capturing statitical information about the search performed by the
+/// solver instance.
+pub struct SearchStatistics {
+	/// Number of conflicts encountered
+	pub(crate) conflicts: u64,
+	/// Number of search decisions left to the oracle solver
+	pub(crate) oracle_decisions: u64,
+	/// Peak search depth
+	pub(crate) peak_depth: u32,
+	/// Number of times a CP propagator was called
+	pub(crate) propagations: u64,
+	/// Number of backtracks to level 0
+	pub(crate) restarts: u32,
+	/// Number of decisions following the user-specified search heuristics
+	pub(crate) user_decisions: u64,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Result of a solving attempt
@@ -513,6 +531,55 @@ impl AssumptionChecker for NoAssumptions {
 	}
 }
 
+impl SearchStatistics {
+	/// Returns the number of conflicts encountered during the search.
+	pub fn conflicts(&self) -> u64 {
+		self.conflicts
+	}
+	/// Return the number of search decisions that was left to the oracle solver.
+	pub fn oracle_decisions(&self) -> u64 {
+		self.oracle_decisions
+	}
+	/// Returns the peak depth of the search tree.
+	pub fn peak_depth(&self) -> u32 {
+		self.peak_depth
+	}
+	/// Returns the number of propagations performed by the constraint programming
+	/// engine during the search.
+	pub fn cp_propagations(&self) -> u64 {
+		self.propagations
+	}
+	/// Returns the number of times the search was restarted by the oracle solver.
+	pub fn restarts(&self) -> u32 {
+		self.restarts
+	}
+	/// Returns the number of search decisions that followed the user specified
+	/// search heuristic.
+	pub fn user_decisions(&self) -> u64 {
+		self.user_decisions
+	}
+}
+
+impl Add for SearchStatistics {
+	type Output = SearchStatistics;
+
+	fn add(mut self, other: SearchStatistics) -> SearchStatistics {
+		self += other;
+		self
+	}
+}
+
+impl AddAssign for SearchStatistics {
+	fn add_assign(&mut self, other: SearchStatistics) {
+		self.conflicts += other.conflicts;
+		self.oracle_decisions += other.oracle_decisions;
+		self.peak_depth = self.peak_depth.max(other.peak_depth);
+		self.propagations += other.propagations;
+		self.restarts += other.restarts;
+		self.user_decisions += other.user_decisions;
+	}
+}
+
 impl<Oracle> Solver<Oracle>
 where
 	Oracle: PropagatingSolver<Engine>,
@@ -616,10 +683,14 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 	/// that you can clone the Solver object before calling this method to work around this
 	/// limitation.
 	pub fn all_solutions(
-		&mut self,
+		mut self,
 		vars: &[View],
 		mut on_sol: impl FnMut(&dyn Valuation),
-	) -> SolveResult {
+	) -> (SolveResult, SearchStatistics) {
+		use SolveResult::*;
+
+		let ret = |x: Self, status: SolveResult| (status, x.search_statistics());
+
 		let mut num_sol = 0;
 		loop {
 			let mut vals = Vec::with_capacity(vars.len());
@@ -631,23 +702,23 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 				on_sol(value);
 			});
 			match status {
-				SolveResult::Satisfied => {
+				Satisfied => {
 					if self.add_no_good(vars, &vals).is_err() {
-						return SolveResult::Complete;
+						return ret(self, Complete);
 					}
 				}
-				SolveResult::Unsatisfiable => {
+				Unsatisfiable => {
 					if num_sol == 0 {
-						return SolveResult::Unsatisfiable;
+						return ret(self, Unsatisfiable);
 					} else {
-						return SolveResult::Complete;
+						return ret(self, Complete);
 					}
 				}
-				SolveResult::Unknown => {
+				Unknown => {
 					if num_sol == 0 {
-						return SolveResult::Unknown;
+						return ret(self, Unknown);
 					} else {
-						return SolveResult::Satisfied;
+						return ret(self, Satisfied);
 					}
 				}
 				_ => unreachable!(),
@@ -660,38 +731,38 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 	/// Note that this method uses assumptions iteratively increase the lower bound of the objective.
 	/// This does not impact the state of the solver for continued use.
 	pub fn branch_and_bound(
-		&mut self,
+		mut self,
 		objective: IntView,
 		goal: Goal,
 		mut on_sol: impl FnMut(&dyn Valuation),
-	) -> (SolveResult, Option<IntVal>) {
+	) -> (SolveResult, SearchStatistics, Option<IntVal>) {
+		use SolveResult::*;
+		let ret = |x: Self, status: SolveResult, obj: Option<IntVal>| {
+			(status, x.search_statistics(), obj)
+		};
+
 		let mut obj_curr = None;
 		let obj_bound = match goal {
 			Goal::Minimize => self.get_int_lower_bound(objective),
 			Goal::Maximize => self.get_int_upper_bound(objective),
 		};
-		let mut assump = None;
 		debug!(obj_bound, "start branch and bound");
 		loop {
-			let status = self.solve_assuming(
-				assump,
-				|value| {
-					obj_curr = if let Value::Int(i) = value(View::Int(objective)) {
-						Some(i)
-					} else {
-						unreachable!()
-					};
-					on_sol(value);
-				},
-				|_| {},
-			);
+			let status = self.solve(|value| {
+				obj_curr = if let Value::Int(i) = value(View::Int(objective)) {
+					Some(i)
+				} else {
+					unreachable!()
+				};
+				on_sol(value);
+			});
 			debug!(?status, ?obj_curr, obj_bound, ?goal, "oracle solve result");
 			match status {
-				SolveResult::Satisfied => {
+				Satisfied => {
 					if obj_curr == Some(obj_bound) {
-						return (SolveResult::Complete, obj_curr);
+						return ret(self, Complete, obj_curr);
 					} else {
-						assump = match goal {
+						let bound_lit = match goal {
 							Goal::Minimize => Some(
 								self.get_int_lit(objective, IntLitMeaning::Less(obj_curr.unwrap())),
 							),
@@ -702,30 +773,31 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 						};
 						debug!(
 							lit = i32::from({
-								let BoolViewInner::Lit(l) = assump.unwrap().0 else {
+								let BoolViewInner::Lit(l) = bound_lit.unwrap().0 else {
 									unreachable!()
 								};
 								l
 							}),
 							"add objective bound"
 						);
+						self.add_clause([bound_lit.unwrap()]).unwrap();
 					}
 				}
-				SolveResult::Unsatisfiable => {
+				Unsatisfiable => {
 					return if obj_curr.is_none() {
-						(SolveResult::Unsatisfiable, None)
+						ret(self, Unsatisfiable, None)
 					} else {
-						(SolveResult::Complete, obj_curr)
-					}
+						ret(self, Complete, obj_curr)
+					};
 				}
-				SolveResult::Unknown => {
+				Unknown => {
 					return if obj_curr.is_none() {
-						(SolveResult::Unknown, None)
+						ret(self, Unknown, None)
 					} else {
-						(SolveResult::Satisfied, obj_curr)
+						ret(self, Satisfied, obj_curr)
 					}
 				}
-				SolveResult::Complete => unreachable!(),
+				Complete => unreachable!(),
 			}
 		}
 	}
@@ -766,16 +838,19 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 	/// from being generated twice. This will make repeated use of the Solver object impossible. Note
 	/// that you can clone the Solver object before calling this method to work around this
 	/// limitation.
-	pub fn get_all_solutions(&mut self, vars: &[View]) -> (SolveResult, Vec<Vec<Value>>) {
+	pub fn get_all_solutions(
+		self,
+		vars: &[View],
+	) -> (SolveResult, SearchStatistics, Vec<Vec<Value>>) {
 		let mut solutions = Vec::new();
-		let status = self.all_solutions(vars, |sol| {
+		let (status, stats) = self.all_solutions(vars, |sol| {
 			let mut sol_vec = Vec::with_capacity(vars.len());
 			for v in vars {
 				sol_vec.push(sol(*v));
 			}
 			solutions.push(sol_vec);
 		});
-		(status, solutions)
+		(status, stats, solutions)
 	}
 
 	/// Access the initilization statistics of the [`Solver`] object.
@@ -792,8 +867,16 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 	}
 
 	/// Access the search statistics for the search process up to this point.
-	pub fn search_statistics(&self) -> &SearchStatistics {
-		&self.engine().state.statistics
+	pub fn search_statistics(&self) -> SearchStatistics {
+		let cp_stats = &self.engine().state.statistics;
+		SearchStatistics {
+			conflicts: cp_stats.conflicts,
+			oracle_decisions: cp_stats.oracle_decisions,
+			peak_depth: cp_stats.peak_depth,
+			propagations: cp_stats.propagations,
+			restarts: cp_stats.restarts,
+			user_decisions: cp_stats.user_decisions,
+		}
 	}
 
 	/// Try and find a solution to the problem for which the Solver was
@@ -958,7 +1041,7 @@ impl<Oracle: PropagatingSolver<Engine>> DecisionActions for Solver<Oracle> {
 	}
 
 	fn get_num_conflicts(&self) -> u64 {
-		self.engine().state.statistics.conflicts()
+		self.engine().state.statistics.conflicts
 	}
 }
 

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -62,7 +62,7 @@ pub struct Engine {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
-pub struct SearchStatistics {
+pub(crate) struct EngineStatistics {
 	/// Number of conflicts encountered
 	pub(crate) conflicts: u64,
 	/// Number of search decisions left to the oracle solver
@@ -115,7 +115,7 @@ pub struct State {
 	/// Storage for clauses to be communicated to the solver
 	pub(crate) clauses: VecDeque<Clause>,
 	/// Solving statistics
-	pub(crate) statistics: SearchStatistics,
+	pub(crate) statistics: EngineStatistics,
 	/// Whether VSIDS is currently enabled
 	pub(crate) vsids: bool,
 
@@ -483,35 +483,6 @@ impl Engine {
 				lit
 			);
 		}
-	}
-}
-
-impl SearchStatistics {
-	/// Returns the number of conflicts encountered during the search.
-	pub fn conflicts(&self) -> u64 {
-		self.conflicts
-	}
-	/// Return the number of search decisions that was left to the oracle solver.
-	pub fn oracle_decisions(&self) -> u64 {
-		self.oracle_decisions
-	}
-	/// Returns the peak depth of the search tree.
-	pub fn peak_depth(&self) -> u32 {
-		self.peak_depth
-	}
-	/// Returns the number of propagations performed by the constraint programming
-	/// engine during the search.
-	pub fn propagations(&self) -> u64 {
-		self.propagations
-	}
-	/// Returns the number of times the search was restarted by the oracle solver.
-	pub fn restarts(&self) -> u32 {
-		self.restarts
-	}
-	/// Returns the number of search decisions that followed the user specified
-	/// search heuristic.
-	pub fn user_decisions(&self) -> u64 {
-		self.user_decisions
 	}
 }
 

--- a/crates/huub/src/tests.rs
+++ b/crates/huub/src/tests.rs
@@ -64,13 +64,9 @@ fn test_unify_int_lin_view_domains() {
 	let a = map.get_int(&mut slv, a);
 	let b = map.get_int(&mut slv, b);
 
-	assert_eq!(
-		slv.get_all_solutions(&[a.into(), b.into()]),
-		(
-			SolveResult::Complete,
-			vec![vec![Value::Int(1), Value::Int(3)]]
-		)
-	);
+	let (res, _, solns) = slv.get_all_solutions(&[a.into(), b.into()]);
+	assert_eq!(res, SolveResult::Complete);
+	assert_eq!(solns, vec![vec![Value::Int(1), Value::Int(3)]]);
 }
 
 impl Model {
@@ -85,12 +81,12 @@ impl Model {
 
 impl Solver {
 	pub(crate) fn assert_all_solutions<V: Into<View> + Clone>(
-		&mut self,
+		self,
 		vars: &[V],
 		pred: impl Fn(&[Value]) -> bool,
 	) {
 		let vars: Vec<_> = vars.iter().map(|v| v.clone().into()).collect();
-		let status = self.all_solutions(&vars, |value| {
+		let (status, _) = self.all_solutions(&vars, |value| {
 			let mut soln = Vec::with_capacity(vars.len());
 			for var in &vars {
 				soln.push(value(*var));
@@ -104,9 +100,9 @@ impl Solver {
 		assert_eq!(self.solve(|_| unreachable!()), SolveResult::Unsatisfiable);
 	}
 
-	pub(crate) fn expect_solutions<V: Into<View> + Clone>(&mut self, vars: &[V], expected: Expect) {
+	pub(crate) fn expect_solutions<V: Into<View> + Clone>(self, vars: &[V], expected: Expect) {
 		let vars: Vec<_> = vars.iter().map(|v| v.clone().into()).collect();
-		let (status, mut solns) = self.get_all_solutions(&vars);
+		let (status, _, mut solns) = self.get_all_solutions(&vars);
 		assert_eq!(status, SolveResult::Complete);
 		solns.sort();
 		let solns = format!(


### PR DESCRIPTION
Proof of concept for the alternative way to implement branch and bound. @alexeyignatiev suggested that there might be a large overhead for the learned clauses as they would be pre-empted with the assumption.

The current version should be (mostly) correct and allow us to test the difference. However, there are a few things I would like to change before we merge this:
- [x] `Solver::branch_and_bound` would now make the underlying `Solver` object unusable once it is finished. I would like to make the “statistics” of the solver available through a separate (returned) object and have the method consume the solver.
- [x] The current implementation has a customizer `Clone` implementation for `Solver`. We need this to re-observe all the Boolean variables. However, this is probably something that could be handled by `pindakaas`, which could get internal access to all observed variables in the pre-copy Cadical to subscribe the copy to the same variables. 

A **known issue** with this implementation is that copies do not boolean variables that only used in search heuristics. This only impacts run using `--all-optimal` and uncommon instances. As such, no test cases or MiniZinc challenge runs should be affected.