### PR TITLE
Update configurations for VSIDS-related search heuristics

### DIFF
--- a/crates/fzn-huub/src/lib.rs
+++ b/crates/fzn-huub/src/lib.rs
@@ -92,6 +92,8 @@ pub struct Cli<Stdout, Stderr> {
 	// --- Search configuration ---
 	/// Whether solver is allowed to restart
 	restart: bool,
+	/// Whether to switch to the VSIDS heuristic after a restart
+	vsids_after_restart: bool,
 	/// Alternate between the SAT and VSIDS heuristic after every restart
 	toggle_vsids: bool,
 	/// Switch to the VSIDS heuristic after a certain number of conflicts
@@ -302,6 +304,7 @@ where
 			slv.set_vsids_only(self.vsids_only);
 			slv.set_toggle_vsids(self.toggle_vsids);
 			slv.set_vsids_after(self.vsids_after);
+			slv.set_vsids_after_restart(self.vsids_after_restart);
 		}
 
 		// Determine Goal and Objective
@@ -564,6 +567,7 @@ where
 			variable_elimination: self.variable_elimination,
 			probing: self.probing,
 			conditioning: self.conditioning,
+			vsids_after_restart: self.vsids_after_restart,
 			vsids_after: self.vsids_after,
 			vsids_only: self.vsids_only,
 			stdout: self.stdout,
@@ -593,6 +597,7 @@ where
 			variable_elimination: self.variable_elimination,
 			probing: self.probing,
 			conditioning: self.conditioning,
+			vsids_after_restart: self.vsids_after_restart,
 			vsids_after: self.vsids_after,
 			vsids_only: self.vsids_only,
 			stderr: self.stderr,
@@ -637,6 +642,7 @@ impl TryFrom<Arguments> for Cli<io::Stdout, fn() -> io::Stderr> {
 				.opt_value_from_fn("--restart", parse_bool_arg)
 				.map(|x| x.unwrap_or(false))
 				.map_err(|e| e.to_string())?,
+			vsids_after_restart: args.contains("--vsids-after-restart"),
 			toggle_vsids: args.contains("--toggle-vsids"),
 			vsids_only: args.contains("--vsids-only"),
 			vsids_after: args

--- a/crates/fzn-huub/src/lib.rs
+++ b/crates/fzn-huub/src/lib.rs
@@ -92,12 +92,12 @@ pub struct Cli<Stdout, Stderr> {
 	// --- Search configuration ---
 	/// Whether solver is allowed to restart
 	restart: bool,
-	/// Whether to switch to the VSIDS heuristic after a restart
-	vsids_after_restart: bool,
 	/// Alternate between the SAT and VSIDS heuristic after every restart
 	toggle_vsids: bool,
 	/// Switch to the VSIDS heuristic after a certain number of conflicts
-	vsids_after: Option<u32>,
+	vsids_after_conflict: Option<u32>,
+	/// Whether to switch to the VSIDS heuristic after a restart
+	vsids_after_restart: bool,
 	/// Only use the SAT VSIDS heuristic for search
 	vsids_only: bool,
 
@@ -299,11 +299,11 @@ where
 
 		// Set Solver Configuration
 		if self.free_search {
-			slv.set_vsids_after(Some(1000));
+			slv.set_vsids_after_conflict(Some(1000));
 		} else {
 			slv.set_vsids_only(self.vsids_only);
 			slv.set_toggle_vsids(self.toggle_vsids);
-			slv.set_vsids_after(self.vsids_after);
+			slv.set_vsids_after_conflict(self.vsids_after_conflict);
 			slv.set_vsids_after_restart(self.vsids_after_restart);
 		}
 
@@ -567,8 +567,8 @@ where
 			variable_elimination: self.variable_elimination,
 			probing: self.probing,
 			conditioning: self.conditioning,
+			vsids_after_conflict: self.vsids_after_conflict,
 			vsids_after_restart: self.vsids_after_restart,
-			vsids_after: self.vsids_after,
 			vsids_only: self.vsids_only,
 			stdout: self.stdout,
 		}
@@ -597,8 +597,8 @@ where
 			variable_elimination: self.variable_elimination,
 			probing: self.probing,
 			conditioning: self.conditioning,
+			vsids_after_conflict: self.vsids_after_conflict,
 			vsids_after_restart: self.vsids_after_restart,
-			vsids_after: self.vsids_after,
 			vsids_only: self.vsids_only,
 			stderr: self.stderr,
 			ansi_color: self.ansi_color,
@@ -642,12 +642,12 @@ impl TryFrom<Arguments> for Cli<io::Stdout, fn() -> io::Stderr> {
 				.opt_value_from_fn("--restart", parse_bool_arg)
 				.map(|x| x.unwrap_or(false))
 				.map_err(|e| e.to_string())?,
-			vsids_after_restart: args.contains("--vsids-after-restart"),
 			toggle_vsids: args.contains("--toggle-vsids"),
-			vsids_only: args.contains("--vsids-only"),
-			vsids_after: args
-				.opt_value_from_str("--vsids-after")
+			vsids_after_conflict: args
+				.opt_value_from_str("--vsids-after-conflict")
 				.map_err(|e| e.to_string())?,
+			vsids_after_restart: args.contains("--vsids-after-restart"),
+			vsids_only: args.contains("--vsids-only"),
 
 			conditioning: args
 				.opt_value_from_fn("--conditioning", parse_bool_arg)

--- a/crates/fzn-huub/src/lib.rs
+++ b/crates/fzn-huub/src/lib.rs
@@ -299,7 +299,7 @@ where
 
 		// Set Solver Configuration
 		if self.free_search {
-			slv.set_toggle_vsids(true);
+			slv.set_vsids_after(Some(1000));
 		} else {
 			slv.set_vsids_only(self.vsids_only);
 			slv.set_toggle_vsids(self.toggle_vsids);

--- a/crates/fzn-huub/src/main.rs
+++ b/crates/fzn-huub/src/main.rs
@@ -59,10 +59,10 @@ FLAGS
                       === SEARCH OPTIONS ===
   --restart <on|off>              Whether to enable restarts of the search.
                                   (default: off)
-  --vsids-after-restart           Switch to the VSIDS search heuristic after restart 
-                                  (overwritten by --toggle-vsids and --vsids-only)
   --vsids-after-conflict <value>  Switch to the VSIDS search heuristic after a certain number of
                                   conflicts. (overwritten by --toggle-vsids and --vsids-only)
+  --vsids-after-restart           Switch to the VSIDS search heuristic after restart 
+                                  (overwritten by --toggle-vsids and --vsids-only)
   --toggle-vsids                  Switch between the activity-based search heuristic and the user-
                                   specific search heuristic after every restart.
                                   (overwritten by --vsids-only)

--- a/crates/fzn-huub/src/main.rs
+++ b/crates/fzn-huub/src/main.rs
@@ -59,6 +59,8 @@ FLAGS
                       === SEARCH OPTIONS ===
   --restart <on|off>              Whether to enable restarts of the search.
                                   (default: off)
+  --vsids-after-restart           Switch to the VSIDS search heuristic after restart 
+                                  (overwritten by --toggle-vsids and --vsids-only)
   --vsids-after <value>           Switch to the VSIDS search heuristic after a certain number of
                                   conflicts. (overwritten by --toggle-vsids and --vsids-only)
   --toggle-vsids                  Switch between the activity-based search heuristic and the user-

--- a/crates/fzn-huub/src/main.rs
+++ b/crates/fzn-huub/src/main.rs
@@ -61,7 +61,7 @@ FLAGS
                                   (default: off)
   --vsids-after-restart           Switch to the VSIDS search heuristic after restart 
                                   (overwritten by --toggle-vsids and --vsids-only)
-  --vsids-after <value>           Switch to the VSIDS search heuristic after a certain number of
+  --vsids-after-conflict <value>  Switch to the VSIDS search heuristic after a certain number of
                                   conflicts. (overwritten by --toggle-vsids and --vsids-only)
   --toggle-vsids                  Switch between the activity-based search heuristic and the user-
                                   specific search heuristic after every restart.

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -1113,7 +1113,12 @@ impl Model {
 			r.set_option("vivify", config.vivification() as i32);
 
 			// Set the solver options for search configurations
-			r.set_option("restart", config.restart() as i32);
+			// Enable restart if the config is set to true or if there are no
+			// user search heuristics are provided
+			r.set_option(
+				"restart",
+				(config.restart() || self.branchings.is_empty()) as i32,
+			);
 		} else {
 			warn!("unknown solver: vivification and restart options are ignored");
 		}

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -961,10 +961,9 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 			/// Set the number of conflicts after which the solver should switch to using
 			/// VSIDS to make search decisions.
 			pub fn set_vsids_after_conflict(&mut self, conflicts: Option<u32>);
-			/// Set the number of restarts after which the solver should switch to using
-			/// VSIDS to make search decisions.
+			/// Set whether the solver should switch to VSIDS after restart to make search.
 			pub fn set_vsids_after_restart(&mut self, enable: bool);
-			/// Set wether the solver should make all search decisions based on the VSIDS
+			/// Set whether the solver should make all search decisions based on the VSIDS
 			/// only.
 			pub fn set_vsids_only(&mut self, enable: bool);
 		}

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -189,6 +189,8 @@ pub struct Solver<Oracle = PropagatingCadical<Engine>> {
 /// Structure holding the options using to configure the solver during its
 /// initialization.
 pub(crate) struct SolverConfiguration {
+	/// The number of restarts after which the activity-based search heuristic is enabled.
+	vsids_after_restart: bool,
 	/// Switch between the activity-based search heuristic and the user-specific search heuristic after each restart.
 	///
 	/// This option is ignored if [`vsids_only`] is set to `true`.
@@ -949,6 +951,9 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 
 	delegate! {
 		to self.engine_mut().state {
+			/// Set the number of restarts after which the solver should switch to using
+			/// VSIDS to make search decisions.
+			pub fn set_vsids_after_restart(&mut self, enable: bool);
 			/// Set whether the solver should toggle between VSIDS and a user defined
 			/// search strategy after every restart.
 			///

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -189,8 +189,6 @@ pub struct Solver<Oracle = PropagatingCadical<Engine>> {
 /// Structure holding the options using to configure the solver during its
 /// initialization.
 pub(crate) struct SolverConfiguration {
-	/// The number of restarts after which the activity-based search heuristic is enabled.
-	vsids_after_restart: bool,
 	/// Switch between the activity-based search heuristic and the user-specific search heuristic after each restart.
 	///
 	/// This option is ignored if [`vsids_only`] is set to `true`.
@@ -198,7 +196,11 @@ pub(crate) struct SolverConfiguration {
 	/// Switch to the activity-based search heuristic after the given number of conflicts.
 	///
 	/// This option is ignored if [`toggle_vsids`] or [`vsids_only`] is set to `true`.
-	vsids_after: Option<u32>,
+	vsids_after_conflict: Option<u32>,
+	/// Switch to the activity-based search heuristic after restart.
+	///
+	/// This option is ignored if [`toggle_vsids`] or [`vsids_only`] is set to `true`.
+	vsids_after_restart: bool,
 	/// Only use the activity-based search heuristic provided by the SAT solver. Ignore the user-specific search heuristic.
 	vsids_only: bool,
 }
@@ -951,9 +953,6 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 
 	delegate! {
 		to self.engine_mut().state {
-			/// Set the number of restarts after which the solver should switch to using
-			/// VSIDS to make search decisions.
-			pub fn set_vsids_after_restart(&mut self, enable: bool);
 			/// Set whether the solver should toggle between VSIDS and a user defined
 			/// search strategy after every restart.
 			///
@@ -961,7 +960,10 @@ impl<Oracle: PropagatingSolver<Engine>> Solver<Oracle> {
 			pub fn set_toggle_vsids(&mut self, enable: bool);
 			/// Set the number of conflicts after which the solver should switch to using
 			/// VSIDS to make search decisions.
-			pub fn set_vsids_after(&mut self, conflicts: Option<u32>);
+			pub fn set_vsids_after_conflict(&mut self, conflicts: Option<u32>);
+			/// Set the number of restarts after which the solver should switch to using
+			/// VSIDS to make search decisions.
+			pub fn set_vsids_after_restart(&mut self, enable: bool);
 			/// Set wether the solver should make all search decisions based on the VSIDS
 			/// only.
 			pub fn set_vsids_only(&mut self, enable: bool);

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -538,6 +538,14 @@ impl State {
 					"toggling vsids"
 				);
 			}
+			if self.config.vsids_after_restart {
+				self.vsids = true;
+				debug!(
+					vsids = self.vsids,
+					restart = self.statistics.restarts,
+					"enable vsids after restart"
+				);
+			}
 			if level == 0 {
 				// Memory cleanup (Reasons are known to no longer be relevant)
 				self.reason_map.clear();
@@ -569,6 +577,10 @@ impl State {
 			}
 			Err(false) => unreachable!("invalid reason"),
 		}
+	}
+
+	pub(crate) fn set_vsids_after_restart(&mut self, enable: bool) {
+		self.config.vsids_after_restart = enable;
 	}
 
 	/// Set whether the solver should toggle between VSIDS and a user defined

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -512,7 +512,7 @@ impl State {
 		self.statistics.conflicts += 1;
 
 		// Switch to VSIDS if the number of conflicts exceeds the threshold
-		if let Some(conflicts) = self.config.vsids_after {
+		if let Some(conflicts) = self.config.vsids_after_conflict {
 			if !self.config.vsids_only
 				&& !self.config.toggle_vsids
 				&& self.statistics.conflicts > conflicts as u64
@@ -537,8 +537,7 @@ impl State {
 					restart = self.statistics.restarts,
 					"toggling vsids"
 				);
-			}
-			if self.config.vsids_after_restart {
+			} else if self.config.vsids_after_restart {
 				self.vsids = true;
 				debug!(
 					vsids = self.vsids,
@@ -579,10 +578,6 @@ impl State {
 		}
 	}
 
-	pub(crate) fn set_vsids_after_restart(&mut self, enable: bool) {
-		self.config.vsids_after_restart = enable;
-	}
-
 	/// Set whether the solver should toggle between VSIDS and a user defined
 	/// search strategy after every restart.
 	///
@@ -593,8 +588,13 @@ impl State {
 
 	/// Set the number of conflicts after which the solver should switch to using
 	/// VSIDS to make search decisions.
-	pub(crate) fn set_vsids_after(&mut self, conflicts: Option<u32>) {
-		self.config.vsids_after = conflicts;
+	pub(crate) fn set_vsids_after_conflict(&mut self, conflicts: Option<u32>) {
+		self.config.vsids_after_conflict = conflicts;
+	}
+
+	/// Set whether the solver should switch to using VSIDS after a restart.
+	pub(crate) fn set_vsids_after_restart(&mut self, enable: bool) {
+		self.config.vsids_after_restart = enable;
 	}
 
 	/// Set wether the solver should make all search decisions based on the VSIDS

--- a/share/minizinc/solvers/huub.msc
+++ b/share/minizinc/solvers/huub.msc
@@ -17,9 +17,9 @@
     ["--subsumption","Whether to enable the global forward subsumption","bool:false:true","false"],
     ["--toggle-vsids", "Alternate between the activity-based search heuristic and the user-specific search heuristic after every restart.", "bool", "false"],
     ["--variable-elimination","Whether to enable the bounded variable elimination ","bool:false:true","false"],
-    ["--vsids-after-restart", "Switch to activity-based search heuristic provided by the SAT solver after the given number of restarts.", "bool", "false"],
     ["--vivify","Whether to enable vivification","bool:false:true","false"],
-    ["--vsids-after", "Switch to activity-based search heuristic provided by the SAT solver after the given number of conflicts.", "int", "None"],
+    ["--vsids-after-restart", "Switch to activity-based search heuristic provided by the SAT solver after restart.", "bool", "false"],
+    ["--vsids-after-conflict", "Switch to activity-based search heuristic provided by the SAT solver after the given number of conflicts.", "int", "None"],
     ["--vsids-only", "Only use the activity-based search provided by the SAT solver", "bool", "false"]
   ]
 }

--- a/share/minizinc/solvers/huub.msc
+++ b/share/minizinc/solvers/huub.msc
@@ -18,8 +18,8 @@
     ["--toggle-vsids", "Alternate between the activity-based search heuristic and the user-specific search heuristic after every restart.", "bool", "false"],
     ["--variable-elimination","Whether to enable the bounded variable elimination ","bool:false:true","false"],
     ["--vivify","Whether to enable vivification","bool:false:true","false"],
-    ["--vsids-after-restart", "Switch to activity-based search heuristic provided by the SAT solver after restart.", "bool", "false"],
     ["--vsids-after-conflict", "Switch to activity-based search heuristic provided by the SAT solver after the given number of conflicts.", "int", "None"],
+    ["--vsids-after-restart", "Switch to activity-based search heuristic provided by the SAT solver after restart.", "bool", "false"],
     ["--vsids-only", "Only use the activity-based search provided by the SAT solver", "bool", "false"]
   ]
 }

--- a/share/minizinc/solvers/huub.msc
+++ b/share/minizinc/solvers/huub.msc
@@ -17,8 +17,9 @@
     ["--subsumption","Whether to enable the global forward subsumption","bool:false:true","false"],
     ["--toggle-vsids", "Alternate between the activity-based search heuristic and the user-specific search heuristic after every restart.", "bool", "false"],
     ["--variable-elimination","Whether to enable the bounded variable elimination ","bool:false:true","false"],
+    ["--vsids-after-restart", "Switch to activity-based search heuristic provided by the SAT solver after the given number of restarts.", "bool", "false"],
     ["--vivify","Whether to enable vivification","bool:false:true","false"],
-    ["--vsids-after", "Switch to activity-based search heuristic provided by the SAT solver after the given number of conflicts.", "int", "0"],
+    ["--vsids-after", "Switch to activity-based search heuristic provided by the SAT solver after the given number of conflicts.", "int", "None"],
     ["--vsids-only", "Only use the activity-based search provided by the SAT solver", "bool", "false"]
   ]
 }


### PR DESCRIPTION
- update the free search configuration to switching to VSIDS after 1000 conflicts 
- add a command line option `vsids-after-restart`
- enable restart when no user search heuristics are provided