### PR TITLE
allow further simplification at root level

### DIFF
--- a/crates/huub/src/actions.rs
+++ b/crates/huub/src/actions.rs
@@ -295,6 +295,9 @@ pub trait SimplificationActions {
 	/// Get the current value of a [`BoolView`], if it has been assigned.
 	fn get_bool_val(&self, bv: BoolDecision) -> Option<bool>;
 
+	/// Get the domain from which an integer view is guaranteed to take a value.
+	fn get_int_domain(&self, var: IntDecision) -> IntSetVal;
+
 	/// Get the minimum value that an integer view is guaranteed to take.
 	fn get_int_lower_bound(&self, var: IntDecision) -> IntVal;
 

--- a/crates/huub/src/constraints.rs
+++ b/crates/huub/src/constraints.rs
@@ -95,7 +95,7 @@ pub trait Constraint<S: SimplificationActions>: Debug + DynConstraintClone {
 	/// is already subsumed by the current state of the model.
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		let _ = actions;
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	/// Encode the constraint using [`Propagator`] objects or clauses for a
@@ -229,11 +229,10 @@ pub trait ReasonBuilder<A: ExplanationActions + ?Sized> {
 /// removed from the [`Model`]) or not.
 pub enum SimplificationStatus {
 	/// The constraint has been simplified as much as possible, but should be
-	/// kept in the [`Model`].
-	///
-	/// Simplification can be triggered again if any of the decision variables
-	/// the constraint depends on change.
-	Fixpoint,
+	/// kept in the [`Model`]. Simplification can be triggered again if any of
+	/// the decision variables the constraint depends on change (even by its
+	/// own changes).
+	NoFixpoint,
 	/// The constraint has been simplified to the point where it is subsumed.
 	/// The constraint can be removed from the [`Model`].
 	Subsumed,

--- a/crates/huub/src/constraints/bool_array_element.rs
+++ b/crates/huub/src/constraints/bool_array_element.rs
@@ -48,7 +48,7 @@ impl<S: SimplificationActions> Constraint<S> for BoolDecisionArrayElement {
 			actions.unify_bool(self.array[i as usize], self.result)?;
 			return Ok(SimplificationStatus::Subsumed);
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/bool_array_element.rs
+++ b/crates/huub/src/constraints/bool_array_element.rs
@@ -7,7 +7,7 @@ use std::iter::once;
 use pindakaas::ClauseDatabaseTools;
 
 use crate::{
-	actions::{ReformulationActions, SimplificationActions},
+	actions::{ConstraintInitActions, ReformulationActions, SimplificationActions},
 	constraints::{Constraint, SimplificationStatus},
 	reformulate::ReformulationError,
 	solver::IntLitMeaning,
@@ -31,6 +31,14 @@ pub struct BoolDecisionArrayElement {
 }
 
 impl<S: SimplificationActions> Constraint<S> for BoolDecisionArrayElement {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		for &b in &self.array {
+			actions.simplify_on_change_bool(b);
+		}
+		actions.simplify_on_change_int(self.index);
+		actions.simplify_on_change_bool(self.result);
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		// Fix the bounds of the index is to the length of the array
 		actions.set_int_lower_bound(self.index, 0)?;

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -118,7 +118,7 @@ impl<S: SimplificationActions> Constraint<S> for Cumulative {
 			return Err(ReformulationError::TrivialUnsatisfiable);
 		}
 		// Reformulate the cumulative constraint into a propagator
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -9,8 +9,8 @@ use tracing::trace;
 
 use crate::{
 	actions::{
-		ExplanationActions, InspectionActions, PropagatorInitActions, ReformulationActions,
-		SimplificationActions,
+		ConstraintInitActions, ExplanationActions, InspectionActions, PropagatorInitActions,
+		ReformulationActions, SimplificationActions,
 	},
 	constraints::{
 		Conflict, Constraint, PropagationActions, Propagator, ReasonBuilder, SimplificationStatus,
@@ -79,6 +79,18 @@ pub struct CumulativeTimeTablePropagator {
 }
 
 impl<S: SimplificationActions> Constraint<S> for Cumulative {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		for &i in self
+			.start_times
+			.iter()
+			.chain(&self.durations)
+			.chain(&self.usages)
+		{
+			actions.simplify_on_change_int(i);
+		}
+		actions.simplify_on_change_int(self.capacity);
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		// Check if the cumulative constraint is trivially unsatisfiable
 		let mut earliest_start = IntVal::MAX;

--- a/crates/huub/src/constraints/disjunctive_strict.rs
+++ b/crates/huub/src/constraints/disjunctive_strict.rs
@@ -7,8 +7,8 @@ use tracing::trace;
 
 use crate::{
 	actions::{
-		ExplanationActions, InspectionActions, PropagatorInitActions, ReformulationActions,
-		SimplificationActions,
+		ConstraintInitActions, ExplanationActions, InspectionActions, PropagatorInitActions,
+		ReformulationActions, SimplificationActions,
 	},
 	constraints::{
 		Conflict, Constraint, PropagationActions, Propagator, ReasonBuilder, SimplificationStatus,
@@ -221,6 +221,12 @@ impl DisjunctiveStrict {
 }
 
 impl<S: SimplificationActions> Constraint<S> for DisjunctiveStrict {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		for &i in &self.start_times {
+			actions.simplify_on_change_int(i);
+		}
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		// return TrivialUnsatisfiable if overload is detected
 		let (earliest_start, latest_completion) =

--- a/crates/huub/src/constraints/disjunctive_strict.rs
+++ b/crates/huub/src/constraints/disjunctive_strict.rs
@@ -249,7 +249,7 @@ impl<S: SimplificationActions> Constraint<S> for DisjunctiveStrict {
 		if earliest_start + total_duration > latest_completion {
 			return Err(ReformulationError::TrivialUnsatisfiable);
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_abs.rs
+++ b/crates/huub/src/constraints/int_abs.rs
@@ -63,7 +63,7 @@ impl<S: SimplificationActions> Constraint<S> for IntAbs {
 			return Ok(SimplificationStatus::Subsumed);
 		}
 
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_all_different.rs
+++ b/crates/huub/src/constraints/int_all_different.rs
@@ -151,12 +151,12 @@ impl<S: SimplificationActions> Constraint<S> for IntAllDifferent {
 			return Ok(SimplificationStatus::Subsumed);
 		}
 		if vals.is_empty() {
-			return Ok(SimplificationStatus::Fixpoint);
+			return Ok(SimplificationStatus::NoFixpoint);
 		}
 		for &v in &self.vars {
 			actions.set_int_not_in_set(v, &neg_dom)?;
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_all_different.rs
+++ b/crates/huub/src/constraints/int_all_different.rs
@@ -128,6 +128,12 @@ impl IntAllDifferent {
 }
 
 impl<S: SimplificationActions> Constraint<S> for IntAllDifferent {
+	fn initialize(&self, actions: &mut dyn crate::actions::ConstraintInitActions) {
+		for &var in &self.vars {
+			actions.simplify_on_change_int(var);
+		}
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		let (vals, vars): (Vec<_>, Vec<_>) = self.vars.iter().partition_map(|&var| {
 			if let Some(val) = actions.get_int_val(var) {

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -104,7 +104,7 @@ impl<S: SimplificationActions> Constraint<S> for IntDecisionArrayElement {
 		if max_ub < actions.get_int_upper_bound(self.result) {
 			actions.set_int_upper_bound(self.result, max_ub)?;
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {
@@ -353,7 +353,7 @@ impl<S: SimplificationActions> Constraint<S> for IntValArrayElement {
 			actions.set_int_val(self.result, self.array[idx as usize])?;
 			return Ok(SimplificationStatus::Subsumed);
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -339,6 +339,11 @@ where
 }
 
 impl<S: SimplificationActions> Constraint<S> for IntValArrayElement {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		actions.simplify_on_change_int(self.result);
+		actions.simplify_on_change_int(self.index);
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		// Fix the bounds of the index is to the length of the array
 		actions.set_int_lower_bound(self.index, 0)?;

--- a/crates/huub/src/constraints/int_array_minimum.rs
+++ b/crates/huub/src/constraints/int_array_minimum.rs
@@ -64,7 +64,7 @@ impl<S: SimplificationActions> Constraint<S> for IntArrayMinimum {
 		for &v in &self.vars {
 			actions.set_int_lower_bound(v, lb)?;
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_div.rs
+++ b/crates/huub/src/constraints/int_div.rs
@@ -59,7 +59,7 @@ impl<S: SimplificationActions> Constraint<S> for IntDiv {
 
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		actions.set_int_not_eq(self.denominator, 0)?;
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_div.rs
+++ b/crates/huub/src/constraints/int_div.rs
@@ -8,7 +8,8 @@ use pindakaas::ClauseDatabaseTools;
 
 use crate::{
 	actions::{
-		ExplanationActions, PropagatorInitActions, ReformulationActions, SimplificationActions,
+		ConstraintInitActions, ExplanationActions, PropagatorInitActions, ReformulationActions,
+		SimplificationActions,
 	},
 	constraints::{Conflict, Constraint, PropagationActions, Propagator, SimplificationStatus},
 	helpers::div_ceil,
@@ -50,6 +51,12 @@ pub struct IntDivBounds {
 }
 
 impl<S: SimplificationActions> Constraint<S> for IntDiv {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		actions.simplify_on_change_int(self.numerator);
+		actions.simplify_on_change_int(self.denominator);
+		actions.simplify_on_change_int(self.result);
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		actions.set_int_not_eq(self.denominator, 0)?;
 		Ok(SimplificationStatus::Fixpoint)

--- a/crates/huub/src/constraints/int_in_set.rs
+++ b/crates/huub/src/constraints/int_in_set.rs
@@ -42,7 +42,7 @@ impl<S: SimplificationActions> Constraint<S> for IntInSetReif {
 				actions.set_int_not_in_set(self.var, &self.set)?;
 				Ok(SimplificationStatus::Subsumed)
 			}
-			None => Ok(SimplificationStatus::Fixpoint),
+			None => Ok(SimplificationStatus::NoFixpoint),
 		}
 	}
 

--- a/crates/huub/src/constraints/int_in_set.rs
+++ b/crates/huub/src/constraints/int_in_set.rs
@@ -4,6 +4,7 @@
 //! `true`.
 
 use pindakaas::propositional_logic::Formula;
+use rangelist::IntervalIterator;
 
 use crate::{
 	actions::{ConstraintInitActions, ReformulationActions, SimplificationActions},
@@ -29,21 +30,56 @@ pub struct IntInSetReif {
 
 impl<S: SimplificationActions> Constraint<S> for IntInSetReif {
 	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		actions.simplify_on_change_int(self.var);
 		actions.simplify_on_change_bool(self.reif);
 	}
 
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
+		// Check whether `reif` is set, then just enforce the domain.
 		match actions.get_bool_val(self.reif) {
 			Some(true) => {
 				actions.set_int_in_set(self.var, &self.set)?;
-				Ok(SimplificationStatus::Subsumed)
+				return Ok(SimplificationStatus::Subsumed);
 			}
 			Some(false) => {
 				actions.set_int_not_in_set(self.var, &self.set)?;
-				Ok(SimplificationStatus::Subsumed)
+				return Ok(SimplificationStatus::Subsumed);
 			}
-			None => Ok(SimplificationStatus::NoFixpoint),
+			None => {}
 		}
+		// Compute the overlap between the set and the domain of `var`.
+		let domain = actions.get_int_domain(self.var);
+		self.set = self.set.intersect(&domain);
+		// If the intersection is empty, then `reif` must be false.
+		if self.set.is_empty() {
+			actions.set_bool(!self.reif)?;
+			return Ok(SimplificationStatus::Subsumed);
+		}
+		// If `set` is a superset of domain, then it is known that `reif` is true.
+		// (After intersection, we can just check equality)
+		if domain == self.set {
+			actions.set_bool(self.reif)?;
+			return Ok(SimplificationStatus::Subsumed);
+		}
+		// Otherwise, we check whether we can rewrite the constraint into a simpler
+		// form.
+		if self.set.intervals().len() == 1 {
+			let lb = self.set.lower_bound().unwrap();
+			let ub = self.set.upper_bound().unwrap();
+			if lb == ub {
+				actions.unify_bool(self.reif, self.var.eq(*lb))?;
+				return Ok(SimplificationStatus::Subsumed);
+			}
+			if lb == domain.lower_bound().unwrap() {
+				actions.unify_bool(self.reif, self.var.leq(*ub))?;
+				return Ok(SimplificationStatus::Subsumed);
+			}
+			if ub == domain.upper_bound().unwrap() {
+				actions.unify_bool(self.reif, self.var.geq(*lb))?;
+				return Ok(SimplificationStatus::Subsumed);
+			}
+		}
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -153,7 +153,7 @@ impl<S: SimplificationActions> Constraint<S> for IntEq {
 		if ub_1 <= ub_0 {
 			actions.set_int_upper_bound(self.vars[0], ub_1)?;
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, actions: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {
@@ -347,7 +347,7 @@ impl<S: SimplificationActions> Constraint<S> for IntLinear {
 			};
 		} else if self.operator == LinOperator::NotEqual {
 			// No further bounds propagation possible
-			return Ok(SimplificationStatus::Fixpoint);
+			return Ok(SimplificationStatus::NoFixpoint);
 		}
 
 		// The difference between the right-hand-side value and the sum of the lower
@@ -389,7 +389,7 @@ impl<S: SimplificationActions> Constraint<S> for IntLinear {
 				}
 			}
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -10,7 +10,9 @@ use pindakaas::{
 };
 
 use crate::{
-	actions::{PropagatorInitActions, ReformulationActions, SimplificationActions},
+	actions::{
+		ConstraintInitActions, PropagatorInitActions, ReformulationActions, SimplificationActions,
+	},
 	constraints::{
 		Conflict, Constraint, ExplanationActions, PropagationActions, Propagator, ReasonBuilder,
 		SimplificationStatus,
@@ -121,6 +123,12 @@ pub(crate) enum Reification {
 }
 
 impl<S: SimplificationActions> Constraint<S> for IntEq {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		for &var in &self.vars {
+			actions.simplify_on_change_int(var);
+		}
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		let (lb_0, ub_0) = actions.get_int_bounds(self.vars[0]);
 		let (lb_1, ub_1) = actions.get_int_bounds(self.vars[1]);
@@ -214,8 +222,17 @@ impl IntLinear {
 }
 
 impl<S: SimplificationActions> Constraint<S> for IntLinear {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		for &v in &self.terms {
+			actions.simplify_on_change_int(v);
+		}
+		if let Some(Reification::ImpliedBy(r) | Reification::ReifiedBy(r)) = self.reif {
+			actions.simplify_on_change_bool(r);
+		}
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
-		// If the reification of the constriant is known, simplify to non-reified
+		// If the reification of the constraint is known, simplify to non-reified
 		// version
 		if let Some(Reification::ImpliedBy(r) | Reification::ReifiedBy(r)) = self.reif {
 			match actions.get_bool_val(r) {

--- a/crates/huub/src/constraints/int_pow.rs
+++ b/crates/huub/src/constraints/int_pow.rs
@@ -6,7 +6,8 @@ use pindakaas::ClauseDatabaseTools;
 
 use crate::{
 	actions::{
-		ExplanationActions, PropagatorInitActions, ReformulationActions, SimplificationActions,
+		ConstraintInitActions, ExplanationActions, PropagatorInitActions, ReformulationActions,
+		SimplificationActions,
 	},
 	constraints::{CachedReason, Conflict, Constraint, PropagationActions, Propagator},
 	reformulate::ReformulationError,
@@ -68,6 +69,12 @@ fn pow(base: IntVal, exponent: IntVal) -> Option<IntVal> {
 }
 
 impl<S: SimplificationActions> Constraint<S> for IntPow {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		actions.simplify_on_change_int(self.base);
+		actions.simplify_on_change_int(self.exponent);
+		actions.simplify_on_change_int(self.result);
+	}
+
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {
 		let base = slv.get_solver_int(self.base);
 		let exponent = slv.get_solver_int(self.exponent);

--- a/crates/huub/src/constraints/int_table.rs
+++ b/crates/huub/src/constraints/int_table.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use pindakaas::ClauseDatabaseTools;
 
 use crate::{
-	actions::{ReformulationActions, SimplificationActions},
+	actions::{ConstraintInitActions, ReformulationActions, SimplificationActions},
 	constraints::{Constraint, SimplificationStatus},
 	reformulate::ReformulationError,
 	solver::{BoolView, IntLitMeaning},
@@ -26,6 +26,12 @@ pub struct IntTable {
 }
 
 impl<S: SimplificationActions> Constraint<S> for IntTable {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		for var in &self.vars {
+			actions.simplify_on_change_int(*var);
+		}
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		match self.vars.len() {
 			0 => return Ok(SimplificationStatus::Subsumed),

--- a/crates/huub/src/constraints/int_table.rs
+++ b/crates/huub/src/constraints/int_table.rs
@@ -75,7 +75,7 @@ impl<S: SimplificationActions> Constraint<S> for IntTable {
 				.collect();
 			actions.set_int_in_set(var, &dom)?;
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_times.rs
+++ b/crates/huub/src/constraints/int_times.rs
@@ -4,7 +4,8 @@
 
 use crate::{
 	actions::{
-		ExplanationActions, PropagatorInitActions, ReformulationActions, SimplificationActions,
+		ConstraintInitActions, ExplanationActions, PropagatorInitActions, ReformulationActions,
+		SimplificationActions,
 	},
 	constraints::{
 		CachedReason, Conflict, Constraint, PropagationActions, Propagator, SimplificationStatus,
@@ -41,6 +42,12 @@ pub struct IntTimesBounds {
 }
 
 impl<S: SimplificationActions> Constraint<S> for IntTimes {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		actions.simplify_on_change_int(self.factor1);
+		actions.simplify_on_change_int(self.factor2);
+		actions.simplify_on_change_int(self.product);
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		let (f1_lb, f1_ub) = actions.get_int_bounds(self.factor1);
 		let (f2_lb, f2_ub) = actions.get_int_bounds(self.factor2);

--- a/crates/huub/src/constraints/int_times.rs
+++ b/crates/huub/src/constraints/int_times.rs
@@ -112,7 +112,7 @@ impl<S: SimplificationActions> Constraint<S> for IntTimes {
 				.unwrap();
 			actions.set_int_upper_bound(self.factor2, max)?;
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_value_precede.rs
+++ b/crates/huub/src/constraints/int_value_precede.rs
@@ -117,7 +117,7 @@ impl<S: SimplificationActions> Constraint<S> for IntSeqPrecedeChain {
 		if self.vars.is_empty() {
 			return Ok(SimplificationStatus::Subsumed);
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {
@@ -467,7 +467,7 @@ impl<S: SimplificationActions> Constraint<S> for IntValuePrecedeChain {
 		if self.vars.is_empty() {
 			return Ok(SimplificationStatus::Subsumed);
 		}
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {

--- a/crates/huub/src/constraints/int_value_precede.rs
+++ b/crates/huub/src/constraints/int_value_precede.rs
@@ -6,8 +6,8 @@ use std::cmp::{max, min};
 
 use crate::{
 	actions::{
-		ExplanationActions, InspectionActions, PropagatorInitActions, ReformulationActions,
-		SimplificationActions,
+		ConstraintInitActions, ExplanationActions, InspectionActions, PropagatorInitActions,
+		ReformulationActions, SimplificationActions,
 	},
 	constraints::{Conflict, Constraint, PropagationActions, Propagator, SimplificationStatus},
 	reformulate::ReformulationError,
@@ -97,6 +97,12 @@ pub struct IntValuePrecedeChainValue {
 }
 
 impl<S: SimplificationActions> Constraint<S> for IntSeqPrecedeChain {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		for &v in self.vars.iter() {
+			actions.simplify_on_change_int(v);
+		}
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		let mut ub = 0;
 		for &v in self.vars.iter() {
@@ -431,6 +437,12 @@ where
 }
 
 impl<S: SimplificationActions> Constraint<S> for IntValuePrecedeChain {
+	fn initialize(&self, actions: &mut dyn ConstraintInitActions) {
+		for &v in self.vars.iter() {
+			actions.simplify_on_change_int(v);
+		}
+	}
+
 	fn simplify(&mut self, actions: &mut S) -> Result<SimplificationStatus, ReformulationError> {
 		if self.values.len() <= 1 {
 			return Ok(SimplificationStatus::Subsumed);

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -1059,7 +1059,7 @@ impl Model {
 			SimplificationStatus::Subsumed => {
 				// Constraint is known to be satisfied, no need to place back.
 			}
-			SimplificationStatus::Fixpoint => {
+			SimplificationStatus::NoFixpoint => {
 				self.constraints[con] = Some(con_obj);
 			}
 		}
@@ -1208,8 +1208,8 @@ impl Model {
 		}
 
 		while let Some(con) = self.prop_queue.pop_front() {
-			self.propagate(con)?;
 			self.enqueued[con] = false;
+			self.propagate(con)?;
 		}
 
 		// TODO: Detect Views From Model

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -1478,6 +1478,43 @@ impl SimplificationActions for Model {
 		}
 	}
 
+	fn get_int_domain(&self, var: IntDecision) -> IntSetVal {
+		use IntDecisionInner::*;
+
+		let var = var.resolve_alias(self);
+		match var.0 {
+			Var(v) => {
+				let Domain::Domain(dom) = &self.int_vars[v].domain else {
+					unreachable!()
+				};
+				dom.clone()
+			}
+			Const(v) => (v..=v).into(),
+			Linear(t, v) => {
+				let Domain::Domain(dom) = &self.int_vars[v].domain else {
+					unreachable!()
+				};
+				dom.iter()
+					.flatten()
+					.map(|v| {
+						let v = t.transform(v);
+						v..=v
+					})
+					.collect()
+			}
+			Bool(t, bv) => {
+				if let Some(v) = self.get_bool_val(bv) {
+					let v = t.transform(v as IntVal);
+					(v..=v).into()
+				} else {
+					let v0 = t.transform(0);
+					let v1 = t.transform(1);
+					if t.positive_scale() { v0..=v1 } else { v1..=v0 }.into()
+				}
+			}
+		}
+	}
+
 	fn get_int_lower_bound(&self, var: IntDecision) -> IntVal {
 		use IntDecisionInner::*;
 

--- a/crates/huub/src/reformulate.rs
+++ b/crates/huub/src/reformulate.rs
@@ -230,7 +230,7 @@ pub(crate) struct ReformulationMapBuilder {
 
 impl<S: SimplificationActions> Constraint<S> for BoolFormula {
 	fn simplify(&mut self, _: &mut S) -> Result<SimplificationStatus, ReformulationError> {
-		Ok(SimplificationStatus::Fixpoint)
+		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut dyn ReformulationActions) -> Result<(), ReformulationError> {


### PR DESCRIPTION
Allow further simplification of `int_linear` at the modelling layer when integer domain changes