### PR TITLE
Advisors on literals that can be assigned immediately

### DIFF
--- a/crates/huub/src/constraints/int_all_different.rs
+++ b/crates/huub/src/constraints/int_all_different.rs
@@ -15,7 +15,7 @@ use crate::{
 	solver::{
 		activation_list::{IntEvent, IntPropCond},
 		queue::PriorityLevel,
-		IntLitMeaning, IntView, IntViewInner,
+		IntLitMeaning, IntView,
 	},
 	IntDecision, IntVal,
 };
@@ -454,27 +454,11 @@ impl IntAllDifferentValue {
 	/// Create a new [`IntAllDifferentValue`] propagator and post it in the
 	/// solver.
 	pub fn new_in<P: PropagatorInitActions + ?Sized>(solver: &mut P, vars: Vec<IntView>) {
-		// Initialize a list of indices of decisions that already have a fixed
-		// value.
-		let action_list: Vec<usize> = vars
-			.iter()
-			.enumerate()
-			.flat_map(|(i, v)| {
-				if let IntView(IntViewInner::Const(_)) = v {
-					Some(i)
-				} else {
-					None
-				}
-			})
-			.collect();
-		// If the list is not empty, then the propagator should be enqueued at the
-		// root level.
-		let enqueue = !action_list.is_empty();
 		// Post the propagator to the solver
 		let prop = solver.add_propagator(
 			Box::new(Self {
 				vars: vars.clone(),
-				action_list,
+				action_list: Vec::new(),
 			}),
 			PriorityLevel::Low,
 		);
@@ -486,9 +470,6 @@ impl IntAllDifferentValue {
 		// Advise the propagator of backtracking to clear the list of fixed decision
 		// (indices).
 		solver.advise_on_backtrack(prop);
-		if enqueue {
-			solver.enqueue_now(prop);
-		}
 	}
 }
 

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -13,7 +13,7 @@ use std::{
 	fmt::{self, Debug, Display, Formatter},
 	hash::Hash,
 	num::NonZeroI32,
-	ops::{Add, AddAssign, Deref, Mul, Neg, Not},
+	ops::{Add, AddAssign, Deref, DerefMut, Mul, Neg, Not},
 	rc::Rc,
 };
 
@@ -39,7 +39,7 @@ use crate::{
 	flatzinc::{FlatZincError, FlatZincStatistics},
 	reformulate::InitConfig,
 	solver::{
-		activation_list::{ActivationAction, IntPropCond},
+		activation_list::{ActivationAction, IntEvent, IntPropCond},
 		engine::{trace_new_lit, AdvisorDef, Engine, PropRef},
 		int_var::{DirectStorage, IntVarRef, LazyLitDef, OrderStorage},
 		queue::{PriorityLevel, PropagatorInfo},
@@ -692,20 +692,39 @@ impl<Oracle: ExternalPropagation> Solver<Oracle> {
 	/// Used by [`Solver::advise_on_bool_change`] and
 	/// [`Solver::advise_on_int_change`].
 	fn advise_on_lit_change(&mut self, prop: PropRef, lit: RawLit, data: u64, bool2int: bool) {
+		{
+			// Ensure the trail has allocated a space to track the variable
+			self.engine
+				.borrow_mut()
+				.state
+				.trail
+				.grow_to_boolvar(lit.var());
+		}
+		// Ensure that the variable is marked as observed
 		self.oracle.add_observed_var(lit.var());
-		let state = &mut self.engine.borrow_mut().state;
-		state.trail.grow_to_boolvar(lit.var());
-		let adv = state.advisors.push(AdvisorDef {
-			bool2int,
-			data,
-			negated: false,
-			propagator: prop,
-		});
-		state
-			.bool_activation
-			.entry(lit.var())
-			.or_default()
-			.push(ActivationAction::Advise(adv).into());
+		// Add the advisor to the engine
+		let mut engine = self.engine.borrow_mut();
+		// If the variable is already assigned, notify the advisor immediately
+		if engine.state.trail.get_sat_value(lit).is_some() {
+			if engine.notify_lit_advisor(prop, lit, data, bool2int) {
+				drop(engine);
+				self.enqueue_now(prop);
+			}
+		} else {
+			// Otherwise, add the advisor to the engine
+			let adv = engine.state.advisors.push(AdvisorDef {
+				bool2int,
+				data,
+				negated: false,
+				propagator: prop,
+			});
+			engine
+				.state
+				.bool_activation
+				.entry(lit.var())
+				.or_default()
+				.push(ActivationAction::Advise(adv).into());
+		}
 	}
 
 	/// Find all solutions with regard to a list of given variables.
@@ -1201,10 +1220,18 @@ impl<Oracle: ExternalPropagation> PropagatorInitActions for Solver<Oracle> {
 
 	fn advise_on_bool_change(&mut self, prop: PropRef, var: BoolView, data: u64) {
 		match var.0 {
-			BoolViewInner::Lit(lit) => {
-				self.advise_on_lit_change(prop, lit, data, false);
+			BoolViewInner::Lit(lit) => self.advise_on_lit_change(prop, lit, data, false),
+			BoolViewInner::Const(_) => {
+				// Immediate notify the propagator, and enqueue if necessary
+				let mut engine_ref = self.engine.borrow_mut();
+				let engine: &mut Engine = engine_ref.deref_mut();
+				let enqueue =
+					engine.propagators[prop].advise_of_bool_change(&mut engine.state, var, data);
+				drop(engine_ref);
+				if enqueue {
+					self.enqueue_now(prop);
+				}
 			}
-			BoolViewInner::Const(_) => {}
 		}
 	}
 
@@ -1229,7 +1256,20 @@ impl<Oracle: ExternalPropagation> PropagatorInitActions for Solver<Oracle> {
 				};
 				(var, condition, !transformer.positive_scale())
 			}
-			IntViewInner::Const(_) => return, // ignore
+			IntViewInner::Const(_) => {
+				// Immediately notify the propagator, and enqueue the propagator if it is
+				// required.
+				if self.engine.borrow_mut().notify_int_advisor(
+					prop,
+					var,
+					IntEvent::Fixed,
+					data,
+					false,
+				) {
+					self.enqueue_now(prop);
+				}
+				return;
+			}
 			IntViewInner::Bool { lit, .. } => {
 				return self.advise_on_lit_change(prop, lit, data, true);
 			}
@@ -1253,18 +1293,30 @@ impl<Oracle: ExternalPropagation> PropagatorInitActions for Solver<Oracle> {
 	fn enqueue_on_bool_change(&mut self, prop: PropRef, var: BoolView) {
 		match var.0 {
 			BoolViewInner::Lit(lit) => {
+				// Ensure that the trail has a space to track the literal
 				{
 					let state = &mut self.engine.borrow_mut().state;
 					state.trail.grow_to_boolvar(lit.var());
-					state
+				}
+				// Ensure the oracle knows the literal is observed.
+				self.oracle.add_observed_var(lit.var());
+
+				let mut engine = self.engine.borrow_mut();
+				// If the literal is already assigned, enqueue the propagator immediately.
+				if engine.state.trail.get_sat_value(lit).is_some() {
+					drop(engine);
+					self.enqueue_now(prop);
+				} else {
+					// Otherwise, add propagator to the activation list.
+					engine
+						.state
 						.bool_activation
 						.entry(lit.var())
 						.or_default()
 						.push(ActivationAction::Enqueue(prop).into());
-				}
-				self.oracle.add_observed_var(lit.var());
+				};
 			}
-			BoolViewInner::Const(_) => {}
+			BoolViewInner::Const(_) => self.enqueue_now(prop),
 		}
 	}
 
@@ -1283,7 +1335,11 @@ impl<Oracle: ExternalPropagation> PropagatorInitActions for Solver<Oracle> {
 				};
 				(var, condition)
 			}
-			IntViewInner::Const(_) => return, // ignore
+			IntViewInner::Const(_) => {
+				// Immediately enqueue, and no further action is required
+				self.enqueue_now(prop);
+				return;
+			}
 			IntViewInner::Bool { lit, .. } => {
 				return self.enqueue_on_bool_change(prop, BoolView(BoolViewInner::Lit(lit)))
 			}

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -187,6 +187,57 @@ impl Engine {
 			);
 		}
 	}
+
+	/// Notify the given propagator about the integer change, providing the
+	/// given data.
+	///
+	/// If `negated` is true, then the event is negated.
+	pub(crate) fn notify_int_advisor(
+		&mut self,
+		prop: PropRef,
+		iv: IntView,
+		event: IntEvent,
+		data: u64,
+		negated: bool,
+	) -> bool {
+		let event = match event {
+			IntEvent::LowerBound if negated => IntEvent::UpperBound,
+			IntEvent::UpperBound if negated => IntEvent::LowerBound,
+			e => e,
+		};
+		self.propagators[prop].advise_of_int_change(&mut self.state, iv, event, data)
+	}
+
+	/// Notify the given propagator about the literal change, providing the
+	/// given data.
+	///
+	/// If `bool2int` is true, then the literal is transformed into an integer
+	/// view.
+	pub(crate) fn notify_lit_advisor(
+		&mut self,
+		prop: PropRef,
+		lit: RawLit,
+		data: u64,
+		bool2int: bool,
+	) -> bool {
+		if bool2int {
+			self.propagators[prop].advise_of_int_change(
+				&mut self.state,
+				IntView(IntViewInner::Bool {
+					transformer: Default::default(),
+					lit,
+				}),
+				IntEvent::Fixed,
+				data,
+			)
+		} else {
+			self.propagators[prop].advise_of_bool_change(
+				&mut self.state,
+				BoolView(BoolViewInner::Lit(lit)),
+				data,
+			)
+		}
+	}
 }
 
 impl PropagatorExtension for Engine {
@@ -397,23 +448,8 @@ impl PropagatorExtension for Engine {
 									propagator,
 									..
 								} = &self.state.advisors[adv];
-								let enqueue = if bool2int {
-									self.propagators[propagator].advise_of_int_change(
-										&mut self.state,
-										IntView(IntViewInner::Bool {
-											transformer: Default::default(),
-											lit,
-										}),
-										IntEvent::Fixed,
-										data,
-									)
-								} else {
-									self.propagators[propagator].advise_of_bool_change(
-										&mut self.state,
-										BoolView(BoolViewInner::Lit(lit)),
-										data,
-									)
-								};
+								let enqueue =
+									self.notify_lit_advisor(propagator, lit, data, bool2int);
 								if !enqueue {
 									continue;
 								}
@@ -501,17 +537,14 @@ impl PropagatorExtension for Engine {
 										propagator,
 										..
 									} = &self.state.advisors[adv];
-									let event = match event {
-										IntEvent::LowerBound if negated => IntEvent::UpperBound,
-										IntEvent::UpperBound if negated => IntEvent::LowerBound,
-										e => e,
-									};
-									if !self.propagators[propagator].advise_of_int_change(
-										&mut self.state,
+									let enqueue = self.notify_int_advisor(
+										propagator,
 										IntView(IntViewInner::VarRef(iv)),
 										event,
 										data,
-									) {
+										negated,
+									);
+									if !enqueue {
 										continue;
 									}
 									propagator


### PR DESCRIPTION
I noted that sometimes I would get an error when setting an advisor for a boolean in difference logic for rcpsp_max:
[advisor_panic.txt](https://github.com/user-attachments/files/22091564/advisor_panic.txt)

I realized it was triggered when the literal to observe can immediately be assigned during the add_observed_var call. 
This would call assign_lit in trail.rs before grow_to_boolvar and lead to the error. I moved the add_observed_var call to the end of advise_on_lit_change, in this case the advisor get set up correctly and gets immediately called even if the literal is directly assigned.

I have test cases using difference logic for this, not sure how to extract the problem into a small stand-alone test case though.