### PR TITLE
fix(huub): resolution of a sequence of linear transformation aliases

### DIFF
--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -645,9 +645,8 @@ impl IntDecision {
 				Linear(t, x) => {
 					if let Domain::Alias(alias) = model.int_vars[x].domain {
 						result = alias;
+						offset += scale * t.offset;
 						scale *= t.scale.get();
-						offset *= t.scale.get();
-						offset += t.offset;
 					} else {
 						return IntDecision(Linear(t, x)) * scale + offset;
 					}

--- a/crates/huub/src/tests.rs
+++ b/crates/huub/src/tests.rs
@@ -4,6 +4,7 @@ use pindakaas::{propositional_logic::Formula, Cnf};
 use rangelist::RangeList;
 
 use crate::{
+	actions::SimplificationActions,
 	branchers::IntBrancher,
 	constraints::int_linear::{IntLinearLessEqBounds, IntLinearNotEqValue},
 	solver::{
@@ -114,6 +115,22 @@ fn test_unify_int_lin_view_domains() {
 	let (res, _, solns) = slv.get_all_solutions(&[a.into(), b.into()]);
 	assert_eq!(res, SolveResult::Complete);
 	assert_eq!(solns, vec![vec![Value::Int(1), Value::Int(3)]]);
+}
+
+#[test]
+/// Test case to check if resolving a multistep linear alias works properly.
+fn lin_multi_alias() {
+	let mut prb = Model::default();
+	let x = prb.new_int_var(RangeList::from_iter([1..=10]));
+	let y = prb.new_int_var(RangeList::from_iter([1..=10]));
+	let z = prb.new_int_var(RangeList::from_iter([1..=10]));
+	let x_trans = x * -1 - 1;
+	let y_trans = y + 1;
+	let z_trans = z + 1;
+	assert!(prb.unify_int(x, y_trans).is_ok());
+	assert!(prb.unify_int(y, z_trans).is_ok());
+	assert_eq!(prb.get_int_lower_bound(x_trans), -11);
+	assert_eq!(prb.get_int_upper_bound(x_trans), -4);
 }
 
 impl Model {


### PR DESCRIPTION
I found a bug when resolving multiple stages of linear transformations after variable unifications. The problem was as follows:

- resolve_alias is called for a linear transformation -x-1
- x is an alias for y+1
- y is an alias for z+1

The result was that the final offset was incorrectly calculated which lead to wrong bounds being returned. I added a test case replicating this chain (which initially failed), and a fix in resolve_alias which makes the test case work. 