### PR TITLE
fix(huub): do not remove reason when propagating the same literal twice

### DIFF
--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -392,8 +392,6 @@ impl PropagatorExtension for Engine {
 		while let Some(&lit) = self.state.propagation_queue.front() {
 			if self.state.trail.get_sat_value(lit) == Some(true) {
 				let _ = self.state.propagation_queue.pop_front();
-				let reason = self.state.reason_map.remove(&lit);
-				debug_assert!(reason.is_some());
 			} else {
 				break;
 			}


### PR DESCRIPTION
The reason was currently removed under the assumption that any already propagated literal was propagated by the SAT solver, and had an explanation there. This, however, causes an issue when literals were propagated multiple times by CP propagators, as the LCG engine assumed that the literal would globally hold.

@AllenZzw As discussed, should you see whether it is possible to create a minimal test case that showcases the problem? Then I think this can be merged.