### PR TITLE
XCSP3 (competition) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-test",
+ "xcsp3-serde",
 ]
 
 [[package]]
@@ -346,10 +347,12 @@ dependencies = [
  "humantime",
  "huub",
  "pico-args",
+ "quick-xml",
  "serde_json",
  "tracing",
  "tracing-subscriber",
  "ustr",
+ "xcsp3-serde",
 ]
 
 [[package]]
@@ -464,6 +467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +482,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -667,6 +686,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1159,6 +1188,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "xcsp3-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dac2ee78acf9ade2a25cc38b1b3ad517c11b5b8266e9253e29b141e3e3f24e"
+dependencies = [
+ "nom",
+ "rangelist",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ keywords = ["sat", "lcg", "flatzinc", "minizinc", "optimization"]
 expect-test = "1.5"
 flatzinc-serde = "0.4"
 tracing = "0.1.40"
+xcsp3-serde = "0.1.1"
 
 [workspace.lints.rust]
 missing_debug_implementations = "warn"

--- a/crates/huub-cli/Cargo.toml
+++ b/crates/huub-cli/Cargo.toml
@@ -22,7 +22,7 @@ harness = false
 ctrlc = "3.4.4"
 flatzinc-serde = { workspace = true }
 humantime = "2.1.0"
-huub = { path = "../huub", features = ["flatzinc"] }
+huub = { path = "../huub", features = ["flatzinc", "xcsp3"] }
 pico-args = { version = "0.5.0", features = ["combined-flags"] }
 serde_json = "1.0"
 tracing = { workspace = true }

--- a/crates/huub-cli/Cargo.toml
+++ b/crates/huub-cli/Cargo.toml
@@ -28,6 +28,8 @@ serde_json = "1.0"
 tracing = { workspace = true }
 tracing-subscriber = "0.3.18"
 ustr = { version = "1.0", features = ["serde"] }
+xcsp3-serde = { workspace = true }
+quick-xml = { version = "0.37.4", features = ["serialize"] }
 
 [dev-dependencies]
 divan = { package = "codspeed-divan-compat", version = "2.10.1" }

--- a/crates/huub-cli/Cargo.toml
+++ b/crates/huub-cli/Cargo.toml
@@ -22,7 +22,7 @@ harness = false
 ctrlc = "3.4.4"
 flatzinc-serde = { workspace = true }
 humantime = "2.1.0"
-huub = { path = "../huub" }
+huub = { path = "../huub", features = ["flatzinc"] }
 pico-args = { version = "0.5.0", features = ["combined-flags"] }
 serde_json = "1.0"
 tracing = { workspace = true }

--- a/crates/huub-cli/corpus/simple_sum.sol
+++ b/crates/huub-cli/corpus/simple_sum.sol
@@ -1,73 +1,73 @@
+_objective = 10;
 x = [1,2,3,4];
-_objective = 10;
 ----------
+_objective = 10;
 x = [1,2,4,3];
-_objective = 10;
 ----------
+_objective = 10;
 x = [1,3,2,4];
-_objective = 10;
 ----------
+_objective = 10;
 x = [1,3,4,2];
-_objective = 10;
 ----------
+_objective = 10;
 x = [1,4,2,3];
-_objective = 10;
 ----------
+_objective = 10;
 x = [1,4,3,2];
-_objective = 10;
 ----------
+_objective = 10;
 x = [2,1,3,4];
-_objective = 10;
 ----------
+_objective = 10;
 x = [2,1,4,3];
-_objective = 10;
 ----------
+_objective = 10;
 x = [2,3,1,4];
-_objective = 10;
 ----------
+_objective = 10;
 x = [2,3,4,1];
-_objective = 10;
 ----------
+_objective = 10;
 x = [2,4,1,3];
-_objective = 10;
 ----------
+_objective = 10;
 x = [2,4,3,1];
-_objective = 10;
 ----------
+_objective = 10;
 x = [3,1,2,4];
-_objective = 10;
 ----------
+_objective = 10;
 x = [3,1,4,2];
-_objective = 10;
 ----------
+_objective = 10;
 x = [3,2,1,4];
-_objective = 10;
 ----------
+_objective = 10;
 x = [3,2,4,1];
-_objective = 10;
 ----------
+_objective = 10;
 x = [3,4,1,2];
-_objective = 10;
 ----------
+_objective = 10;
 x = [3,4,2,1];
-_objective = 10;
 ----------
+_objective = 10;
 x = [4,1,2,3];
-_objective = 10;
 ----------
+_objective = 10;
 x = [4,1,3,2];
-_objective = 10;
 ----------
+_objective = 10;
 x = [4,2,1,3];
-_objective = 10;
 ----------
+_objective = 10;
 x = [4,2,3,1];
-_objective = 10;
 ----------
+_objective = 10;
 x = [4,3,1,2];
-_objective = 10;
 ----------
-x = [4,3,2,1];
 _objective = 10;
+x = [4,3,2,1];
 ----------
 ==========

--- a/crates/huub-cli/src/lib.rs
+++ b/crates/huub-cli/src/lib.rs
@@ -25,6 +25,7 @@ mod trace;
 
 use std::{
 	collections::HashMap,
+	ffi::OsStr,
 	fmt::{self, Debug, Display},
 	fs::File,
 	io::{self, BufReader},
@@ -40,15 +41,17 @@ use std::{
 use flatzinc_serde::{FlatZinc, Literal, Method};
 use huub::{
 	actions::DecisionActions,
-	flatzinc::{FlatZincError, FlatZincStatistics},
+	flatzinc::FlatZincError,
 	reformulate::{InitConfig, ReformulationError},
-	solver::{Goal, IntLitMeaning, SolveResult, Solver, Valuation, Value, View},
+	solver::{BoolView, Goal, IntLitMeaning, IntView, SolveResult, Solver, Valuation, Value, View},
 	SlvTermSignal,
 };
 use pico_args::Arguments;
+use quick_xml as _;
 use tracing::{subscriber::set_default, warn};
 use tracing_subscriber::fmt::MakeWriter;
 use ustr::{ustr, Ustr, UstrMap};
+use xcsp3_serde::Instance as Xcsp3Instance;
 
 use crate::trace::LitName;
 
@@ -126,16 +129,37 @@ pub struct Cli<Stdout, Stderr> {
 	stderr: Stderr,
 	/// Whether to use ANSI color codes in the output (only for stderr)
 	ansi_color: bool,
+
+	// --- Derived information ---
+	/// Format of the input file, for which the output is matched.
+	format: Format,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+/// Input and output format
+enum Format {
+	/// FlatZinc (JSON)
+	FlatZinc,
+	/// XCSP3 (XML)
+	Xcsp3,
+}
+
+/// Output definition for the problem
+struct Output {
+	/// List of single variables with their names
+	singletons: Vec<(Ustr, View)>,
+	/// List of arrays of variables with their (array) names
+	arrays: Vec<(Ustr, Vec<View>)>,
 }
 
 /// Solution struct to display the results of the solver
 struct Solution<'a> {
-	/// FlatZinc instance
-	fzn: &'a FlatZinc<Ustr>,
+	/// What format to use to output a solution
+	format: Format,
 	/// Mapping from solver views to solution values
 	value: &'a dyn Valuation,
-	/// Mapping from FlatZinc identifiers to solver views
-	var_map: &'a UstrMap<View>,
+	/// Output definition of the problem
+	output: &'a Output,
 }
 
 /// Parse time duration for the time limit flag
@@ -150,13 +174,45 @@ fn parse_time_limit(s: &str) -> Result<Duration, humantime::DurationError> {
 	}
 }
 
-/// Print a statistics block formulated for MiniZinc
-fn print_statistics_block<W: io::Write>(stream: &mut W, name: &str, stats: &[(&str, &dyn Debug)]) {
-	outputln!(stream, "%%%mzn-stat: blockType={:?}", name);
-	for stat in stats {
-		outputln!(stream, "%%%mzn-stat: {}={:?}", stat.0, stat.1);
-	}
-	outputln!(stream, "%%%mzn-stat-end");
+/// Set the termination conditions of the [`Solver`] instance.
+fn solver_set_terminate(
+	solver: &mut Solver,
+	interrupted: &Arc<AtomicBool>,
+	interrupt_handling: bool,
+	deadline: Option<Instant>,
+) {
+	match (interrupt_handling, deadline) {
+		(true, Some(deadline)) => {
+			let interrupted = Arc::clone(interrupted);
+			solver.set_terminate_callback(Some(move || {
+				if interrupted.load(Ordering::SeqCst) || Instant::now() >= deadline {
+					SlvTermSignal::Terminate
+				} else {
+					SlvTermSignal::Continue
+				}
+			}));
+		}
+		(true, None) => {
+			let interrupted = Arc::clone(interrupted);
+			solver.set_terminate_callback(Some(move || {
+				if interrupted.load(Ordering::SeqCst) {
+					SlvTermSignal::Terminate
+				} else {
+					SlvTermSignal::Continue
+				}
+			}));
+		}
+		(false, Some(deadline)) => {
+			solver.set_terminate_callback(Some(move || {
+				if Instant::now() >= deadline {
+					SlvTermSignal::Terminate
+				} else {
+					SlvTermSignal::Continue
+				}
+			}));
+		}
+		_ => {}
+	};
 }
 
 impl<Stdout, Stderr> Cli<Stdout, Stderr>
@@ -208,44 +264,79 @@ where
 			File::open(&self.path)
 				.map_err(|_| format!("Unable to open file “{}”", self.path.display()))?,
 		);
-		let fzn: FlatZinc<Ustr> = serde_json::from_reader(rdr).map_err(|_| {
-			format!(
-				"Unable to parse file “{}” as FlatZinc JSON",
-				self.path.display()
-			)
-		})?;
 
-		// Convert FlatZinc model to internal Solver representation
-		let res = Solver::from_fzn::<Ustr, UstrMap<View>>(&fzn, &self.init_config());
-		// Resolve any errors that may have occurred during the conversion
-		let (mut slv, var_map, fzn_stats): (Solver, UstrMap<View>, FlatZincStatistics) = match res {
-			Err(FlatZincError::ReformulationError(ReformulationError::TrivialUnsatisfiable)) => {
-				outputln!(self.stdout, "{}", FZN_UNSATISFIABLE);
-				return Ok(());
+		let (mut slv, var_map, output, goal) = match self.format {
+			Format::FlatZinc => {
+				let fzn: FlatZinc<Ustr> = serde_json::from_reader(rdr).map_err(|_| {
+					format!(
+						"Unable to parse file “{}” as FlatZinc JSON",
+						self.path.display()
+					)
+				})?;
+				// Convert FlatZinc model to internal Solver representation
+				let (slv, var_map, fzn_stats) =
+					match Solver::from_fzn::<Ustr, UstrMap<View>>(&fzn, &self.init_config()) {
+						// Resolve any errors that may have occurred during the conversion
+						Err(FlatZincError::ReformulationError(
+							ReformulationError::TrivialUnsatisfiable,
+						)) => {
+							outputln!(self.stdout, "{}", FZN_UNSATISFIABLE);
+							return Ok(());
+						}
+						Err(err) => {
+							return Err(err.to_string());
+						}
+						Ok(x) => x,
+					};
+
+				if self.statistics {
+					let stats = slv.init_statistics();
+					self.print_statistics_block(
+						"init",
+						&[
+							("intVariables", &stats.int_vars()),
+							("propagators", &stats.propagators()),
+							("unifiedVariables", &fzn_stats.unified_variables()),
+							("extractedViews", &fzn_stats.extracted_views()),
+							(
+								"initTime",
+								&Instant::now().duration_since(start).as_secs_f64(),
+							),
+						],
+					);
+				}
+
+				let output = Output::from_fzn(&fzn, &var_map);
+
+				let goal = if fzn.solve.method != Method::Satisfy {
+					let obj_expr = fzn.solve.objective.as_ref().unwrap();
+					if let Literal::Identifier(ident) = obj_expr {
+						Some((
+							if fzn.solve.method == Method::Minimize {
+								Goal::Minimize
+							} else {
+								Goal::Maximize
+							},
+							if let View::Int(iv) = var_map[ident] {
+								iv
+							} else {
+								todo!()
+							},
+						))
+					} else {
+						None
+					}
+				} else {
+					None
+				};
+
+				(slv, var_map, output, goal)
 			}
-			Err(err) => {
-				return Err(err.to_string());
+			Format::Xcsp3 => {
+				let _instance: Xcsp3Instance = quick_xml::de::from_reader(rdr).unwrap();
+				todo!()
 			}
-			Ok(x) => x,
 		};
-
-		if self.statistics {
-			let stats = slv.init_statistics();
-			print_statistics_block(
-				&mut self.stdout,
-				"init",
-				&[
-					("intVariables", &stats.int_vars()),
-					("propagators", &stats.propagators()),
-					("unifiedVariables", &fzn_stats.unified_variables()),
-					("extractedViews", &fzn_stats.extracted_views()),
-					(
-						"initTime",
-						&Instant::now().duration_since(start).as_secs_f64(),
-					),
-				],
-			);
-		}
 
 		// Create reverse map for solver variables if required
 		if self.verbose > 0 {
@@ -296,6 +387,10 @@ where
 			*lit_reverse_map.lock().unwrap() = lit_map;
 			*int_reverse_map.lock().unwrap() = int_map;
 		}
+		drop(var_map);
+
+		// Flat list of output variables (used to create no-goods)
+		let output_vars: Vec<_> = output.iter_vars().collect();
 
 		// Set Solver Configuration
 		if self.free_search {
@@ -307,87 +402,12 @@ where
 			slv.set_vsids_after_restart(self.vsids_after_restart);
 		}
 
-		// Determine Goal and Objective
-		let start_solve = Instant::now();
-		let goal = if fzn.solve.method != Method::Satisfy {
-			let obj_expr = fzn.solve.objective.as_ref().unwrap();
-			if let Literal::Identifier(ident) = obj_expr {
-				Some((
-					if fzn.solve.method == Method::Minimize {
-						Goal::Minimize
-					} else {
-						Goal::Maximize
-					},
-					if let View::Int(iv) = var_map[ident] {
-						iv
-					} else {
-						todo!()
-					},
-				))
-			} else {
-				None
-			}
-		} else {
-			None
-		};
-
 		// Set termination conditions for solver
+		let start_solve = Instant::now();
 		let interrupt_handling = goal.is_some() && !self.intermediate_solutions;
 		let interrupted = Arc::new(AtomicBool::new(false));
-		match (interrupt_handling, deadline) {
-			(true, Some(deadline)) => {
-				let interrupted = Arc::clone(&interrupted);
-				slv.set_terminate_callback(Some(move || {
-					if interrupted.load(Ordering::SeqCst) || Instant::now() >= deadline {
-						SlvTermSignal::Terminate
-					} else {
-						SlvTermSignal::Continue
-					}
-				}));
-			}
-			(true, None) => {
-				let interrupted = Arc::clone(&interrupted);
-				slv.set_terminate_callback(Some(move || {
-					if interrupted.load(Ordering::SeqCst) {
-						SlvTermSignal::Terminate
-					} else {
-						SlvTermSignal::Continue
-					}
-				}));
-			}
-			(false, Some(deadline)) => {
-				slv.set_terminate_callback(Some(move || {
-					if Instant::now() >= deadline {
-						SlvTermSignal::Terminate
-					} else {
-						SlvTermSignal::Continue
-					}
-				}));
-			}
-			_ => {}
-		};
+		solver_set_terminate(&mut slv, &interrupted, interrupt_handling, deadline);
 
-		// Variables that the user is interested in
-		let output_vars: Vec<_> = fzn
-			.output
-			.iter()
-			.flat_map(|ident| {
-				if let Some(arr) = fzn.arrays.get(ident) {
-					arr.contents
-						.iter()
-						.filter_map(|lit| {
-							if let Literal::Identifier(ident) = lit {
-								Some(var_map[ident])
-							} else {
-								None
-							}
-						})
-						.collect()
-				} else {
-					vec![var_map[ident]]
-				}
-			})
-			.collect();
 		// Run the solver!
 		let (res, stats) = match goal {
 			Some((goal, obj)) => {
@@ -402,7 +422,6 @@ where
 						0
 					}
 				];
-				// TODO: Fix statistics
 				let all_opt_slv = if self.all_optimal {
 					Some(slv.clone())
 				} else {
@@ -415,20 +434,23 @@ where
 							"{}",
 							Solution {
 								value,
-								fzn: &fzn,
-								var_map: &var_map
+								format: self.format,
+								output: &output,
 							}
 						);
 						if self.all_optimal {
-							for (i, var) in output_vars.iter().enumerate() {
-								no_good_vals[i] = value(*var);
+							for (i, &var) in output_vars.iter().enumerate() {
+								no_good_vals[i] = value(var);
 							}
 						}
 					})
 				} else {
 					// Set up Ctrl-C handler (to allow printing last solution)
-					if let Err(err) = ctrlc::set_handler(move || {
-						interrupted.store(true, Ordering::SeqCst);
+					if let Err(err) = ctrlc::set_handler({
+						let interrupted = Arc::clone(&interrupted);
+						move || {
+							interrupted.store(true, Ordering::SeqCst);
+						}
 					}) {
 						warn!("unable to set Ctrl-C handler: {}", err);
 					}
@@ -437,13 +459,13 @@ where
 					let res = slv.branch_and_bound(obj, goal, |value| {
 						last_sol = Solution {
 							value,
-							fzn: &fzn,
-							var_map: &var_map,
+							format: self.format,
+							output: &output,
 						}
 						.to_string();
 						if self.all_optimal {
-							for (i, var) in output_vars.iter().enumerate() {
-								no_good_vals[i] = value(*var);
+							for (i, &var) in output_vars.iter().enumerate() {
+								no_good_vals[i] = value(var);
 							}
 						}
 					});
@@ -452,6 +474,7 @@ where
 				};
 				if status == SolveResult::Complete && self.all_optimal {
 					let mut slv = all_opt_slv.unwrap();
+					solver_set_terminate(&mut slv, &interrupted, interrupt_handling, deadline);
 					// Ensure all following solutions have the same objective value as the
 					// first optimal solution
 					let Some(obj_val) = obj_val else {
@@ -471,8 +494,8 @@ where
 								"{}",
 								Solution {
 									value,
-									fzn: &fzn,
-									var_map: &var_map
+									format: self.format,
+									output: &output,
 								}
 							);
 						});
@@ -488,8 +511,8 @@ where
 					"{}",
 					Solution {
 						value,
-						fzn: &fzn,
-						var_map: &var_map
+						format: self.format,
+						output: &output,
 					}
 				);
 			}),
@@ -500,18 +523,17 @@ where
 						"{}",
 						Solution {
 							value,
-							fzn: &fzn,
-							var_map: &var_map
+							format: self.format,
+							output: &output,
 						}
 					);
 				});
 				(res, slv.search_statistics())
 			}
 		};
-		// output solving statistics
+		// Output final solving statistics
 		if self.statistics {
-			print_statistics_block(
-				&mut self.stdout,
+			self.print_statistics_block(
 				"complete",
 				&[
 					("solveTime", &(Instant::now() - start_solve).as_secs_f64()),
@@ -524,19 +546,47 @@ where
 				],
 			);
 		}
-		match res {
-			SolveResult::Satisfied => {}
-			SolveResult::Unsatisfiable => {
-				outputln!(self.stdout, "{}", FZN_UNSATISFIABLE);
-			}
-			SolveResult::Unknown => {
-				outputln!(self.stdout, "{}", FZN_UNKNOWN);
-			}
-			SolveResult::Complete => {
-				outputln!(self.stdout, "{}", FZN_COMPLETE);
+		// Print the final solving status
+		self.print_result_status(res);
+		Ok(())
+	}
+
+	/// Print a status message for the given [`SolveResult`] in the enabled
+	/// format.
+	fn print_result_status(&mut self, result: SolveResult) {
+		match self.format {
+			Format::FlatZinc => match result {
+				SolveResult::Satisfied => {}
+				SolveResult::Unsatisfiable => {
+					outputln!(self.stdout, "{}", FZN_UNSATISFIABLE);
+				}
+				SolveResult::Unknown => {
+					outputln!(self.stdout, "{}", FZN_UNKNOWN);
+				}
+				SolveResult::Complete => {
+					outputln!(self.stdout, "{}", FZN_COMPLETE);
+				}
+			},
+			Format::Xcsp3 => {
+				todo!()
 			}
 		}
-		Ok(())
+	}
+
+	/// Print a statistics block formulated for the chosen format
+	fn print_statistics_block(&mut self, name: &str, stats: &[(&str, &dyn Debug)]) {
+		match self.format {
+			Format::FlatZinc => {
+				outputln!(self.stdout, "%%%mzn-stat: blockType={:?}", name);
+				for stat in stats {
+					outputln!(self.stdout, "%%%mzn-stat: {}={:?}", stat.0, stat.1);
+				}
+				outputln!(self.stdout, "%%%mzn-stat-end");
+			}
+			Format::Xcsp3 => {
+				todo!()
+			}
+		}
 	}
 
 	/// Set the writer that is used for error, warning, and other logging
@@ -571,6 +621,7 @@ where
 			vsids_after_restart: self.vsids_after_restart,
 			vsids_only: self.vsids_only,
 			stdout: self.stdout,
+			format: self.format,
 		}
 	}
 
@@ -602,6 +653,7 @@ where
 			vsids_only: self.vsids_only,
 			stderr: self.stderr,
 			ansi_color: self.ansi_color,
+			format: self.format,
 		}
 	}
 }
@@ -624,7 +676,7 @@ impl TryFrom<Arguments> for Cli<io::Stdout, fn() -> io::Stderr> {
 			)),
 		};
 
-		let cli = Cli {
+		let mut cli = Cli {
 			all_solutions: args.contains(["-a", "--all-solutions"]),
 			all_optimal: args.contains("--all-optimal"),
 			intermediate_solutions: args.contains(["-i", "--intermediate-solutions"]),
@@ -686,8 +738,11 @@ impl TryFrom<Arguments> for Cli<io::Stdout, fn() -> io::Stderr> {
 			#[expect(trivial_casts, reason = "doesn't compile without the case")]
 			stderr: io::stderr as fn() -> io::Stderr,
 			ansi_color: true,
+
+			format: Format::FlatZinc, // Set to default
 		};
 
+		// Check whether there are any unexpected arguments remaining
 		let remaining = args.finish();
 		match remaining.len() {
 			0 => Ok(()),
@@ -704,53 +759,84 @@ impl TryFrom<Arguments> for Cli<io::Stdout, fn() -> io::Stderr> {
 					.join(", ")
 			)),
 		}?;
+
+		// Initialize the correct input format based on the file extension.
+		match cli.path.extension().and_then(OsStr::to_str) {
+			Some("xml") => {
+				cli.format = Format::Xcsp3;
+			}
+			_ => {
+				if !cli.path.ends_with(".fzn.json") {
+					warn!(
+						"Model file with unknown extension “{}”, assuming FlatZinc JSON file",
+						cli.path.to_string_lossy()
+					);
+				}
+			}
+		}
+
 		Ok(cli)
 	}
 }
 
-impl Solution<'_> {
-	/// Method used to print a literal that is part of a solution.
-	fn print_lit(&self, lit: &Literal<Ustr>) -> String {
-		match lit {
-			Literal::Int(i) => format!("{i}"),
-			Literal::Float(f) => format!("{f}"),
-			Literal::Identifier(ident) => {
-				format!("{}", (self.value)(self.var_map[ident]))
+impl Output {
+	/// Iterate over all variables mentioned in the output specifications, both
+	/// single variables and variables contained in arrays.
+	fn iter_vars(&self) -> impl Iterator<Item = View> + '_ {
+		self.singletons.iter().map(|(_, var)| *var).chain(
+			self.arrays
+				.iter()
+				.flat_map(|(_, vars)| vars.iter().copied()),
+		)
+	}
+
+	/// Extract the output definition from a [`FlatZinc`] instance.
+	fn from_fzn(fzn: &FlatZinc<Ustr>, var_map: &UstrMap<View>) -> Self {
+		let mut arrays = Vec::new();
+		let mut singletons = Vec::new();
+		for &ident in &fzn.output {
+			match fzn.arrays.get(&ident) {
+				Some(arr) => {
+					let vars = arr
+						.contents
+						.iter()
+						.map(|x| match x {
+							Literal::Int(i) => IntView::from(*i).into(),
+							Literal::Identifier(ident) => var_map[ident],
+							Literal::Bool(b) => BoolView::from(*b).into(),
+							_ => unimplemented!("unsupported output type"),
+						})
+						.collect();
+					arrays.push((ident, vars));
+				}
+				None => singletons.push((ident, var_map[&ident])),
 			}
-			Literal::Bool(b) => format!("{b}"),
-			Literal::IntSet(is) => is
-				.into_iter()
-				.map(|r| format!("{}..{}", r.start(), r.end()))
-				.collect::<Vec<_>>()
-				.join(" union "),
-			Literal::FloatSet(fs) => fs
-				.into_iter()
-				.map(|r| format!("{}..{}", r.start(), r.end()))
-				.collect::<Vec<_>>()
-				.join(" union "),
-			Literal::String(s) => s.clone(),
 		}
+		Self { arrays, singletons }
 	}
 }
 
 impl Display for Solution<'_> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		for ident in &self.fzn.output {
-			if let Some(arr) = self.fzn.arrays.get(ident) {
-				writeln!(
-					f,
-					"{ident} = [{}];",
-					arr.contents
-						.iter()
-						.map(|lit| self.print_lit(lit))
-						.collect::<Vec<_>>()
-						.join(",")
-				)?;
-			} else {
-				writeln!(f, "{ident} = {};", (self.value)(self.var_map[ident]))?;
+		match self.format {
+			Format::FlatZinc => {
+				for &(ident, var) in &self.output.singletons {
+					writeln!(f, "{ident} = {};", (self.value)(var))?;
+				}
+				for (ident, vars) in &self.output.arrays {
+					writeln!(
+						f,
+						"{ident} = [{}];",
+						vars.iter()
+							.map(|var| format!("{}", (self.value)(*var)))
+							.collect::<Vec<_>>()
+							.join(",")
+					)?;
+				}
+				writeln!(f, "{}", FZN_SEPERATOR)
 			}
+			Format::Xcsp3 => todo!(),
 		}
-		writeln!(f, "{}", FZN_SEPERATOR)
 	}
 }
 

--- a/crates/huub-cli/src/lib.rs
+++ b/crates/huub-cli/src/lib.rs
@@ -44,6 +44,7 @@ use huub::{
 	flatzinc::FlatZincError,
 	reformulate::{InitConfig, ReformulationError},
 	solver::{BoolView, Goal, IntLitMeaning, IntView, SolveResult, Solver, Valuation, Value, View},
+	xcsp3::Xcsp3Error,
 	SlvTermSignal,
 };
 use pico_args::Arguments;
@@ -333,8 +334,79 @@ where
 				(slv, var_map, output, goal)
 			}
 			Format::Xcsp3 => {
-				let _instance: Xcsp3Instance = quick_xml::de::from_reader(rdr).unwrap();
-				todo!()
+				let instance: Xcsp3Instance<Ustr> =
+					quick_xml::de::from_reader(rdr).map_err(|err| {
+						format!(
+							"Unable to parse file “{}” as XCSP3 XML: {}",
+							self.path.display(),
+							err
+						)
+					})?;
+				let (slv, mut var_map, fzn_stats, goal) = match Solver::from_xcsp3::<
+					Ustr,
+					UstrMap<Vec<View>>,
+				>(&instance, &self.init_config())
+				{
+					// Resolve any errors that may have occurred during the conversion
+					Err(Xcsp3Error::ReformulationError(
+						ReformulationError::TrivialUnsatisfiable,
+					)) => {
+						outputln!(self.stdout, "{}", FZN_UNSATISFIABLE);
+						return Ok(());
+					}
+					Err(err) => {
+						if matches!(
+							err,
+							Xcsp3Error::UnsupportedConstraint(_)
+								| Xcsp3Error::UnsupportedFeature(_)
+								| Xcsp3Error::UnsupportedType(_)
+						) {
+							outputln!(self.stdout, "s UNSUPPORTED");
+						}
+						return Err(err.to_string());
+					}
+					Ok(x) => x,
+				};
+
+				if self.statistics {
+					let stats = slv.init_statistics();
+					self.print_statistics_block(
+						"init",
+						&[
+							("intVariables", &stats.int_vars()),
+							("propagators", &stats.propagators()),
+							("unifiedVariables", &fzn_stats.unified_variables()),
+							("extractedViews", &fzn_stats.extracted_views()),
+							(
+								"initTime",
+								&Instant::now().duration_since(start).as_secs_f64(),
+							),
+						],
+					);
+				}
+
+				(
+					slv,
+					Default::default(),
+					Output {
+						singletons: instance
+							.variables
+							.iter()
+							.map(|v| (v.identifier, var_map[&v.identifier][0]))
+							.collect(),
+						arrays: instance
+							.arrays
+							.iter()
+							.map(|a| {
+								(
+									format!("{}{}", a.identifier, "[]".repeat(a.size.len())).into(),
+									var_map.remove(&a.identifier).unwrap(),
+								)
+							})
+							.collect(),
+					},
+					goal,
+				)
 			}
 		};
 
@@ -413,6 +485,7 @@ where
 			Some((goal, obj)) => {
 				if self.all_solutions {
 					warn!("--all-solutions is ignored when optimizing, use --intermediate-solutions or --all-optimal instead");
+					self.all_solutions = false;
 				}
 				let mut no_good_vals = vec![
 					Value::Bool(false);
@@ -429,6 +502,9 @@ where
 				};
 				let (status, stats, obj_val) = if self.intermediate_solutions {
 					slv.branch_and_bound(obj, goal, |value| {
+						if self.format == Format::Xcsp3 {
+							outputln!(self.stdout, "o {}", value(obj.into()));
+						}
 						output!(
 							self.stdout,
 							"{}",
@@ -457,6 +533,9 @@ where
 
 					let mut last_sol = String::new();
 					let res = slv.branch_and_bound(obj, goal, |value| {
+						if self.format == Format::Xcsp3 {
+							outputln!(self.stdout, "o {}", value(obj.into()));
+						}
 						last_sol = Solution {
 							value,
 							format: self.format,
@@ -567,9 +646,26 @@ where
 					outputln!(self.stdout, "{}", FZN_COMPLETE);
 				}
 			},
-			Format::Xcsp3 => {
-				todo!()
-			}
+			Format::Xcsp3 => match result {
+				SolveResult::Satisfied => {
+					outputln!(self.stdout, "s SATISFIABLE");
+				}
+				SolveResult::Unsatisfiable => {
+					outputln!(self.stdout, "s UNSATISFIABLE");
+				}
+				SolveResult::Unknown => {
+					outputln!(self.stdout, "s UNKNOWN");
+				}
+				SolveResult::Complete if self.all_solutions => {
+					outputln!(self.stdout, "s ALL SATISFIABLE");
+				}
+				SolveResult::Complete if self.all_optimal => {
+					outputln!(self.stdout, "s ALL OPTIMAL");
+				}
+				SolveResult::Complete => {
+					outputln!(self.stdout, "s OPTIMUM FOUND");
+				}
+			},
 		}
 	}
 
@@ -584,7 +680,9 @@ where
 				outputln!(self.stdout, "%%%mzn-stat-end");
 			}
 			Format::Xcsp3 => {
-				todo!()
+				for stat in stats {
+					outputln!(self.stdout, "d {} {:?}", stat.0, stat.1);
+				}
 			}
 		}
 	}
@@ -835,7 +933,32 @@ impl Display for Solution<'_> {
 				}
 				writeln!(f, "{}", FZN_SEPERATOR)
 			}
-			Format::Xcsp3 => todo!(),
+			Format::Xcsp3 => {
+				writeln!(f, "v <instantiation>")?;
+				write!(f, "v <list> ")?;
+				for i in self
+					.output
+					.singletons
+					.iter()
+					.map(|(i, _)| i)
+					.chain(self.output.arrays.iter().map(|(i, _)| i))
+				{
+					write!(f, "{} ", i)?;
+				}
+				writeln!(f, "</list>")?;
+				write!(f, "v <values> ")?;
+				for i in self
+					.output
+					.singletons
+					.iter()
+					.map(|(_, v)| v)
+					.chain(self.output.arrays.iter().flat_map(|(_, vs)| vs))
+				{
+					write!(f, "{} ", (*self.value)(*i))?;
+				}
+				writeln!(f, "</values>")?;
+				writeln!(f, "v </instantiation>")
+			}
 		}
 	}
 }

--- a/crates/huub/Cargo.toml
+++ b/crates/huub/Cargo.toml
@@ -21,6 +21,7 @@ pindakaas = { git = "https://github.com/pindakaashq/pindakaas.git", features = [
 rangelist = "0.2"
 thiserror = "2.0"
 tracing = { workspace = true }
+xcsp3-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 expect-test = { workspace = true }
@@ -31,3 +32,4 @@ workspace = true
 
 [features]
 flatzinc = ["flatzinc-serde"]
+xcsp3 = ["xcsp3-serde"]

--- a/crates/huub/Cargo.toml
+++ b/crates/huub/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 
 [dependencies]
 delegate = "0.13"
-flatzinc-serde = { workspace = true }
+flatzinc-serde = { workspace = true, optional = true }
 index_vec = "0.1.3"
 itertools = "0.14.0"
 pindakaas = { git = "https://github.com/pindakaashq/pindakaas.git", features = [
@@ -28,3 +28,6 @@ tracing-test = "0.2.5"
 
 [lints]
 workspace = true
+
+[features]
+flatzinc = ["flatzinc-serde"]

--- a/crates/huub/src/constraints/disjunctive_strict.rs
+++ b/crates/huub/src/constraints/disjunctive_strict.rs
@@ -631,8 +631,8 @@ impl OmegaThetaTree {
 #[cfg(test)]
 mod tests {
 	use expect_test::expect;
-	use flatzinc_serde::RangeList;
 	use pindakaas::{solver::cadical::PropagatingCadical, Cnf};
+	use rangelist::RangeList;
 	use tracing_test::traced_test;
 
 	use crate::{

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod actions;
 pub mod branchers;
 pub mod constraints;
+#[cfg(feature = "flatzinc")]
 pub mod flatzinc;
 pub(crate) mod helpers;
 pub mod reformulate;
@@ -22,15 +23,14 @@ pub(crate) mod tests;
 use std::{
 	any::Any,
 	collections::{HashSet, VecDeque},
-	fmt::{Debug, Display},
+	fmt::Debug,
 	hash::Hash,
 	iter::{repeat_n, repeat_with, Sum},
 	mem,
 	num::NonZeroI64,
-	ops::{Add, AddAssign, Deref, Mul, Neg, Not, Sub},
+	ops::{Add, AddAssign, Mul, Neg, Not, Sub},
 };
 
-use flatzinc_serde::FlatZinc;
 use index_vec::{index_vec, IndexVec};
 use itertools::Itertools;
 pub use pindakaas::solver::SlvTermSignal;
@@ -61,7 +61,6 @@ use crate::{
 		int_value_precede::{IntSeqPrecedeChain, IntValuePrecedeChain},
 		BoxedConstraint, Constraint, SimplificationStatus,
 	},
-	flatzinc::{FlatZincError, FlatZincStatistics, FznModelBuilder},
 	helpers::{linear_transform::LinearTransform, var_from_u32},
 	reformulate::{
 		BoolDecisionDef, BoolDecisionInner, ConstraintStore, Domain, InitConfig, IntDecisionDef,
@@ -937,14 +936,15 @@ impl Model {
 		}
 	}
 
+	#[cfg(feature = "flatzinc")]
 	/// Create a new [`Model`] instance from a [`FlatZinc`] instance.
 	pub fn from_fzn<S, MapTy: FromIterator<(S, Decision)>>(
-		fzn: &FlatZinc<S>,
-	) -> Result<(Self, MapTy, FlatZincStatistics), FlatZincError>
+		fzn: &flatzinc_serde::FlatZinc<S>,
+	) -> Result<(Self, MapTy, flatzinc::FlatZincStatistics), flatzinc::FlatZincError>
 	where
-		S: Clone + Debug + Deref<Target = str> + Display + Eq + Hash + Ord,
+		S: Clone + Debug + std::ops::Deref<Target = str> + std::fmt::Display + Eq + Hash + Ord,
 	{
-		let mut builder = FznModelBuilder::new(fzn);
+		let mut builder = flatzinc::FznModelBuilder::new(fzn);
 		builder.unify_variables()?;
 		builder.extract_views()?;
 		builder.post_constraints()?;

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -19,6 +19,8 @@ pub mod reformulate;
 pub mod solver;
 #[cfg(test)]
 pub(crate) mod tests;
+#[cfg(feature = "xcsp3")]
+pub mod xcsp3;
 
 use std::{
 	any::Any,

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -30,7 +30,7 @@ use std::{
 	iter::{repeat_n, repeat_with, Sum},
 	mem,
 	num::NonZeroI64,
-	ops::{Add, AddAssign, Mul, Neg, Not, Sub},
+	ops::{Add, AddAssign, Mul, Neg, Not, Sub, SubAssign},
 };
 
 use index_vec::{index_vec, IndexVec};
@@ -847,10 +847,18 @@ impl IntLinExpr {
 impl Add<IntDecision> for IntLinExpr {
 	type Output = IntLinExpr;
 
-	fn add(self, rhs: IntDecision) -> Self::Output {
-		let mut terms = self.terms;
-		terms.push(rhs);
-		IntLinExpr { terms }
+	fn add(mut self, rhs: IntDecision) -> Self::Output {
+		self += rhs;
+		self
+	}
+}
+
+impl Add<IntLinExpr> for IntLinExpr {
+	type Output = IntLinExpr;
+
+	fn add(mut self, rhs: IntLinExpr) -> Self::Output {
+		self += rhs;
+		self
 	}
 }
 
@@ -858,8 +866,34 @@ impl Add<IntVal> for IntLinExpr {
 	type Output = IntLinExpr;
 
 	fn add(mut self, rhs: IntVal) -> Self::Output {
-		self.terms[0] = self.terms[0] + rhs;
+		self += rhs;
 		self
+	}
+}
+
+impl AddAssign<IntDecision> for IntLinExpr {
+	fn add_assign(&mut self, rhs: IntDecision) {
+		if let IntDecisionInner::Const(c) = rhs.0 {
+			self.add_assign(c);
+		} else {
+			self.terms.push(rhs);
+		}
+	}
+}
+
+impl AddAssign<IntLinExpr> for IntLinExpr {
+	fn add_assign(&mut self, rhs: IntLinExpr) {
+		rhs.terms.into_iter().for_each(|term| self.add_assign(term));
+	}
+}
+
+impl AddAssign<IntVal> for IntLinExpr {
+	fn add_assign(&mut self, rhs: IntVal) {
+		if self.terms.is_empty() {
+			self.terms.push(rhs.into());
+		} else {
+			self.terms[0] = self.terms[0] + rhs;
+		}
 	}
 }
 
@@ -873,10 +907,27 @@ impl Mul<IntVal> for IntLinExpr {
 	}
 }
 
+impl Neg for IntLinExpr {
+	type Output = IntLinExpr;
+
+	fn neg(mut self) -> Self::Output {
+		self.terms.iter_mut().for_each(|x| *x = -*x);
+		self
+	}
+}
+
 impl Sub<IntDecision> for IntLinExpr {
 	type Output = IntLinExpr;
 
 	fn sub(self, rhs: IntDecision) -> Self::Output {
+		self + -rhs
+	}
+}
+
+impl Sub<IntLinExpr> for IntLinExpr {
+	type Output = IntLinExpr;
+
+	fn sub(self, rhs: IntLinExpr) -> Self::Output {
 		self + -rhs
 	}
 }
@@ -889,11 +940,27 @@ impl Sub<IntVal> for IntLinExpr {
 	}
 }
 
+impl SubAssign<IntDecision> for IntLinExpr {
+	fn sub_assign(&mut self, rhs: IntDecision) {
+		self.add_assign(-rhs);
+	}
+}
+
+impl SubAssign<IntLinExpr> for IntLinExpr {
+	fn sub_assign(&mut self, rhs: IntLinExpr) {
+		self.add_assign(-rhs);
+	}
+}
+
+impl SubAssign<IntVal> for IntLinExpr {
+	fn sub_assign(&mut self, rhs: IntVal) {
+		self.add_assign(-rhs);
+	}
+}
+
 impl Sum<IntDecision> for IntLinExpr {
 	fn sum<I: Iterator<Item = IntDecision>>(iter: I) -> Self {
-		IntLinExpr {
-			terms: iter.collect(),
-		}
+		iter.fold(IntLinExpr { terms: Vec::new() }, |acc, x| acc + x)
 	}
 }
 
@@ -955,6 +1022,32 @@ impl Model {
 
 		let res = builder.finalize();
 		Ok(res)
+	}
+
+	#[cfg(feature = "xcsp3")]
+	/// Create a new [`Model`] instance from a [`FlatZinc`] instance.
+	pub fn from_xcsp3<S, MapTy: FromIterator<(S, Vec<Decision>)>>(
+		instance: &xcsp3_serde::Instance<S>,
+	) -> Result<
+		(
+			Self,
+			MapTy,
+			xcsp3::Xcsp3Statistics,
+			Option<(solver::Goal, IntDecision)>,
+		),
+		xcsp3::Xcsp3Error,
+	>
+	where
+		S: Clone + Debug + std::ops::Deref<Target = str> + std::fmt::Display + Eq + Hash + Ord,
+	{
+		let mut builder = xcsp3::Xcsp3ModelBuilder::new(instance);
+		builder.create_decisions()?;
+		builder.post_constraints()?;
+		builder.create_branchers()?;
+		let goal = builder.extract_goal()?;
+
+		let (model, map, stats) = builder.finalize();
+		Ok((model, map, stats, goal))
 	}
 
 	/// Create a new Boolean variable.

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -12,11 +12,10 @@ use std::{
 	fmt::{self, Debug, Display, Formatter},
 	hash::Hash,
 	num::NonZeroI32,
-	ops::{Add, AddAssign, Deref, Mul, Neg, Not},
+	ops::{Add, AddAssign, Mul, Neg, Not},
 };
 
 use delegate::delegate;
-use flatzinc_serde::FlatZinc;
 use itertools::Itertools;
 use pindakaas::{
 	solver::{
@@ -36,8 +35,6 @@ use crate::{
 	},
 	branchers::BoxedBrancher,
 	constraints::BoxedPropagator,
-	flatzinc::{FlatZincError, FlatZincStatistics},
-	reformulate::InitConfig,
 	solver::{
 		activation_list::IntPropCond,
 		engine::{trace_new_lit, Engine, PropRef},
@@ -45,7 +42,7 @@ use crate::{
 		queue::{PriorityLevel, PropagatorInfo},
 		trail::TrailedInt,
 	},
-	Clause, IntVal, LinearTransform, Model, NonZeroIntVal, ReformulationError,
+	Clause, IntVal, LinearTransform, NonZeroIntVal, ReformulationError,
 };
 
 /// Trait implemented by the object given to the callback on detecting failure
@@ -816,17 +813,18 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 		self.oracle.propagator_mut()
 	}
 
+	#[cfg(feature = "flatzinc")]
 	/// Create a new [`Solver`] instance from a [`FlatZinc`] instance.
 	pub fn from_fzn<S, MapTy: FromIterator<(S, View)>>(
-		fzn: &FlatZinc<S>,
-		config: &InitConfig,
-	) -> Result<(Self, MapTy, FlatZincStatistics), FlatZincError>
+		fzn: &flatzinc_serde::FlatZinc<S>,
+		config: &crate::reformulate::InitConfig,
+	) -> Result<(Self, MapTy, crate::flatzinc::FlatZincStatistics), crate::flatzinc::FlatZincError>
 	where
-		S: Clone + Debug + Deref<Target = str> + Display + Eq + Hash + Ord,
+		S: Clone + Debug + std::ops::Deref<Target = str> + Display + Eq + Hash + Ord,
 		Solver<Oracle>: for<'a> From<&'a Cnf>,
 		Oracle::Slv: 'static,
 	{
-		let (mut prb, map, fzn_stats) = Model::from_fzn::<S, Vec<_>>(fzn)?;
+		let (mut prb, map, fzn_stats) = crate::Model::from_fzn::<S, Vec<_>>(fzn)?;
 		let (mut slv, remap) = prb.to_solver(config)?;
 		let map = map
 			.into_iter()

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -804,7 +804,7 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 	}
 
 	/// Access the inner [`Engine`] object.
-	pub(crate) fn engine(&self) -> &Engine {
+	pub fn engine(&self) -> &Engine {
 		self.oracle.propagator()
 	}
 
@@ -831,6 +831,35 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 			.map(|(k, v)| (k, remap.get(&mut slv, &v)))
 			.collect();
 		Ok((slv, map, fzn_stats))
+	}
+
+	#[cfg(feature = "xcsp3")]
+	/// Create a new [`Solver`] instance from a [`FlatZinc`] instance.
+	pub fn from_xcsp3<S, MapTy: FromIterator<(S, Vec<View>)>>(
+		instance: &xcsp3_serde::Instance<S>,
+		config: &crate::reformulate::InitConfig,
+	) -> Result<
+		(
+			Self,
+			MapTy,
+			crate::xcsp3::Xcsp3Statistics,
+			Option<(Goal, IntView)>,
+		),
+		crate::xcsp3::Xcsp3Error,
+	>
+	where
+		S: Clone + Debug + std::ops::Deref<Target = str> + Display + Eq + Hash + Ord,
+		Solver<Oracle>: for<'a> From<&'a Cnf>,
+		Oracle::Slv: 'static,
+	{
+		let (mut prb, map, stats, goal) = crate::Model::from_xcsp3::<S, Vec<_>>(instance)?;
+		let (mut slv, remap) = prb.to_solver(config)?;
+		let map = map
+			.into_iter()
+			.map(|(k, vars)| (k, vars.iter().map(|v| remap.get(&mut slv, &v)).collect()))
+			.collect();
+		let goal = goal.map(|(g, v)| (g, remap.get_int(&mut slv, v)));
+		Ok((slv, map, stats, goal))
 	}
 
 	/// Wrapper function for `all_solutions` that collects all solutions and returns them in a vector

--- a/crates/huub/src/xcsp3.rs
+++ b/crates/huub/src/xcsp3.rs
@@ -1,5 +1,787 @@
 //! Module for the creation of a [`Model`] from a [`Xcsp3Instance`] instance.
 
-use xcsp3_serde::Instance as Xcsp3Instance;
+use std::{
+	collections::HashMap,
+	fmt::{Debug, Display},
+	hash::Hash,
+	iter::once,
+	ops::Deref,
+};
 
-const _: Option<Xcsp3Instance> = None;
+use rangelist::RangeList;
+use thiserror::Error;
+
+use xcsp3_serde::{
+	constraint::Constraint,
+	error::UnrollError,
+	expression::{BoolExp, Exp, IntExp},
+	Instance as Xcsp3Instance, ObjType, Objective, SimpleRef,
+};
+
+use crate::{
+	abs_int, actions::SimplificationActions, all_different_int, array_maximum_int,
+	array_minimum_int, div_int, pow_int, reformulate::ReformulationError, solver::Goal, table_int,
+	times_int, BoolDecision, BoolFormula, Decision, IntDecision, IntDecisionInner, IntLinExpr,
+	IntVal, Model,
+};
+
+#[derive(Error, Debug)]
+/// Errors that can occur when converting a [`Xcsp3Instance`] instance to a
+/// [`Model`] or [`Solver`] object.
+pub enum Xcsp3Error {
+	#[error("identifier `{0}' is defined more than once")]
+	/// XCSP3 instance used an identifier multiple times.
+	DuplicateIdentifier(String),
+	#[error("argument found of type `{found}', expected `{expected}'")]
+	/// FlatZinc constraint or annotation used an argument of the wrong type.
+	InvalidArgumentType {
+		/// Expected type of the argument.
+		expected: &'static str,
+		/// Type of the argument found.
+		found: String,
+	},
+	#[error("could not find identifier `{0}'")]
+	/// XCSP3 instance used an identifier that was not defined.
+	UnknownIdentifier(String),
+	#[error("xcsp3 instance contains an unsupported constraint type `{0}'")]
+	/// XCSP3 instance contained a constraint with an unsupported constraint
+	UnsupportedConstraint(&'static str),
+	#[error("xcsp3 instance contains an unsupported feature type `{0}'")]
+	/// XCSP3 instance contained a constraint with an unsupported constraint
+	UnsupportedFeature(&'static str),
+	#[error("{0:?} type variables are not supported by huub")]
+	/// XCSP3 instance contained a decision variable with an unsupported type.
+	UnsupportedType(&'static str),
+	#[error("an error occurred when unrolling instance constraints: {0}")]
+	/// An error occurred when resolving the instance into a flat constraint list.
+	UnrollError(#[from] UnrollError),
+	#[error("error reformulating generated model `{0}'")]
+	/// Error that occorred when converting a generated [`Model`] to a [`Solver`]
+	/// object.
+	ReformulationError(#[from] ReformulationError),
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+/// Statistical information about the extraction process that creates a
+/// [`Model`] from a [`Xcsp3Instance`].
+pub struct Xcsp3Statistics {
+	/// Number of literal views extracted from the [`Xcsp3Instance`] specification
+	extracted_views: u32,
+	/// Number of variables removed by unification
+	vars_unified: u32,
+}
+
+/// Builder for creating a [`Model`] from a [`Xcsp3Instance`].
+pub(crate) struct Xcsp3ModelBuilder<'a, S: Eq + Hash + Ord> {
+	/// The FlatZinc instance to build the model from
+	instance: &'a Xcsp3Instance<S>,
+	/// A mapping from identifiers and expressions to decisions
+	expr_map: HashMap<Exp<SimpleRef<S>>, Decision>,
+	/// A mapping from array identifiers to (flat) vector of decisions and the dimensions
+	array_map: HashMap<S, (Vec<Decision>, Vec<usize>)>,
+	/// The incumbent model
+	prb: Model,
+	/// Statistics about the extraction process
+	stats: Xcsp3Statistics,
+}
+
+/// Function to initialize an uncomputed domain.
+// TODO: This should be removed in the future.
+fn full_domain() -> RangeList<IntVal> {
+	// These bounds are not IntVal::MIN..=IntVal::MAX, because the cardinality of
+	// individual ranges must be representable as IntVal in the `rangelist`
+	// library.
+	let r = IntVal::MAX >> 1;
+	RangeList::from(-r..=r)
+}
+
+fn resolve_index(idxs: &[usize], dims: &[usize]) -> usize {
+	debug_assert_eq!(idxs.len(), dims.len());
+	let mut mult = 1;
+	let mut idx = 0;
+	for (i, size) in idxs.iter().zip(dims) {
+		idx += mult * i;
+		mult *= size;
+	}
+	idx
+}
+
+impl Xcsp3Statistics {
+	/// Returns the number of views extracted from the FlatZinc instance
+	///
+	/// Views currently creates the following types of views:
+	/// - literal views (i.e., direct use of literals used to as part of variable
+	///   representation instead of reified constraints)
+	/// - linear views (i.e., scaled and offset views of integer variables)
+	/// - Boolean linear views (i.e., scaled and offset views of Boolean
+	///   variables, able to represent any integer value with two values)
+	pub fn extracted_views(&self) -> u32 {
+		self.extracted_views
+	}
+
+	/// Returns the number of variables removed by unification
+	pub fn unified_variables(&self) -> u32 {
+		self.vars_unified
+	}
+}
+
+impl<'a, S> Xcsp3ModelBuilder<'a, S>
+where
+	S: Clone + Debug + Deref<Target = str> + Display + Eq + Hash + Ord,
+{
+	/// Create the decisions defined in the variable and array fields of the
+	/// [`Xcsp3Instance`].
+	pub(crate) fn create_decisions(&mut self) -> Result<(), Xcsp3Error> {
+		let create_var = |prb: &mut Model, dom: RangeList<IntVal>| -> Decision {
+			if dom == RangeList::from(0..=1) {
+				prb.new_bool_var().into()
+			} else {
+				prb.new_int_var(dom).into()
+			}
+		};
+
+		// Create all singleton variables
+		for vardef in &self.instance.variables {
+			let dom = vardef.domain.iter().collect();
+			let var = create_var(&mut self.prb, dom);
+			let prev = self
+				.expr_map
+				.insert(Exp::Var(SimpleRef::Ident(vardef.identifier.clone())), var);
+			if prev.is_some() {
+				return Err(Xcsp3Error::DuplicateIdentifier(
+					vardef.identifier.to_string(),
+				));
+			}
+		}
+
+		// Create all arrays of variables
+		for arr in &self.instance.arrays {
+			let arr = arr.unroll()?;
+			// Find the base domain of the variables (if no specific domains are
+			// provided).
+			let base = arr
+				.domains
+				.iter()
+				.find_map(|(v, dom)| {
+					if v.iter().any(|v| match v {
+						SimpleRef::Ident(v) if &**v == "others" => todo!(),
+						_ => false,
+					}) {
+						Some(dom.iter().collect())
+					} else {
+						None
+					}
+				})
+				// Create fixed value if no domain is provided (undefined variable)
+				.unwrap_or_else(|| RangeList::from(0..=0));
+
+			// Determine number of elements and create positions
+			let len: usize = arr.size.iter().product();
+			let mut vars: Vec<Option<Decision>> = vec![None; len];
+
+			// Initialize specialized domains for variables
+			for (v, dom) in arr.domains.iter() {
+				let dom = dom.iter().collect();
+				for v in v {
+					// TODO: Maybe throw an error if the identifier does not match
+					match v {
+						SimpleRef::ArrayAccess(_, idxs) => {
+							let idx = resolve_index(idxs, &arr.size);
+							if let Some(d) = &vars[idx] {
+								// TODO: Duplicate domain definition, intersect domains or throw error?
+								match d {
+									Decision::Bool(_) => todo!(),
+									&Decision::Int(iv) => self.prb.set_int_in_set(iv, &dom)?,
+								}
+							} else {
+								vars[idx] = Some(create_var(&mut self.prb, dom.clone()));
+							}
+						}
+						SimpleRef::Ident(_) => {}
+					}
+				}
+			}
+
+			// Initialize all other variables
+			let vars = vars
+				.into_iter()
+				.map(|v| {
+					if v.is_some() {
+						v.unwrap()
+					} else {
+						create_var(&mut self.prb, base.clone())
+					}
+				})
+				.collect();
+			// Store variables and sizes to later resolve array accesses
+			let prev = self
+				.array_map
+				.insert(arr.identifier.clone(), (vars, arr.size.clone()));
+			if prev.is_some() {
+				return Err(Xcsp3Error::DuplicateIdentifier(arr.identifier.to_string()));
+			}
+		}
+		Ok(())
+	}
+
+	/// Create branchers according to the search annotations in the FlatZinc instance
+	pub(crate) fn create_branchers(&mut self) -> Result<(), Xcsp3Error> {
+		// let mut branchings = Vec::new();
+		// let mut warm_start = Vec::new();
+		// for ann in self.fzn.solve.ann.iter() {
+		// 	match ann {
+		// 		Annotation::Call(c) => {
+		// 			let (w, b) = self.ann_to_branchings(c)?;
+		// 			warm_start.extend(w);
+		// 			branchings.extend(b);
+		// 		}
+		// 		_ => warn!("ignoring unsupported search annotation: {}", ann),
+		// 	}
+		// }
+		// if !warm_start.is_empty() {
+		// 	self.prb += Branching::WarmStart(warm_start);
+		// }
+		// for b in branchings {
+		// 	self.prb += b;
+		// }
+		Ok(())
+	}
+
+	fn enforce_bool_exp(&mut self, exp: &BoolExp<SimpleRef<S>>) -> Result<(), Xcsp3Error> {
+		match exp {
+			BoolExp::Const(true) => Ok(()),
+			BoolExp::Const(false) => Err(Xcsp3Error::ReformulationError(
+				ReformulationError::TrivialUnsatisfiable,
+			)),
+			exp @ BoolExp::Var(_) => {
+				let var = self.extract_bool(&exp)?;
+				self.prb.set_bool(var)?;
+				Ok(())
+			}
+			BoolExp::Not(exp) => {
+				let var = self.extract_bool(&exp)?;
+				self.prb.set_bool(var)?;
+				Ok(())
+			}
+			BoolExp::And(sub) => {
+				for exp in sub {
+					self.enforce_bool_exp(exp)?;
+				}
+				Ok(())
+			}
+			BoolExp::Equiv(sub) | BoolExp::Or(sub) | BoolExp::Xor(sub) => {
+				let sub = self
+					.extract_bool_list(sub)?
+					.into_iter()
+					.map(BoolFormula::Atom)
+					.collect();
+				let f = match exp {
+					BoolExp::Equiv(_) => BoolFormula::Equiv,
+					BoolExp::Or(_) => BoolFormula::Or,
+					BoolExp::Xor(_) => BoolFormula::Xor,
+					_ => unreachable!(),
+				};
+				self.prb += f(sub);
+				Ok(())
+			}
+			BoolExp::Implies(a, b) => {
+				let a = self.extract_bool(&a)?;
+				let b = self.extract_bool(&b)?;
+				self.prb +=
+					BoolFormula::Implies(BoolFormula::Atom(a).into(), BoolFormula::Atom(b).into());
+				Ok(())
+			}
+			BoolExp::LessThan(a, b)
+			| BoolExp::LessThanEq(a, b)
+			| BoolExp::GreaterThan(a, b)
+			| BoolExp::GreaterThanEq(a, b) => {
+				let a = self.extract_int_lin(&a)?;
+				let b = self.extract_int_lin(&b)?;
+				let lin = a - b;
+
+				match lin.terms.len() {
+					// No remaining terms, check against constant 0
+					0 => {
+						match exp {
+							BoolExp::LessThan(_, _) | BoolExp::GreaterThan(_, _) => {
+								// 0 is not .lt(0) or .gt(0)
+								return Err(ReformulationError::TrivialUnsatisfiable.into());
+							}
+							BoolExp::LessThanEq(_, _) | BoolExp::GreaterThanEq(_, _) => {}
+							_ => unreachable!(),
+						};
+					}
+					// One remaining term, change the domains allowed
+					1 => {
+						let var = lin.terms[0];
+						match exp {
+							BoolExp::LessThan(_, _) => self.prb.set_int_upper_bound(var, -1)?,
+							BoolExp::LessThanEq(_, _) => self.prb.set_int_upper_bound(var, 0)?,
+							BoolExp::GreaterThan(_, _) => self.prb.set_int_lower_bound(var, 1)?,
+							BoolExp::GreaterThanEq(_, _) => self.prb.set_int_lower_bound(var, 0)?,
+							_ => unreachable!(),
+						};
+					}
+					// Multiple terms, create linear constraint
+					_ => {
+						let lin = match exp {
+							BoolExp::LessThan(_, _) => lin.lt(0),
+							BoolExp::LessThanEq(_, _) => lin.leq(0),
+							BoolExp::GreaterThan(_, _) => lin.gt(0),
+							BoolExp::GreaterThanEq(_, _) => lin.geq(0),
+							_ => unreachable!(),
+						};
+						self.prb += lin;
+					}
+				}
+
+				Ok(())
+			}
+			BoolExp::NotEqual(_, _) => todo!(),
+			BoolExp::Equal(_) => todo!(),
+			BoolExp::Member(_, _) => Err(Xcsp3Error::UnsupportedConstraint("member")),
+			BoolExp::Disjoint(_, _) => Err(Xcsp3Error::UnsupportedConstraint("disjoint")),
+			BoolExp::SubSet(_, _) => Err(Xcsp3Error::UnsupportedConstraint("subset")),
+			BoolExp::SubSetEq(_, _) => Err(Xcsp3Error::UnsupportedConstraint("subset")),
+			BoolExp::SuperSet(_, _) => Err(Xcsp3Error::UnsupportedConstraint("superset")),
+			BoolExp::SuperSetEq(_, _) => Err(Xcsp3Error::UnsupportedConstraint("superset")),
+			BoolExp::Convex(_) => Err(Xcsp3Error::UnsupportedConstraint("convex")),
+		}
+	}
+
+	/// Extract one or more Boolean decision variables from a [`BoolExp`] in a
+	/// [`Xcsp3Instance`]. A [`Xcsp3Error`] will be returned if the expression is
+	/// invalid or unsupported.
+	fn extract_bool(&mut self, exp: &BoolExp<SimpleRef<S>>) -> Result<BoolDecision, Xcsp3Error> {
+		let map_to_bool = |v: Decision| match v {
+			Decision::Bool(bv) => Ok(bv),
+			Decision::Int(_) => Err(Xcsp3Error::InvalidArgumentType {
+				expected: "bool",
+				found: "int".into(),
+			}),
+		};
+		let key = Exp::Bool(exp.clone().into());
+		if let Some(var) = self.expr_map.get(&key) {
+			return map_to_bool(var.clone());
+		}
+		debug_assert!(!self.expr_map.contains_key(&key));
+		match exp {
+			&BoolExp::Const(b) => Ok(b.into()),
+			BoolExp::Var(var) => map_to_bool(self.extract_var(var)?),
+			BoolExp::Not(sub) => {
+				let sub = self.extract_bool(sub)?;
+				Ok(!sub)
+			}
+			BoolExp::And(sub) | BoolExp::Equiv(sub) | BoolExp::Or(sub) | BoolExp::Xor(sub) => {
+				// Recursively extract boolean variables from sub-expressions
+				let sub = self.extract_bool_list(sub)?;
+				// Create reification variable
+				let ret = self.prb.new_bool_var();
+				// Create relational constraint
+				let f = match exp {
+					BoolExp::And(_) => BoolFormula::And,
+					BoolExp::Equiv(_) => BoolFormula::Equiv,
+					BoolExp::Or(_) => BoolFormula::Or,
+					BoolExp::Xor(_) => BoolFormula::Xor,
+					_ => unreachable!(),
+				};
+				self.prb += BoolFormula::Equiv(vec![
+					BoolFormula::Atom(ret),
+					f(sub.into_iter().map(BoolFormula::Atom).collect()),
+				]);
+				// TODO: Normalize
+				// Add result to CSE map
+				let _ = self.expr_map.insert(key, ret.into());
+				Ok(ret)
+			}
+			BoolExp::Implies(_, _) => todo!(),
+			BoolExp::LessThan(_, _) => todo!(),
+			BoolExp::LessThanEq(_, _) => todo!(),
+			BoolExp::GreaterThan(_, _) => todo!(),
+			BoolExp::GreaterThanEq(_, _) => todo!(),
+			BoolExp::NotEqual(_, _) => todo!(),
+			BoolExp::Equal(_) => todo!(),
+			BoolExp::Member(_, _) => todo!(),
+			BoolExp::Disjoint(_, _) => todo!(),
+			BoolExp::SubSet(_, _) => todo!(),
+			BoolExp::SubSetEq(_, _) => todo!(),
+			BoolExp::SuperSet(_, _) => todo!(),
+			BoolExp::SuperSetEq(_, _) => todo!(),
+			BoolExp::Convex(_) => todo!(),
+		}
+	}
+
+	/// Extract a list of integer decision variables from a list of [`IntExp`] in
+	/// a [`Xcsp3Instance`]. A [`Xcsp3Error`] will be returned if the expression
+	/// is invalid or unsupported.
+	fn extract_bool_list(
+		&mut self,
+		exp: &[BoolExp<SimpleRef<S>>],
+	) -> Result<Vec<BoolDecision>, Xcsp3Error> {
+		exp.iter().map(|v| self.extract_bool(v)).collect()
+	}
+
+	pub(crate) fn extract_goal(&mut self) -> Result<Option<(Goal, IntDecision)>, Xcsp3Error> {
+		if self.instance.objectives.is_empty() {
+			return Ok(None);
+		}
+		if self.instance.objectives.objectives.len() > 1 {
+			return Err(Xcsp3Error::UnsupportedFeature(
+				"multi objective optimization",
+			));
+		}
+		let (g, e) = match &self.instance.objectives.objectives[0] {
+			Objective::Minimize(e) => (Goal::Minimize, e),
+			Objective::Maximize(e) => (Goal::Maximize, e),
+		};
+		let e = e.unroll(self.instance)?;
+		let list = if e.coeffs.is_empty() {
+			e.list
+		} else if e.list.len() == e.coeffs.len() {
+			e.list
+				.into_iter()
+				.zip(e.coeffs)
+				.map(|(v, c)| IntExp::Mul(vec![IntExp::Const(c), v]))
+				.collect()
+		} else {
+			todo!()
+		};
+		let e = match e.ty {
+			ObjType::Sum => IntExp::Add,
+			ObjType::Minimum => IntExp::Min,
+			ObjType::Maximum => IntExp::Max,
+			ObjType::NValues => todo!(),
+			ObjType::Lex => todo!(),
+		}(list);
+		self.extract_int(&e).map(|e| Some((g, e)))
+	}
+
+	/// Extract one or more integer decision variables from a [`IntExp`] in a
+	/// [`Xcsp3Instance`]. A [`Xcsp3Error`] will be returned if the expression is
+	/// invalid or unsupported.
+	fn extract_int(&mut self, exp: &IntExp<SimpleRef<S>>) -> Result<IntDecision, Xcsp3Error> {
+		let map_to_int = |v: Decision| match v {
+			Decision::Bool(bv) => bv.into(),
+			Decision::Int(iv) => iv,
+		};
+		let key = Exp::Int(exp.clone().into());
+		if let Some(var) = self.expr_map.get(&key) {
+			return Ok(map_to_int(var.clone()));
+		}
+		debug_assert!(!self.expr_map.contains_key(&key));
+		match exp {
+			&IntExp::Const(c) => Ok(IntDecision(IntDecisionInner::Const(c))),
+			IntExp::Var(var) => Ok(map_to_int(self.extract_var(var)?)),
+			IntExp::Neg(exp) => {
+				let v = self.extract_int(exp)?;
+				Ok(-v)
+			}
+			IntExp::Abs(sub) => {
+				let sub = self.extract_int(sub)?;
+				let r = self.prb.new_int_var(full_domain());
+				self.prb += abs_int(sub, r);
+				let _ = self.expr_map.insert(key, r.into());
+				Ok(r)
+			}
+			exp @ IntExp::Add(_) => {
+				let mut lin = self.extract_int_lin(exp)?;
+				match lin.terms.len() {
+					0 => Ok(0.into()),
+					1 => Ok(lin.terms[0]),
+					_ => {
+						// Create returned decision variable
+						let ret = self.prb.new_int_var(full_domain());
+						lin -= ret;
+						self.prb += lin.eq(0);
+						// Store result in CSE map
+						// TODO: normalize before storing in CSE map
+						let _ = self.expr_map.insert(key, Decision::Int(ret));
+						// Return the created decision variable
+						Ok(ret)
+					}
+				}
+			}
+			IntExp::Sub(a, b) => self.extract_int(&IntExp::Add(vec![
+				(**a).clone(),
+				IntExp::Neg(b.clone()).into(),
+			])),
+			IntExp::Mul(sub) => {
+				let rsub = self.extract_int_list(sub)?;
+				let mut c = 1;
+				let mut inc = None;
+				for (i, &v) in rsub.iter().enumerate() {
+					if let IntDecisionInner::Const(k) = v.0 {
+						c *= k;
+					} else if let Some(x) = inc {
+						// Create a new decision variable for the (intermediate) product
+						let r = self.prb.new_int_var(full_domain());
+						// Post relational int_times constraint
+						self.prb += times_int(v, x, r);
+						// Store (intermediate) product in CSE map using original expression
+						let _ = self.expr_map.insert(
+							Exp::Int(IntExp::Mul(sub[0..=i].iter().cloned().collect()).into()),
+							Decision::Int(r),
+						);
+						inc = Some(r);
+					} else {
+						inc = Some(v);
+					}
+				}
+
+				Ok(match inc {
+					Some(v) => v * c,
+					None => c.into(),
+				})
+			}
+			IntExp::Div(a, b) | IntExp::Pow(a, b) => {
+				// Extract different variables
+				let a = self.extract_int(a)?;
+				let b = self.extract_int(b)?;
+				// Create returned decision variable
+				let r = self.prb.new_int_var(full_domain());
+				match exp {
+					IntExp::Div(_, _) => self.prb += div_int(a, b, r),
+					IntExp::Pow(_, _) => self.prb += pow_int(a, b, r),
+					_ => unreachable!(),
+				}
+				// Store result in CSE map
+				let _ = self.expr_map.insert(key, r.into());
+				Ok(r)
+			}
+			IntExp::Max(sub) | IntExp::Min(sub) => {
+				// Extract list of subexpressions
+				let vars: Vec<_> = self.extract_int_list(sub)?;
+				// Create returned decision variable
+				let ret = self.prb.new_int_var(full_domain());
+				// Post relational constraint
+				match exp {
+					IntExp::Add(_) => {
+						let lin: IntLinExpr = vars.iter().copied().chain(once(ret)).sum();
+						self.prb += lin.eq(0);
+					}
+					IntExp::Max(_) => self.prb += array_maximum_int(vars, ret),
+					IntExp::Min(_) => self.prb += array_minimum_int(vars, ret),
+					_ => unreachable!(),
+				}
+				// Store result in CSE map
+				// TODO: normalize before storing in CSE map
+				let _ = self.expr_map.insert(key, ret.into());
+				// Return the created decision variable
+				Ok(ret)
+			}
+			IntExp::Dist(a, b) => {
+				// TODO: normalize
+				self.extract_int(&IntExp::Abs(IntExp::Sub(a.clone(), b.clone()).into()))
+			}
+			IntExp::Bool(bv) => {
+				let bv = self.extract_bool(bv)?;
+				Ok(bv.into())
+			}
+			IntExp::Mod(_, _) => todo!(),
+			IntExp::Sqr(_) => todo!(),
+			IntExp::If(_, _, _) => todo!(),
+			IntExp::Card(_) => todo!(),
+		}
+	}
+
+	fn extract_int_lin(&mut self, exp: &IntExp<SimpleRef<S>>) -> Result<IntLinExpr, Xcsp3Error> {
+		match exp {
+			IntExp::Add(sub) => {
+				let mut lin = IntLinExpr { terms: Vec::new() };
+				for term in sub {
+					lin += self.extract_int_lin(term)?
+				}
+				Ok(lin)
+			}
+			IntExp::Sub(a, b) => Ok(self.extract_int_lin(a)? - self.extract_int_lin(b)?),
+			IntExp::Neg(a) => Ok(-self.extract_int_lin(a)?),
+			IntExp::Mul(sub) => {
+				let mut x = None;
+				let mut mult = 1;
+				for term in sub {
+					match term {
+						IntExp::Const(c) => mult *= c,
+						v if x == None => {
+							x = Some(self.extract_int_lin(v)?);
+						}
+						_ => return self.extract_int(exp).map(|e| IntLinExpr { terms: vec![e] }),
+					}
+				}
+				match x {
+					Some(lin) => Ok(lin * mult),
+					None => Ok(IntLinExpr {
+						terms: vec![mult.into()],
+					}),
+				}
+			}
+			exp => self.extract_int(exp).map(|e| IntLinExpr { terms: vec![e] }),
+		}
+	}
+
+	/// Extract a list of integer decision variables from a list of [`IntExp`] in
+	/// a [`Xcsp3Instance`]. A [`Xcsp3Error`] will be returned if the expression
+	/// is invalid or unsupported.
+	fn extract_int_list(
+		&mut self,
+		exp: &[IntExp<SimpleRef<S>>],
+	) -> Result<Vec<IntDecision>, Xcsp3Error> {
+		exp.iter().map(|v| self.extract_int(v)).collect()
+	}
+
+	fn extract_var(&mut self, var: &SimpleRef<S>) -> Result<Decision, Xcsp3Error> {
+		match var {
+			SimpleRef::Ident(x) => {
+				if let Some(vars) = self.expr_map.get(&Exp::Var(SimpleRef::Ident(x.clone()))) {
+					Ok(vars.clone())
+				} else {
+					Err(Xcsp3Error::UnknownIdentifier(x.to_string()))
+				}
+			}
+			SimpleRef::ArrayAccess(ident, idxs) => {
+				if let Some((vars, dims)) = self.array_map.get(&ident) {
+					let idx = resolve_index(idxs, dims);
+					Ok(vars[idx].clone())
+				} else {
+					Err(Xcsp3Error::UnknownIdentifier(ident.to_string()))
+				}
+			}
+		}
+	}
+
+	/// Finalize the builder and return the model
+	pub(crate) fn finalize<MapTy: FromIterator<(S, Vec<Decision>)>>(
+		self,
+	) -> (Model, MapTy, Xcsp3Statistics) {
+		(
+			self.prb,
+			self.expr_map
+				.into_iter()
+				.filter_map(|(k, v)| {
+					if let Exp::Var(SimpleRef::Ident(ident)) = k {
+						Some((ident, vec![v]))
+					} else {
+						None
+					}
+				})
+				.chain(
+					self.array_map
+						.into_iter()
+						.map(|(ident, (vars, _))| (ident, vars)),
+				)
+				.collect(),
+			self.stats,
+		)
+	}
+
+	/// Create a new builder to create a model from a FlatZinc instance
+	pub(crate) fn new(fzn: &'a Xcsp3Instance<S>) -> Self {
+		Self {
+			instance: fzn,
+			expr_map: HashMap::new(),
+			array_map: HashMap::new(),
+			prb: Model::default(),
+			stats: Xcsp3Statistics::default(),
+		}
+	}
+
+	/// Process the [`FlatZinc::constraints`] field and add [`Constraint`] items
+	/// to the [`Model`] to enforce the constraints.
+	pub(crate) fn post_constraints(&mut self) -> Result<(), Xcsp3Error> {
+		// Traditional relational constraints
+		let constraints = self.instance.unroll_constraints()?;
+		for c in constraints {
+			match c {
+				Constraint::AllDifferent(con) => {
+					if con.except.len() != 0 {
+						return Err(Xcsp3Error::UnsupportedConstraint("all_different_except"));
+					}
+					let vars = self.extract_int_list(&con.list)?;
+					self.prb += all_different_int(vars);
+				}
+				Constraint::AllEqual(con) => {
+					if con.except.len() == 0 {
+						return Err(Xcsp3Error::UnsupportedConstraint("all_equal_except"));
+					}
+					let vars = self.extract_int_list(&con.list)?;
+					if let Some(&var) = vars.get(0) {
+						for &v in vars.iter().skip(1) {
+							self.prb.unify_int(var, v)?;
+						}
+					}
+				}
+				Constraint::BinPacking(_) => {
+					return Err(Xcsp3Error::UnsupportedConstraint("bin_packing"))
+				}
+				Constraint::Cardinality(_) => {
+					return Err(Xcsp3Error::UnsupportedConstraint("cardinality"))
+				}
+				Constraint::Channel(_) => return Err(Xcsp3Error::UnsupportedConstraint("channel")),
+				Constraint::Circuit(_) => return Err(Xcsp3Error::UnsupportedConstraint("circuit")),
+				Constraint::Count(_) => return Err(Xcsp3Error::UnsupportedConstraint("count")),
+				Constraint::Cumulative(_) => {
+					return Err(Xcsp3Error::UnsupportedConstraint("cumulative"))
+				}
+				Constraint::Element(_) => return Err(Xcsp3Error::UnsupportedConstraint("element")),
+				Constraint::Extension(con) => {
+					let vars = self.extract_int_list(&con.list)?;
+					if con.conflicts.len() > 0 {
+						for tup in con.conflicts.iter() {
+							if tup.len() != vars.len() {
+								return Err(Xcsp3Error::InvalidArgumentType {
+									expected: "extension value tuple",
+									found: "value tuple of the wrong length".to_string(),
+								});
+							}
+							self.prb += BoolFormula::Or(
+								vars.iter()
+									.zip(tup.iter())
+									.map(|(var, &val)| BoolFormula::Atom(var.ne(val)))
+									.collect(),
+							);
+						}
+					}
+					if con.supports.len() > 0 {
+						for tup in con.supports.iter() {
+							if tup.len() != vars.len() {
+								return Err(Xcsp3Error::InvalidArgumentType {
+									expected: "extension value tuple",
+									found: "value tuple of the wrong length".to_string(),
+								});
+							}
+						}
+						self.prb += table_int(vars, con.supports.clone());
+					}
+				}
+				Constraint::Instantiation(con) => {
+					let vars: Vec<_> = con
+						.list
+						.iter()
+						.map(|v| self.extract_int(&IntExp::Var(v.clone())))
+						.collect::<Result<Vec<_>, _>>()?;
+					for (&var, &val) in vars.iter().zip(con.values.iter()) {
+						self.prb.set_int_val(var, val)?;
+					}
+				}
+				Constraint::Intension(con) => self.enforce_bool_exp(&con.function)?,
+				Constraint::Knapsack(_) => {
+					return Err(Xcsp3Error::UnsupportedConstraint("knapsack"))
+				}
+				Constraint::Maximum(_) => return Err(Xcsp3Error::UnsupportedConstraint("maximum")),
+				Constraint::Mdd(_) => return Err(Xcsp3Error::UnsupportedConstraint("mdd")),
+				Constraint::Minimum(_) => return Err(Xcsp3Error::UnsupportedConstraint("minimum")),
+				Constraint::NValues(_) => return Err(Xcsp3Error::UnsupportedConstraint("nvalues")),
+				Constraint::NoOverlap(_) => {
+					return Err(Xcsp3Error::UnsupportedConstraint("no_overlap"))
+				}
+				Constraint::Ordered(_) => return Err(Xcsp3Error::UnsupportedConstraint("ordered")),
+				Constraint::Precedence(_) => {
+					return Err(Xcsp3Error::UnsupportedConstraint("precedence"))
+				}
+				Constraint::Regular(_) => return Err(Xcsp3Error::UnsupportedConstraint("regular")),
+				Constraint::Sum(_) => return Err(Xcsp3Error::UnsupportedConstraint("sum")),
+			}
+		}
+
+		Ok(())
+	}
+}

--- a/crates/huub/src/xcsp3.rs
+++ b/crates/huub/src/xcsp3.rs
@@ -1,0 +1,5 @@
+//! Module for the creation of a [`Model`] from a [`Xcsp3Instance`] instance.
+
+use xcsp3_serde::Instance as Xcsp3Instance;
+
+const _: Option<Xcsp3Instance> = None;


### PR DESCRIPTION
This PR track the implementation of XCSP3 support. The goal is to support enough of the format to compete in the XCSP3 challenge.

## General Tasks
- [x] Change the name of the executable from `fzn-huub` to `huub`, where the crate will be renamed from `fzn-huub` to `huub-cli`.
- [x] Hide `Model`/`Solver` extraction methods from `FlatZinc` and `Xcsp3Instance` behind `flatzinc` and `xcsp3` feature flags in `huub`.
- [x] Generalize the extracted data based for running instances in a way that works both for FlatZinc and XCSP3. 
  - [ ] Before merging, it would be nice to implement shared version versions of `Output` and `Goal` objects that could directly be output from the `from_X` extraction methods.
  - [ ] Can we generalize the `tracing` variable registration methods, or will we have to specialize the code for each?
- [x] Implement XCSP3 competition conforming output.
- [ ] Test the system using existing XCSP3 (competition) instances. (Is there a way to use the challenge infrastructure?)

## `xcsp3-serde` Tasks
- [ ] Implement the parsing of `meta` constraints
  - [x] `group`
- [x] Implement flattening methods to allow solver the use of relevant constraints without placeholders.

## Constraint support (as quoted from the competition call)>

- [ ] Constraint `extension`
    This constraint is described in Section 4.1.1.2 in [BLAP21a]. Competition restrictions:
    1. Compressed tables (i.e., tables with compressed tuples) and smart tables are not 
accepted. However, do note that starred (or short) tables (i.e., tables with tuples containing ’*’) are accepted, as in 2019.
    2. Empty Tables (i.e., tables with 0 support or 0 conflict) are not accepted.
    Note that unary, binary and n-ary extensional constraints are accepted.
- [ ] Constraint `regular`
    This constraint is described in Section 4.1.2.1 in [BLAP21a]. Competition restrictions:
    1. The automaton on which is based the constraint must be deterministic.
- [ ] Constraint `mdd`
    This constraint is described in Section 4.1.2.3 in [BLAP21a]. Competition restrictions:
    1. There must be at least one path from the root node to the terminal node.
    2. In <transitions>, the root note is given by the first item of the first transition.
- [ ] Constraint `allDifferent`
    This constraint is described in Section 4.1.3.1 in [BLAP21a]. Competition restrictions:
    1. If present, the element <except> only contains one (integer) value.
    2. Restricted forms (obtained by using the attribute restriction) are not accepted.
    In addition to the basic form of `allDifferent`, the advanced form `allDifferent-matrix`
described in Section 7.2.1 in [BLAP21a] is accepted.
    Also, handling view extensions is authorized for the basic form of `allDifferent`. It means that instead of a list of variables inside the element <list>, it is possible to have a list of integer expressions (trees). This is shown at the end of Section 4.1.3.1 in [BLAP21a]. Competition restriction:
    3. For the basic form of `allDifferent`, the element <list> contains either only variables
or only integer expressions (trees). It means that it is not possible to mix both forms.
- [ ] Constraint `allEqual`
    This constraint is described in Section 4.1.3.2 in [BLAP21a]. Compared to 2019, handling
view extensions is authorized for `allEqual`. It means that instead of a list of variables inside the element <list>, it is possible to have a list of integer expressions (trees). There is no competition restriction for this constraint.
- [ ] Constraint `ordered`
     This constraint is described in Section 4.1.3.4 in [BLAP21a]. Competition restrictions:
     1. The compact form, obtained by using the attribute case, is not accepted.
     As in 2019, note that it is now possible to deal with an element <lengths>.
- [ ] Constraint `sum`
    This constraint is described in Section 4.1.4.1 in [BLAP21a]. Competition restrictions:
    1. The condition is such that either the operator must be relational (i.e., must be in {lt,le,gt,ge,eq,ne}) and the (right) operand must be a value or a variable, or the operator must necessarily be in and the (right) operand must be an integer interval; See Section 1.5 in [BLAP21a].
    Also, handling view extensions is authorized for sum. It means here that instead of a list of variables inside the element <list>, it is possible to have a list of integer expressions (trees).
    This is shown at the end of Section 4.1.4.1 in [BLAP21a]. Competition restriction:
    2. The element <list> contains either only variables or only integer expressions (trees). It means that it is not possible to mix both forms.
- [ ] Constraint `count`
    This constraint is described in Section 4.1.4.2 in [BLAP21a]. Competition restrictions:
    1. The element <values> can only contain (integer) values.
    2. The condition is such that either the operator must be relational (i.e., must be in
{lt,le,gt,ge,eq,ne}) and the (right) operand must be a value or a variable, or the operator must necessarily be in and the (right) operand must be an integer interval; See
Section 1.5 in [BLAP21a].
    Compared to 2019, handling view extensions is authorized for count. It means here that instead of a list of variables inside the element <list>, it is possible to have a list of integer expressions (trees).
- [ ] Constraint `nValues`
    This constraint is described in Section 4.1.4.3 in [BLAP21a]. Competition restrictions:
    1. If present, the element <except> only contains one (integer) value.
    2. The condition is such that either the operator must be eq and the (right) operand must be a value or a variable, or the operator is gt and the (right) operand is 1.
    3. Restricted forms (obtained by using the attribute restriction) are not accepted.
    Not that it is possible to deal with the special case where the condition is composed of the operator gt and the (right) operand is the value 1, which corresponds to the global constraint notAllEqual. Compared to 2019, handling view extensions is authorized for nValues. 
    It means here that instead of a list of variables inside the element <list>, it is possible to have a list of integer expressions (trees).
- [ ] Constraint `cardinality`
    This constraint is described in Section 4.1.4.4 in [BLAP21a]. Competition restrictions:
    1. The element <values> can only contain (integer) values.
    2. Restricted forms (obtained by using the attribute restriction) are not accepted.
- [ ] Constraint `maximum`
    This constraint is described in Section 4.1.5.1 in [BLAP21a]. Competition restrictions:
    1. The condition is such that the operator must necessarily be eq and the (right) operand must be a value or a variable.
    2. The element <index>, used for the variant <arg_max>, is not accepted.
- [ ] Constraint `minimum`
    This constraint is described in Section 4.1.5.2 in [BLAP21a]. Competition restrictions:
    1. The condition is such that the operator must necessarily be eq and the (right) operand must be a value or a variable.
    2. The element <index>, used for the variant <arg_min>, is not accepted.
- [ ] Constraint `element`
    This constraint is described in Section 4.1.5.3 in [BLAP21a]. Competition restrictions:
    1. The optionnal attribute startIndex, if present, is necessarily equal to 0.
    2. The attribute rank, whose default value is "any", cannot be present.
    As in 2019, it is possible to have a list of values (instead of variables) inside <list>. This is presented in Section 4.1.5.3 in [BLAP21a].
    Compared to 2019, the advanced form element-matrix described in Section 7.2.3 in [BLAP21a] is accepted.
- [ ] Constraint `channel`
    This constraint is described in Section 4.1.5.4 in [BLAP21a]. Competition restrictions:
    1. Restricted forms (obtained by using the attribute restriction) are not accepted.
    As in 2019, note that for the form of channel involving two lists, it is possible that these two lists have different sizes. This is discussed at the top of Page 79 in Section 4.1.5.4 in [BLAP21a].
- [ ] Constraint `noOverlap`
    This constraint is described in Section 4.1.6.2 in [BLAP21a]. Competition restrictions:
    1. In case the element <lengths> contains (integer) values, whatever is the dimension, the value 0 is not accepted.
- [ ] Constraint `cumulative`
    This constraint is described in Section 4.1.6.3 in [BLAP21a]. Competition restrictions:
    1. The element <ends> is not accepted.
    2. The variant, using <machines>, is not accepted.
- [ ] Constraint `instantiation`
    This constraint is described in Section 4.1.8.2 in [BLAP21a]. There is no competition restriction for this constraint.
- [ ] Constraint `circuit`
    This constraint is described in Section 4.1.7.1 in [BLAP21a]. Competition restrictions:
    1. The optionnal attribute startIndex, if present, is necessarily equal to 0.
    2. The element <size> cannot be present.
- [ ] Meta-Constraint `slide`
    This meta-constraint is described in Section 8.1 in [BLAP21a]. Competition restrictions:
    1. Only one element <list> is accepted.
    2. The constraint template must be of form <intension> or <extension>.
- [ ] Constraint `precedence`
    This constraint is described in Section 4.1.3.5 in [BLAP22]. Competition restrictions:
    - the attribute `covered` will not be used (and so, never present in instances used for the 2023 competition)
- [ ] Constraint `knapsack`
    This constraint is described in Section 4.1.6.5 in [BLAP22]. Competition restrictions:
    - none
    This constraint can be very easily decomposed.
- [ ] Constraint `binPacking`
    This constraint is described in Section 4.1.6.4 in [BLAP22]. Competition restrictions:
    - the general form will not be used (only the first three forms as described in Section
4.1.6.4)
    This constraint can be easily decomposed.