### PR TITLE
Add advisor methods for more in detail propagator notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -25,21 +25,51 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -49,18 +79,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -69,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -81,18 +111,18 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -101,28 +131,33 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "codspeed"
-version = "2.10.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f4cce9c27c49c4f101fffeebb1826f41a9df2e7498b7cd4d95c0658b796c6c"
+checksum = "d29180405ab3b37bb020246ea66bf8ae233708766fd59581ae929feaef10ce91"
 dependencies = [
+ "anyhow",
+ "bincode",
  "colored",
+ "glob",
  "libc",
+ "nix 0.29.0",
  "serde",
  "serde_json",
+ "statrs",
  "uuid",
 ]
 
 [[package]]
 name = "codspeed-divan-compat"
-version = "2.10.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8620a09dfaf37b3c45f982c4b65bd8f9b0203944da3ffa705c0fcae6b84655ff"
+checksum = "e1c73bce1e3f47738bf74a6b58b72a49b4f40c837ce420d8d65a270298592aac"
 dependencies = [
  "codspeed",
  "codspeed-divan-compat-macros",
@@ -131,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat-macros"
-version = "2.10.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fe872bc4214626b35d3a1706a905d0243503bb6ba3bb7be2fc59083d5d680c"
+checksum = "ea51dd8add7eba774cc24b4a98324252ac3ec092ccb5f07e52bbe1cb72a6d373"
 dependencies = [
  "divan-macros",
  "itertools 0.14.0",
@@ -145,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat-walltime"
-version = "2.10.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104caa97b36d4092d89e24e4b103b40ede1edab03c0372d19e14a33f9393132b"
+checksum = "417e9edfc4b0289d4b9b48e62f98c6168d5e30c0e612b2935e394b0dd930fe83"
 dependencies = [
  "cfg-if",
  "clap",
@@ -165,7 +200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -176,19 +211,19 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "ctrlc"
-version = "3.4.6"
+version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
- "nix",
- "windows-sys",
+ "nix 0.30.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -196,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
 dependencies = [
  "fnv",
  "ident_case",
@@ -210,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
 dependencies = [
  "darling_core",
  "quote",
@@ -221,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "delegate"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b6483c2bbed26f97861cf57651d4f2b731964a28cd2257f934a4b452480d21"
+checksum = "6178a82cf56c836a3ba61a7935cdb1c49bfaa6fa4327cd5bf554a503087de26b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -261,12 +296,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -297,9 +332,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -308,10 +343,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.15.2"
+name = "glob"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "humantime"
@@ -368,9 +409,9 @@ checksum = "44faf5bb8861a9c72e20d3fb0fdbd59233e43056e2b80475ab0aacdc2e781355"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -417,6 +458,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,9 +475,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"
@@ -436,9 +487,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -461,15 +512,27 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -574,9 +637,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -584,22 +647,16 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pico-args"
@@ -616,7 +673,7 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 [[package]]
 name = "pindakaas"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#ff69b046f0de23c2741392f2c26180682297cc7a"
+source = "git+https://github.com/pindakaashq/pindakaas.git#ec27d00f49fd70f956c34ab698fce0c90cac74f2"
 dependencies = [
  "iset",
  "itertools 0.13.0",
@@ -626,27 +683,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "pindakaas-build-macros"
-version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#ff69b046f0de23c2741392f2c26180682297cc7a"
-dependencies = [
- "cc",
- "paste",
-]
-
-[[package]]
 name = "pindakaas-cadical"
-version = "2.1.3"
-source = "git+https://github.com/pindakaashq/pindakaas.git#ff69b046f0de23c2741392f2c26180682297cc7a"
+version = "0.1.0"
+source = "git+https://github.com/pindakaashq/pindakaas.git#ec27d00f49fd70f956c34ab698fce0c90cac74f2"
 dependencies = [
  "cc",
- "pindakaas-build-macros",
 ]
 
 [[package]]
 name = "pindakaas-derive"
 version = "0.1.0"
-source = "git+https://github.com/pindakaashq/pindakaas.git#ff69b046f0de23c2741392f2c26180682297cc7a"
+source = "git+https://github.com/pindakaashq/pindakaas.git#ec27d00f49fd70f956c34ab698fce0c90cac74f2"
 dependencies = [
  "darling",
  "quote",
@@ -682,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rangelist"
@@ -698,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags",
 ]
@@ -763,22 +810,22 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -814,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -841,9 +888,19 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
 
 [[package]]
 name = "strsim"
@@ -853,9 +910,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -869,7 +926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -894,25 +951,24 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.25"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -932,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -943,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1022,11 +1078,13 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1048,6 +1106,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1078,7 +1194,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1087,14 +1212,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1104,10 +1245,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1116,10 +1269,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1128,10 +1293,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1140,16 +1317,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.7"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -1165,18 +1354,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/huub-cli/Cargo.toml
+++ b/crates/huub-cli/Cargo.toml
@@ -19,7 +19,7 @@ name = "flatzinc_bench"
 harness = false
 
 [dependencies]
-ctrlc = "3.4.4"
+ctrlc = "3.4"
 flatzinc-serde = { workspace = true }
 humantime = "2.1.0"
 huub = { path = "../huub" }
@@ -31,7 +31,7 @@ tracing-subscriber = "0.3.18"
 ustr = { version = "1.0", features = ["serde"] }
 
 [dev-dependencies]
-divan = { package = "codspeed-divan-compat", version = "2.10.1" }
+divan = { package = "codspeed-divan-compat", version = "3.0" }
 expect-test = { workspace = true }
 
 [lints]

--- a/crates/huub/src/actions.rs
+++ b/crates/huub/src/actions.rs
@@ -220,16 +220,46 @@ pub trait PropagatorInitActions: AsDynClauseDatabase + ClauseDatabase + Decision
 	/// Add a propagator to the solver.
 	fn add_propagator(&mut self, propagator: BoxedPropagator, priority: PriorityLevel) -> PropRef;
 
+	/// Advise a propagator when the solver backtracks.
+	///
+	/// This will call [`Propagator::advise_of_backtrack`] on the propagator.
+	fn advise_on_backtrack(&mut self, prop: PropRef);
+
+	/// Advise a propagator when a [`BoolView`] is assigned, allowing the
+	/// propagator to decide whether to enqueue itself.
+	///
+	/// Different from enqueueing, the propagator is always advised of the
+	/// assignment, not just when it is not yet enqueued.
+	///
+	/// This will call [`Propagator::advise_of_bool_change`] on the propagator.
+	fn advise_on_bool_change(&mut self, prop: PropRef, var: BoolView, data: u64);
+
+	/// Advise a propagator when an [`IntView`] is changed according to the given
+	/// propagation condition, allowing the propagator to decide whether to
+	/// enqueue itself.
+	///
+	/// Different from enqueueing, the propagator is always advised of the
+	/// integer change, not just when it is not yet enqueued.
+	///
+	/// This will call [`Propagator::advise_of_int_change`] on the propagator.
+	fn advise_on_int_change(
+		&mut self,
+		prop: PropRef,
+		var: IntView,
+		condition: IntPropCond,
+		data: u64,
+	);
+
 	/// Create a new trailed integer value with the given initial value.
 	fn new_trailed_int(&mut self, init: IntVal) -> TrailedInt;
 
 	/// Enqueue a propagator to be activated at the root node.
 	fn enqueue_now(&mut self, prop: PropRef);
 
-	/// Enqueue a propagator to be enqueued when a boolean variable is assigned.
+	/// Enqueue a propagator to be enqueued when a [`BoolView`] is assigned.
 	fn enqueue_on_bool_change(&mut self, prop: PropRef, var: BoolView);
 
-	/// Enqueue a propagator to be enqueued when an integer variable is changed
+	/// Enqueue a propagator to be enqueued when an [`IntView`] is changed
 	/// according to the given propagation condition.
 	fn enqueue_on_int_change(&mut self, prop: PropRef, var: IntView, condition: IntPropCond);
 }

--- a/crates/huub/src/constraints.rs
+++ b/crates/huub/src/constraints.rs
@@ -32,9 +32,10 @@ use crate::{
 	},
 	reformulate::ReformulationError,
 	solver::{
+		activation_list::IntEvent,
 		engine::{PropRef, State},
 		solving_context::SolvingContext,
-		BoolView, BoolViewInner,
+		BoolView, BoolViewInner, IntView,
 	},
 	Conjunction, Model,
 };
@@ -137,6 +138,39 @@ where
 	P: PropagationActions,
 	E: ExplanationActions,
 {
+	/// Advises the propagator that the solver is backtracking.
+	fn advise_of_backtrack(&mut self, actions: &mut E) {
+		let _ = actions;
+		unreachable!("propagator did not provide a backtrack advisor implementation")
+	}
+
+	/// Advises the propagator that a [`BoolView`] is assigned with the associated
+	/// data given when registering the advisor. If the advisor returns `true`,
+	/// then the propagator will be enqueued.
+	fn advise_of_bool_change(&mut self, actions: &mut E, view: BoolView, data: u64) -> bool {
+		let _ = actions;
+		let _ = view;
+		let _ = data;
+		unreachable!("propagator did not provide a Boolean advisor implementation")
+	}
+
+	/// Advises the propagator that a [`IntView`] has changed with the associated
+	/// data given when registering the advisor. If the advisor returns `true`,
+	/// then the propagator will be enqueued.
+	fn advise_of_int_change(
+		&mut self,
+		actions: &mut E,
+		view: IntView,
+		event: IntEvent,
+		data: u64,
+	) -> bool {
+		let _ = actions;
+		let _ = view;
+		let _ = event;
+		let _ = data;
+		unreachable!("propagator did not provide an integer advisor implementation")
+	}
+
 	/// The propagate method is called during the search process to allow the
 	/// propagator to enforce
 	fn propagate(&mut self, actions: &mut P) -> Result<(), Conflict> {

--- a/crates/huub/src/constraints/int_all_different.rs
+++ b/crates/huub/src/constraints/int_all_different.rs
@@ -13,7 +13,9 @@ use crate::{
 	constraints::{Conflict, Constraint, PropagationActions, Propagator, SimplificationStatus},
 	reformulate::ReformulationError,
 	solver::{
-		activation_list::IntPropCond, queue::PriorityLevel, IntLitMeaning, IntView, IntViewInner,
+		activation_list::{IntEvent, IntPropCond},
+		queue::PriorityLevel,
+		IntLitMeaning, IntView, IntViewInner,
 	},
 	IntDecision, IntVal,
 };
@@ -85,6 +87,8 @@ pub struct IntAllDifferentBounds {
 pub struct IntAllDifferentValue {
 	/// List of integer variables that must take different values.
 	vars: Vec<IntView>,
+	/// List of (indexes of) variable signaled to be fixed.
+	action_list: Vec<usize>,
 }
 
 impl IntAllDifferent {
@@ -438,13 +442,38 @@ impl IntAllDifferentValue {
 	/// Create a new [`AllDifferentIntValue`] propagator and post it in the
 	/// solver.
 	pub fn new_in<P: PropagatorInitActions + ?Sized>(solver: &mut P, vars: Vec<IntView>) {
-		let enqueue = vars
+		// Initialize a list of indices of decisions that already have a fixed
+		// value.
+		let action_list: Vec<usize> = vars
 			.iter()
-			.any(|v| matches!(v, IntView(IntViewInner::Const(_))));
-		let prop = solver.add_propagator(Box::new(Self { vars: vars.clone() }), PriorityLevel::Low);
-		for v in vars {
-			solver.enqueue_on_int_change(prop, v, IntPropCond::Fixed);
+			.enumerate()
+			.flat_map(|(i, v)| {
+				if let IntView(IntViewInner::Const(_)) = v {
+					Some(i)
+				} else {
+					None
+				}
+			})
+			.collect();
+		// If the list is not empty, then the propagator should be enqueued at the
+		// root level.
+		let enqueue = !action_list.is_empty();
+		// Post the propagator to the solver
+		let prop = solver.add_propagator(
+			Box::new(Self {
+				vars: vars.clone(),
+				action_list,
+			}),
+			PriorityLevel::Low,
+		);
+		// Let the propagator be advised when each specific decision is fixed to a
+		// value, with the index of the decision.
+		for (i, &v) in vars.iter().enumerate() {
+			solver.advise_on_int_change(prop, v, IntPropCond::Fixed, i as u64);
 		}
+		// Advise the propagator of backtracking to clear the list of fixed decision
+		// (indices).
+		solver.advise_on_backtrack(prop);
 		if enqueue {
 			solver.enqueue_now(prop);
 		}
@@ -456,19 +485,43 @@ where
 	P: PropagationActions,
 	E: ExplanationActions,
 {
+	fn advise_of_backtrack(&mut self, _actions: &mut E) {
+		// We forget any previously remembered fixed decisions.
+		self.action_list.clear();
+	}
+
+	fn advise_of_int_change(
+		&mut self,
+		_actions: &mut E,
+		_view: IntView,
+		event: IntEvent,
+		data: u64,
+	) -> bool {
+		// We remember that the decision at index `data` has been fixed to a value.
+		debug_assert_eq!(event, IntEvent::Fixed);
+		self.action_list.push(data as usize);
+		true
+	}
+
 	#[tracing::instrument(name = "all_different", level = "trace", skip(self, actions))]
 	fn propagate(&mut self, actions: &mut P) -> Result<(), Conflict> {
-		for (i, &var) in self.vars.iter().enumerate() {
-			if let Some(val) = actions.get_int_val(var) {
-				let reason = actions.get_int_lit(var, IntLitMeaning::Eq(val));
-				for (j, &other) in self.vars.iter().enumerate() {
-					let other_val = actions.get_int_val(other);
-					if j != i && (other_val.is_none() || other_val.unwrap() == val) {
-						actions.set_int_not_eq(other, val, reason)?;
-					}
+		debug_assert!(!self.action_list.is_empty() && self.action_list.iter().all_unique());
+		// We walk through all fixed decisions (indices).
+		for &i in &self.action_list {
+			// Retrieve the value and value literal for the fixed decision.
+			let val = actions.get_int_val(self.vars[i]).unwrap();
+			let reason = actions.get_int_val_lit(self.vars[i]).unwrap();
+
+			// We now enforce that all other decisions (at different indices) are not
+			// equal to the fixed value.
+			for (j, &v) in self.vars.iter().enumerate() {
+				if j != i {
+					actions.set_int_not_eq(v, val, reason)?;
 				}
 			}
 		}
+		// We clear the list of indices of fixed decisions.
+		self.action_list.clear();
 		Ok(())
 	}
 }

--- a/crates/huub/src/reformulate.rs
+++ b/crates/huub/src/reformulate.rs
@@ -468,6 +468,9 @@ impl PropagatorInitActions for ReformulationContext<'_> {
 	delegate! {
 		to self.slv {
 			fn add_propagator(&mut self, propagator: BoxedPropagator, priority: PriorityLevel) -> PropRef;
+			fn advise_on_backtrack(&mut self, prop: PropRef);
+			fn advise_on_bool_change(&mut self, prop: PropRef, var: BoolView, data: u64);
+			fn advise_on_int_change(&mut self, prop: PropRef, var: IntView, condition: IntPropCond, data: u64);
 			fn new_trailed_int(&mut self, init: IntVal) -> TrailedInt;
 			fn enqueue_now(&mut self, prop: PropRef);
 			fn enqueue_on_bool_change(&mut self, prop: PropRef, var: BoolView);

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -39,8 +39,8 @@ use crate::{
 	flatzinc::{FlatZincError, FlatZincStatistics},
 	reformulate::InitConfig,
 	solver::{
-		activation_list::IntPropCond,
-		engine::{trace_new_lit, Engine, PropRef},
+		activation_list::{ActivationAction, IntPropCond},
+		engine::{trace_new_lit, AdvisorDef, Engine, PropRef},
 		int_var::{DirectStorage, IntVarRef, LazyLitDef, OrderStorage},
 		queue::{PriorityLevel, PropagatorInfo},
 		trail::TrailedInt,
@@ -679,6 +679,28 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 		self.add_clause(clause)
 	}
 
+	/// Internal method used to add an advisor that is triggered when a [`RawLit`]
+	/// changes.
+	///
+	/// Used by [`Solver::advise_on_bool_change`] and
+	/// [`Solver::advise_on_int_change`].
+	fn advise_on_lit_change(&mut self, prop: PropRef, lit: RawLit, data: u64, bool2int: bool) {
+		self.engine_mut().state.trail.grow_to_boolvar(lit.var());
+		self.oracle.add_observed_var(lit.var());
+		let state = &mut self.engine_mut().state;
+		let adv = state.advisors.push(AdvisorDef {
+			bool2int,
+			data,
+			negated: false,
+			propagator: prop,
+		});
+		state
+			.bool_activation
+			.entry(lit.var())
+			.or_default()
+			.push(ActivationAction::Advise(adv).into());
+	}
+
 	/// Find all solutions with regard to a list of given variables.
 	/// The given closure will be called for each solution found.
 	///
@@ -1107,6 +1129,56 @@ impl<Oracle: PropagatingSolver<Engine>> PropagatorInitActions for Solver<Oracle>
 		p
 	}
 
+	fn advise_on_backtrack(&mut self, prop: PropRef) {
+		self.engine_mut().notify_of_backtrack.push(prop);
+	}
+
+	fn advise_on_bool_change(&mut self, prop: PropRef, var: BoolView, data: u64) {
+		match var.0 {
+			BoolViewInner::Lit(lit) => {
+				self.advise_on_lit_change(prop, lit, data, false);
+			}
+			BoolViewInner::Const(_) => {}
+		}
+	}
+
+	fn advise_on_int_change(
+		&mut self,
+		prop: PropRef,
+		var: IntView,
+		condition: IntPropCond,
+		data: u64,
+	) {
+		let (var, cond, negated) = match var.0 {
+			IntViewInner::VarRef(var) => (var, condition, false),
+			IntViewInner::Linear { transformer, var } => {
+				let condition = match condition {
+					IntPropCond::LowerBound if !transformer.positive_scale() => {
+						IntPropCond::UpperBound
+					}
+					IntPropCond::UpperBound if !transformer.positive_scale() => {
+						IntPropCond::LowerBound
+					}
+					_ => condition,
+				};
+				(var, condition, !transformer.positive_scale())
+			}
+			IntViewInner::Const(_) => return, // ignore
+			IntViewInner::Bool { lit, .. } => {
+				return self.advise_on_lit_change(prop, lit, data, true);
+			}
+		};
+
+		let state = &mut self.engine_mut().state;
+		let adv = state.advisors.push(AdvisorDef {
+			bool2int: false,
+			data,
+			negated,
+			propagator: prop,
+		});
+		self.engine_mut().state.int_activation[var].add(ActivationAction::Advise(adv), cond);
+	}
+
 	fn enqueue_now(&mut self, prop: PropRef) {
 		let state = &mut self.engine_mut().state;
 		state.propagator_queue.enqueue_propagator(prop);
@@ -1122,7 +1194,7 @@ impl<Oracle: PropagatingSolver<Engine>> PropagatorInitActions for Solver<Oracle>
 					.bool_activation
 					.entry(lit.var())
 					.or_default()
-					.push(prop);
+					.push(ActivationAction::Enqueue(prop).into());
 			}
 			BoolViewInner::Const(_) => {}
 		}
@@ -1148,7 +1220,7 @@ impl<Oracle: PropagatingSolver<Engine>> PropagatorInitActions for Solver<Oracle>
 				return self.enqueue_on_bool_change(prop, BoolView(BoolViewInner::Lit(lit)))
 			}
 		};
-		self.engine_mut().state.int_activation[var].add(prop, cond);
+		self.engine_mut().state.int_activation[var].add(ActivationAction::Enqueue(prop), cond);
 	}
 
 	fn new_trailed_int(&mut self, init: IntVal) -> TrailedInt {

--- a/crates/huub/src/solver/activation_list.rs
+++ b/crates/huub/src/solver/activation_list.rs
@@ -3,7 +3,9 @@
 
 use std::{mem, ops::Add};
 
-use crate::solver::engine::PropRef;
+use itertools::Itertools;
+
+use crate::solver::engine::{Advisor, PropRef};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 /// A data structure that store a list of propagators to be enqueued based on
@@ -21,7 +23,7 @@ use crate::solver::engine::PropRef;
 pub(crate) struct ActivationList {
 	/// The list of propagators that are to be enqueue based on different
 	/// propagation conditions.
-	activations: Vec<PropRef>,
+	activations: Vec<ActivationActionS>,
 	/// The index for the first propagator to be activated when an event triggers
 	/// [`IntPropCond::LowerBound`].
 	lower_bound_idx: u32,
@@ -36,9 +38,25 @@ pub(crate) struct ActivationList {
 	domain_idx: u32,
 }
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+/// Possible actions to be triggered by the activation list.
+pub(crate) enum ActivationAction {
+	/// When activated, advise the propagator with the given [`PropRef`] of the
+	/// event that triggered the activation. If the advisal method returns `true`,
+	/// then enqueue the propagator if it is not already in the queue.
+	Advise(Advisor),
+	/// When activated, simply add the propagator with the given [`PropRef`] to the
+	/// propagator queue if it is not already in the queue.
+	Enqueue(PropRef),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+/// Object used to efficiently store an [`ActivationAction`].
+pub(crate) struct ActivationActionS(u32);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Change that has occurred in the domain of an integer variable.
-pub(crate) enum IntEvent {
+pub enum IntEvent {
 	/// The variable has been fixed to a single value.
 	Fixed,
 	/// Both of the bounds of the variable has changed.
@@ -74,9 +92,31 @@ pub enum IntPropCond {
 	Domain,
 }
 
+impl From<ActivationActionS> for ActivationAction {
+	fn from(value: ActivationActionS) -> Self {
+		if (value.0 & 0b1) == 1 {
+			Self::Advise(Advisor::from_raw(value.0 >> 1))
+		} else {
+			Self::Enqueue(PropRef::from_raw(value.0 >> 1))
+		}
+	}
+}
+
+impl From<ActivationAction> for ActivationActionS {
+	fn from(value: ActivationAction) -> Self {
+		Self(match value {
+			ActivationAction::Advise(advisor) => (advisor.raw() << 1) | 0b1,
+			ActivationAction::Enqueue(prop) => prop.raw() << 1,
+		})
+	}
+}
+
 impl ActivationList {
 	/// Get an iterator over the list of propagators to be enqueued.
-	pub(crate) fn activated_by(&self, event: IntEvent) -> impl Iterator<Item = PropRef> + '_ {
+	pub(crate) fn activated_by(
+		&self,
+		event: IntEvent,
+	) -> impl Iterator<Item = ActivationAction> + '_ {
 		let r1 = if event == IntEvent::LowerBound {
 			self.lower_bound_idx as usize..self.upper_bound_idx as usize
 		} else {
@@ -92,17 +132,19 @@ impl ActivationList {
 		};
 		self.activations[r1]
 			.iter()
+			.chain(self.activations[r2].iter())
 			.copied()
-			.chain(self.activations[r2].iter().copied())
+			.map_into()
 	}
 	/// Add a propagator to the list of propagators to be enqueued based on the
 	/// given condition.
-	pub(crate) fn add(&mut self, mut prop: PropRef, condition: IntPropCond) {
+	pub(crate) fn add(&mut self, action: ActivationAction, condition: IntPropCond) {
 		assert!(self.activations.len() < u32::MAX as usize, "Unable to add more than u32::MAX propagators to the activation list of a single variable.");
+		let mut action = action.into();
 		let mut cond_swap = |idx: u32| {
 			let idx = idx as usize;
 			if idx < self.activations.len() {
-				mem::swap(&mut prop, &mut self.activations[idx]);
+				mem::swap(&mut action, &mut self.activations[idx]);
 			}
 		};
 		match condition {
@@ -121,7 +163,7 @@ impl ActivationList {
 				self.upper_bound_idx += 1;
 				self.bounds_idx += 1;
 				self.domain_idx += 1;
-				self.activations.push(prop);
+				self.activations.push(action);
 			}
 			IntPropCond::LowerBound => {
 				cond_swap(self.upper_bound_idx);
@@ -134,7 +176,7 @@ impl ActivationList {
 				self.upper_bound_idx += 1;
 				self.bounds_idx += 1;
 				self.domain_idx += 1;
-				self.activations.push(prop);
+				self.activations.push(action);
 			}
 			IntPropCond::UpperBound => {
 				cond_swap(self.bounds_idx);
@@ -143,14 +185,14 @@ impl ActivationList {
 				}
 				self.bounds_idx += 1;
 				self.domain_idx += 1;
-				self.activations.push(prop);
+				self.activations.push(action);
 			}
 			IntPropCond::Bounds => {
 				cond_swap(self.domain_idx);
 				self.domain_idx += 1;
-				self.activations.push(prop);
+				self.activations.push(action);
 			}
-			IntPropCond::Domain => self.activations.push(prop),
+			IntPropCond::Domain => self.activations.push(action),
 		};
 	}
 }
@@ -178,7 +220,7 @@ mod tests {
 	use itertools::Itertools;
 
 	use crate::solver::{
-		activation_list::{ActivationList, IntEvent, IntPropCond},
+		activation_list::{ActivationAction, ActivationList, IntEvent, IntPropCond},
 		engine::PropRef,
 	};
 
@@ -195,43 +237,54 @@ mod tests {
 		for list in props.iter().permutations(5) {
 			let mut activation_list = ActivationList::default();
 			for (prop, cond) in list.iter() {
-				activation_list.add(*prop, *cond);
+				activation_list.add(ActivationAction::Enqueue(*prop), *cond);
 			}
 			let fixed: HashSet<_> = activation_list.activated_by(IntEvent::Fixed).collect();
 			assert_eq!(
 				fixed,
 				HashSet::from_iter([
-					PropRef::from(0),
-					PropRef::from(1),
-					PropRef::from(2),
-					PropRef::from(3),
-					PropRef::from(4)
+					ActivationAction::Enqueue(PropRef::from(0)),
+					ActivationAction::Enqueue(PropRef::from(1)),
+					ActivationAction::Enqueue(PropRef::from(2)),
+					ActivationAction::Enqueue(PropRef::from(3)),
+					ActivationAction::Enqueue(PropRef::from(4))
 				])
 			);
 			let bounds: HashSet<_> = activation_list.activated_by(IntEvent::Bounds).collect();
 			assert_eq!(
 				bounds,
 				HashSet::from_iter([
-					PropRef::from(1),
-					PropRef::from(2),
-					PropRef::from(3),
-					PropRef::from(4)
+					ActivationAction::Enqueue(PropRef::from(1)),
+					ActivationAction::Enqueue(PropRef::from(2)),
+					ActivationAction::Enqueue(PropRef::from(3)),
+					ActivationAction::Enqueue(PropRef::from(4))
 				])
 			);
 			let lower_bound: HashSet<_> =
 				activation_list.activated_by(IntEvent::LowerBound).collect();
 			assert_eq!(
 				lower_bound,
-				HashSet::from_iter([PropRef::from(1), PropRef::from(3), PropRef::from(4)])
+				HashSet::from_iter([
+					ActivationAction::Enqueue(PropRef::from(1)),
+					ActivationAction::Enqueue(PropRef::from(3)),
+					ActivationAction::Enqueue(PropRef::from(4))
+				])
 			);
 			let upper_bound: HashSet<_> =
 				activation_list.activated_by(IntEvent::UpperBound).collect();
 			assert_eq!(
 				upper_bound,
-				HashSet::from_iter([PropRef::from(2), PropRef::from(3), PropRef::from(4)])
+				HashSet::from_iter([
+					ActivationAction::Enqueue(PropRef::from(2)),
+					ActivationAction::Enqueue(PropRef::from(3)),
+					ActivationAction::Enqueue(PropRef::from(4))
+				])
 			);
 			let domain: HashSet<_> = activation_list.activated_by(IntEvent::Domain).collect();
-			assert_eq!(domain, HashSet::from_iter([PropRef::from(4)]));
+			assert_eq!(
+				domain,
+				HashSet::from_iter([ActivationAction::Enqueue(PropRef::from(4))])
+			);
 		}
 	}
 }

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -441,7 +441,8 @@ impl PropagatorExtension for Engine {
 				};
 				if !self.state.failed {
 					if let Some(event) = event {
-						for action in self.state.int_activation[iv].clone().activated_by(event) {
+						let activations = mem::take(&mut self.state.int_activation[iv]);
+						for action in activations.activated_by(event) {
 							let prop = match action {
 								ActivationAction::Advise(adv) => {
 									let &AdvisorDef {
@@ -469,6 +470,7 @@ impl PropagatorExtension for Engine {
 							};
 							self.state.propagator_queue.enqueue_propagator(prop);
 						}
+						self.state.int_activation[iv] = activations;
 					}
 				}
 			}
@@ -481,7 +483,7 @@ impl PropagatorExtension for Engine {
 		self.state.notify_backtrack::<false>(new_level, restart);
 
 		// Notify subscribed propagators of backtracking
-		for p in self.notify_of_backtrack.iter().cloned() {
+		for &p in self.notify_of_backtrack.iter() {
 			self.propagators[p].advise_of_backtrack(&mut self.state);
 		}
 	}

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -37,7 +37,7 @@ use crate::{
 	branchers::{BoxedBrancher, Decision},
 	constraints::{BoxedPropagator, Conflict, Reason},
 	solver::{
-		activation_list::{ActivationList, IntEvent},
+		activation_list::{ActivationAction, ActivationActionS, ActivationList, IntEvent},
 		bool_to_int::BoolToIntMap,
 		int_var::{IntVar, IntVarRef, OrderStorage},
 		queue::PropagatorQueue,
@@ -48,11 +48,27 @@ use crate::{
 	Clause, IntVal,
 };
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// Definition of an [`Advisor`] giving the information about the [`View`]
+/// subscribed to and the way in which to advise the propagator.
+pub(crate) struct AdvisorDef {
+	/// Whether the advise is on a [`BoolView`] being used as an [`IntView`]
+	pub(crate) bool2int: bool,
+	/// 64 bits of data communicated when advising propagator.
+	pub(crate) data: u64,
+	/// Whether the advise is on a [`IntView`] with a negative coefficient.
+	pub(crate) negated: bool,
+	/// The propagator being advised.
+	pub(crate) propagator: PropRef,
+}
+
 #[derive(Debug, Default, Clone)]
 /// A propagation engine implementing the [`Propagator`] trait.
 pub struct Engine {
 	/// Storage of the propagators.
 	pub(crate) propagators: IndexVec<PropRef, BoxedPropagator>,
+	/// List of propagators to advise of backtracking
+	pub(crate) notify_of_backtrack: Vec<PropRef>,
 	/// Storage of the branchers.
 	pub(crate) branchers: Vec<BoxedBrancher>,
 	/// Internal State representation of the propagation engine.
@@ -118,8 +134,10 @@ pub struct State {
 	pub(crate) vsids: bool,
 
 	// ---- Queueing Infrastructure ----
+	/// Advisor data storage
+	pub(crate) advisors: IndexVec<Advisor, AdvisorDef>,
 	/// Boolean variable enqueueing information
-	pub(crate) bool_activation: FxHashMap<RawVar, Vec<PropRef>>,
+	pub(crate) bool_activation: FxHashMap<RawVar, Vec<ActivationActionS>>,
 	/// Integer variable enqueueing information
 	pub(crate) int_activation: IndexVec<IntVarRef, ActivationList>,
 	/// Queue of propagators awaiting action
@@ -225,9 +243,28 @@ impl PropagatorExtension for Engine {
 				}
 				ctx.state.int_vars[r].notify_upper_bound(&mut ctx.state.trail, lb);
 
-				for prop in ctx.state.int_activation[r].activated_by(IntEvent::Fixed) {
+				let activation = mem::take(&mut ctx.state.int_activation[r]);
+				for action in activation.activated_by(IntEvent::Fixed) {
+					let prop = match action {
+						ActivationAction::Advise(adv) => {
+							let &AdvisorDef {
+								data, propagator, ..
+							} = &ctx.state.advisors[adv];
+							if !self.propagators[propagator].advise_of_int_change(
+								ctx.state,
+								IntView(IntViewInner::VarRef(r)),
+								IntEvent::Fixed,
+								data,
+							) {
+								continue;
+							}
+							propagator
+						}
+						ActivationAction::Enqueue(prop) => prop,
+					};
 					ctx.state.propagator_queue.enqueue_propagator(prop);
 				}
+				ctx.state.int_activation[r] = activation;
 			}
 		}
 
@@ -295,14 +332,50 @@ impl PropagatorExtension for Engine {
 
 			// Enqueue based on direct literal
 			if !self.state.failed {
-				self.state.propagator_queue.enqueue_propagators(
-					self.state
-						.bool_activation
-						.get(&lit.var())
-						.into_iter()
-						.flatten()
-						.copied(),
-				);
+				if let Some(activations) = self
+					.state
+					.bool_activation
+					.get_mut(&lit.var())
+					.map(mem::take)
+				{
+					for &action in &activations {
+						let prop = match action.into() {
+							ActivationAction::Advise(adv) => {
+								let &AdvisorDef {
+									bool2int,
+									data,
+									propagator,
+									..
+								} = &self.state.advisors[adv];
+								let enqueue = if bool2int {
+									self.propagators[propagator].advise_of_int_change(
+										&mut self.state,
+										IntView(IntViewInner::Bool {
+											transformer: Default::default(),
+											lit,
+										}),
+										IntEvent::Fixed,
+										data,
+									)
+								} else {
+									self.propagators[propagator].advise_of_bool_change(
+										&mut self.state,
+										BoolView(BoolViewInner::Lit(lit)),
+										data,
+									)
+								};
+								if !enqueue {
+									continue;
+								}
+								propagator
+							}
+							ActivationAction::Enqueue(prop) => prop,
+						};
+						self.state.propagator_queue.enqueue_propagator(prop);
+					}
+
+					*self.state.bool_activation.get_mut(&lit.var()).unwrap() = activations;
+				}
 			}
 
 			// Enqueue based on literal meaning in complex type
@@ -323,12 +396,18 @@ impl PropagatorExtension for Engine {
 						trace!(lit = i32::from(lit), lb, ub, "invalid eq notification");
 						None
 					}
-					IntLitMeaning::Eq(_val) => {
+					IntLitMeaning::Eq(val) => {
 						#[cfg(debug_assertions)]
 						{
 							// (DEBUG ONLY) Push the integer variable and its value to check
 							// that its bounds were updated before propagation occurs.
-							self.state.check_int_fixed.push((iv, _val));
+							self.state.check_int_fixed.push((iv, val));
+						}
+						if val > lb {
+							self.state.int_vars[iv].notify_lower_bound(&mut self.state.trail, val);
+						}
+						if val < ub {
+							self.state.int_vars[iv].notify_upper_bound(&mut self.state.trail, val);
 						}
 						Some(IntEvent::Fixed)
 					}
@@ -362,9 +441,34 @@ impl PropagatorExtension for Engine {
 				};
 				if !self.state.failed {
 					if let Some(event) = event {
-						self.state
-							.propagator_queue
-							.enqueue_propagators(self.state.int_activation[iv].activated_by(event));
+						for action in self.state.int_activation[iv].clone().activated_by(event) {
+							let prop = match action {
+								ActivationAction::Advise(adv) => {
+									let &AdvisorDef {
+										negated,
+										data,
+										propagator,
+										..
+									} = &self.state.advisors[adv];
+									let event = match event {
+										IntEvent::LowerBound if negated => IntEvent::UpperBound,
+										IntEvent::UpperBound if negated => IntEvent::LowerBound,
+										e => e,
+									};
+									if !self.propagators[propagator].advise_of_int_change(
+										&mut self.state,
+										IntView(IntViewInner::VarRef(iv)),
+										event,
+										data,
+									) {
+										continue;
+									}
+									propagator
+								}
+								ActivationAction::Enqueue(prop) => prop,
+							};
+							self.state.propagator_queue.enqueue_propagator(prop);
+						}
 					}
 				}
 			}
@@ -375,6 +479,11 @@ impl PropagatorExtension for Engine {
 		debug!(new_level, restart, "backtrack");
 		// Revert value changes to previous decision level
 		self.state.notify_backtrack::<false>(new_level, restart);
+
+		// Notify subscribed propagators of backtracking
+		for p in self.notify_of_backtrack.iter().cloned() {
+			self.propagators[p].advise_of_backtrack(&mut self.state);
+		}
 	}
 
 	fn notify_new_decision_level(&mut self) {
@@ -409,10 +518,20 @@ impl PropagatorExtension for Engine {
 			#[cfg(debug_assertions)]
 			{
 				// (DEBUG ONLY) Check that all integers that where fixed by equality
-				// literals had their bounds updated to match.
+				// literals had their bound literals set to match.
 				for (iv, i) in mem::take(&mut self.state.check_int_fixed) {
 					let iv = IntView(IntViewInner::VarRef(iv));
 					debug_assert_eq!(self.state.get_int_val(iv), Some(i));
+					let lb_lit = self
+						.state
+						.try_int_lit(iv, IntLitMeaning::GreaterEq(i))
+						.unwrap();
+					let ub_lit = self
+						.state
+						.try_int_lit(iv, IntLitMeaning::Less(i + 1))
+						.unwrap();
+					debug_assert_eq!(self.state.get_bool_val(lb_lit), Some(true));
+					debug_assert_eq!(self.state.get_bool_val(ub_lit), Some(true));
 				}
 			}
 			// If there are no previous changes, run propagators
@@ -935,4 +1054,13 @@ impl TrailingActions for State {
 index_vec::define_index_type! {
 	/// Identifies an propagator in a [`Solver`]
 	pub struct PropRef = u32;
+	// Allow storing as i32 in [`ActivationActionS`]
+	MAX_INDEX = i32::MAX as usize;
+}
+
+index_vec::define_index_type! {
+	/// Identifies an advisor in the [`State`]
+	pub struct Advisor = u32;
+	// Allow storing as i32 in [`ActivationActionS`]
+	MAX_INDEX = i32::MAX as usize;
 }

--- a/crates/huub/src/solver/queue.rs
+++ b/crates/huub/src/solver/queue.rs
@@ -90,13 +90,6 @@ impl PropagatorQueue {
 		}
 	}
 
-	/// Enqueue all propagators from a given iterator.
-	pub(crate) fn enqueue_propagators(&mut self, props: impl IntoIterator<Item = PropRef>) {
-		for prop in props.into_iter() {
-			self.enqueue_propagator(prop);
-		}
-	}
-
 	/// Pop a propagator from the queue if there are any.
 	pub(crate) fn pop(&mut self) -> Option<PropRef> {
 		self.queue.pop().inspect(|&p| self.info[p].enqueued = false)

--- a/crates/huub/src/solver/solving_context.rs
+++ b/crates/huub/src/solver/solving_context.rs
@@ -91,7 +91,7 @@ impl<'a> SolvingContext<'a> {
 		Self {
 			slv,
 			state,
-			current_prop: PropRef::new(u32::MAX as usize),
+			current_prop: PropRef::new(i32::MAX as usize),
 		}
 	}
 
@@ -160,7 +160,7 @@ impl<'a> SolvingContext<'a> {
 			let prop = propagators[p].as_mut();
 			let res = prop.propagate(self);
 			self.state.statistics.propagations += 1;
-			self.current_prop = PropRef::new(u32::MAX as usize);
+			self.current_prop = PropRef::new(i32::MAX as usize);
 			if let Err(conflict) = res {
 				trace!(
 					lit = conflict


### PR DESCRIPTION
Resolves #116

Currently, still a draft implementation. The primary concern is that each element in the activation lists has been increased to 4x the size. This is caused by having to distinguish between the “enqueue” and “advise” actions (increasing the `u32` index to 64 bits just to distinguish between the two variants), and it is then doubled again to store the `u64` of data that the propagator can associate with the “advise” action.