### PR TITLE
feat(huub): static dispatch based on views when posting propagators

### DIFF
--- a/crates/huub/src/actions.rs
+++ b/crates/huub/src/actions.rs
@@ -8,10 +8,11 @@ use std::{
 };
 
 use pindakaas::{AsDynClauseDatabase, ClauseDatabase, Lit as RawLit, Unsatisfiable};
+use rangelist::IntervalIterator;
 
 use crate::{
 	branchers::BoxedBrancher,
-	constraints::{BoxedPropagator, Constraint, LazyReason, ReasonBuilder},
+	constraints::{BoxedPropagator, Conflict, Constraint, LazyReason, ReasonBuilder},
 	reformulate::ReformulationError,
 	solver::{
 		activation_list::IntPropCond, int_var::IntVarRef, queue::PriorityLevel, trail::TrailedInt,
@@ -50,20 +51,17 @@ pub trait BoolOperations: Clone + fmt::Debug + Eq + Hash + Not<Output = Self> + 
 
 /// Actions available to [`Propagator`] and [`Constraint`] implementations in
 /// [`ReasoningEngine::PropagationCtx`] for Boolean decision variables.
-pub trait BoolPropagationActions<Context>: BoolInspectionActions<Context> {
-	/// Type used to represent an atom in an reason for propagation.
-	type Atom: BoolOperations + From<Self>;
-
-	/// Type used to represent a conflict that occurs during propagation.
-	type Conflict;
-
+pub trait BoolPropagationActions<Context>: BoolInspectionActions<Context>
+where
+	Context: ReasoningContext + ?Sized,
+{
 	/// Enforce that the value of a Boolean decision variable is to be `true`,
 	/// because of the given reason.
 	fn set(
 		&self,
 		ctx: &mut Context,
-		reason: impl ReasonBuilder<Context, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<Context, Context::Atom>,
+	) -> Result<(), Context::Conflict> {
 		self.set_val(ctx, true, reason)
 	}
 
@@ -73,8 +71,8 @@ pub trait BoolPropagationActions<Context>: BoolInspectionActions<Context> {
 		&self,
 		ctx: &mut Context,
 		val: bool,
-		reason: impl ReasonBuilder<Context, Self::Atom>,
-	) -> Result<(), Self::Conflict>;
+		reason: impl ReasonBuilder<Context, Context::Atom>,
+	) -> Result<(), Context::Conflict>;
 }
 
 /// Actions available to [`Constraint`] implementations in
@@ -83,6 +81,8 @@ pub trait BoolPropagationActions<Context>: BoolInspectionActions<Context> {
 /// Generally these actions are used in [`Constraint::simplify`].
 pub trait BoolSimplificationActions<Context>:
 	BoolPropagationActions<Context> + Into<BoolDecision>
+where
+	Context: ReasoningContext + ?Sized,
 {
 	/// Mark `self` as being equivalent to `other`, instructing the reasoning
 	/// engine to use the same representation.
@@ -90,7 +90,7 @@ pub trait BoolSimplificationActions<Context>:
 		&self,
 		ctx: &mut Context,
 		other: impl Into<BoolDecision>,
-	) -> Result<(), Self::Conflict>;
+	) -> Result<(), Context::Conflict>;
 }
 
 /// Actions that can be performed during the initialization of branchers.
@@ -140,14 +140,17 @@ pub trait InitActions {
 ///
 /// These actions are also available to [`Propagator`] and [`Constraint`]
 /// implementations in [`Reasoning::PropagationCtx`]
-pub trait IntDecisionActions<Context: ?Sized>: IntInspectionActions<Context> {
+pub trait IntDecisionActions<Context>: IntInspectionActions<Context>
+where
+	Context: ReasoningContext + ?Sized,
+{
 	/// Get (or create) a literal for the given referenced integer variable with
 	/// the given meaning.
-	fn lit(&self, ctx: &mut Context, meaning: IntLitMeaning) -> Self::Atom;
+	fn lit(&self, ctx: &mut Context, meaning: IntLitMeaning) -> Context::Atom;
 
 	/// Get the Boolean view that represents the current assignment of the
 	/// integer view, or `None` if the integer view is not assigned.
-	fn val_lit(&self, ctx: &mut Context) -> Option<Self::Atom> {
+	fn val_lit(&self, ctx: &mut Context) -> Option<Context::Atom> {
 		let val = self.val(ctx)?;
 		Some(self.lit(ctx, IntLitMeaning::Eq(val)))
 	}
@@ -155,16 +158,19 @@ pub trait IntDecisionActions<Context: ?Sized>: IntInspectionActions<Context> {
 
 /// Actions available to [`Propagator`] implementations in
 /// [`Reasoning::ExplanationCtx`] for integer decision variables.
-pub trait IntExplanationActions<Context: ?Sized>: IntInspectionActions<Context> {
+pub trait IntExplanationActions<Context>: IntInspectionActions<Context>
+where
+	Context: ReasoningContext + ?Sized,
+{
 	/// Get a Boolean view that represents the given meaning (that is currently
 	/// `true`) on the integer view, or a relaxation if the literal does not yet
 	/// exist.
-	fn lit_relaxed(&self, ctx: &Context, meaning: IntLitMeaning) -> (Self::Atom, IntLitMeaning);
+	fn lit_relaxed(&self, ctx: &Context, meaning: IntLitMeaning) -> (Context::Atom, IntLitMeaning);
 
 	/// Get the Boolean view that represents the current assignment of the
 	/// integer view, or `None` if the integer view is not assigned or if the
 	/// equality literal does not exist.
-	fn try_val_lit(&self, ctx: &Context) -> Option<Self::Atom> {
+	fn try_val_lit(&self, ctx: &Context) -> Option<Context::Atom> {
 		let val = self.val(ctx)?;
 		self.try_lit(ctx, IntLitMeaning::Eq(val))
 	}
@@ -172,7 +178,10 @@ pub trait IntExplanationActions<Context: ?Sized>: IntInspectionActions<Context> 
 
 /// Actions available to [`Propagator`] implementations in
 /// [`ReasoningEngine::PostingCtx`] for Boolean decision variables.
-pub trait IntInitActions<Context>: IntInspectionActions<Context> {
+pub trait IntInitActions<Context>: IntInspectionActions<Context>
+where
+	Context: ReasoningContext + ?Sized,
+{
 	/// Advise the propagator when [`self`] is changed according to the given
 	/// propagation condition, allowing the propagator to decide whether to
 	/// enqueue itself.
@@ -190,15 +199,13 @@ pub trait IntInitActions<Context>: IntInspectionActions<Context> {
 
 /// Actions available to [`Propagator`] and [`Constraint`] implementations in
 /// all contexts for integer decision variables.
-pub trait IntInspectionActions<Context: ?Sized>: IntOperations {
-	/// Type used to represent an atom in an reason for propagation.
-	type Atom: BoolOperations;
-
+pub trait IntInspectionActions<Context>: IntOperations
+where
+	Context: ReasoningContext + ?Sized,
+{
 	/// Convenience method to get both the lower and upper bounds of an integer
 	/// view.
-	fn bounds(&self, ctx: &Context) -> (IntVal, IntVal) {
-		(self.lower_bound(ctx), self.upper_bound(ctx))
-	}
+	fn bounds(&self, ctx: &Context) -> (IntVal, IntVal);
 	/// Get the set of values from which the integer view is guaranteed to take
 	/// a value (given the current search decisions).
 	fn domain(&self, ctx: &Context) -> IntSetVal;
@@ -209,7 +216,7 @@ pub trait IntInspectionActions<Context: ?Sized>: IntOperations {
 
 	/// Get the meaning of the given literal with respect to the given integer
 	/// view, or `None` it has no direct meaning.
-	fn lit_meaning(&self, ctx: &Context, lit: Self::Atom) -> Option<IntLitMeaning>;
+	fn lit_meaning(&self, ctx: &Context, lit: Context::Atom) -> Option<IntLitMeaning>;
 
 	/// Get the minimum value that an integer view is guaranteed to take (given
 	/// the current search decisions).
@@ -217,11 +224,11 @@ pub trait IntInspectionActions<Context: ?Sized>: IntOperations {
 
 	/// Get the Boolean view that represents that the integer view will take a
 	/// value greater or equal to its current lower bound.
-	fn lower_bound_lit(&self, ctx: &Context) -> Self::Atom;
+	fn lower_bound_lit(&self, ctx: &Context) -> Context::Atom;
 
 	/// Get a Boolean view that represents the given meaning on the integer
 	/// view, if it already exists.
-	fn try_lit(&self, ctx: &Context, meaning: IntLitMeaning) -> Option<Self::Atom>;
+	fn try_lit(&self, ctx: &Context, meaning: IntLitMeaning) -> Option<Context::Atom>;
 
 	/// Get the maximum value that an integer view is guaranteed to take (given
 	/// the current search decisions).
@@ -229,18 +236,11 @@ pub trait IntInspectionActions<Context: ?Sized>: IntOperations {
 
 	/// Get the Boolean view that represents that the integer view will take a
 	/// value less or equal to its current upper bound.
-	fn upper_bound_lit(&self, ctx: &Context) -> Self::Atom;
+	fn upper_bound_lit(&self, ctx: &Context) -> Context::Atom;
 
 	/// Get the current value of an integer view, if it has been assigned (given
 	/// the current search decisions).
-	fn val(&self, ctx: &Context) -> Option<IntVal> {
-		let (lb, ub) = self.bounds(ctx);
-		if lb == ub {
-			Some(lb)
-		} else {
-			None
-		}
-	}
+	fn val(&self, ctx: &Context) -> Option<IntVal>;
 }
 
 /// Operations that are required to be possible to perform on types acting as
@@ -249,18 +249,18 @@ pub trait IntOperations: Clone + fmt::Debug + Eq + Hash + 'static {}
 
 /// Actions available to [`Propagator`] and [`Constraint`] implementations in
 /// [`ReasoningEngine::PropagationCtx`] for integer decision variables.
-pub trait IntPropagationActions<Context: ?Sized>: IntDecisionActions<Context> {
-	/// Type used to represent a conflict that occurs during propagation.
-	type Conflict;
-
+pub trait IntPropagationActions<Context>: IntDecisionActions<Context>
+where
+	Context: ReasoningContext + ?Sized,
+{
 	/// Enforce that a an integer view takes a value that is greater or equal to
 	/// `val` because of the given `reason`.
 	fn set_lower_bound(
 		&self,
 		ctx: &mut Context,
 		val: IntVal,
-		reason: impl ReasonBuilder<Context, Self::Atom>,
-	) -> Result<(), Self::Conflict>;
+		reason: impl ReasonBuilder<Context, Context::Atom>,
+	) -> Result<(), Context::Conflict>;
 
 	/// Enforce that a an integer view cannot take a value `val` because of the
 	/// given `reason`.
@@ -268,8 +268,8 @@ pub trait IntPropagationActions<Context: ?Sized>: IntDecisionActions<Context> {
 		&self,
 		ctx: &mut Context,
 		val: IntVal,
-		reason: impl ReasonBuilder<Context, Self::Atom>,
-	) -> Result<(), Self::Conflict>;
+		reason: impl ReasonBuilder<Context, Context::Atom>,
+	) -> Result<(), Context::Conflict>;
 
 	/// Enforce that a an integer view takes a value that is less or equal to
 	/// `val` because of the given `reason`.
@@ -277,8 +277,8 @@ pub trait IntPropagationActions<Context: ?Sized>: IntDecisionActions<Context> {
 		&self,
 		ctx: &mut Context,
 		val: IntVal,
-		reason: impl ReasonBuilder<Context, Self::Atom>,
-	) -> Result<(), Self::Conflict>;
+		reason: impl ReasonBuilder<Context, Context::Atom>,
+	) -> Result<(), Context::Conflict>;
 
 	/// Enforce that a an integer view takes a value `val` because of the given
 	/// `reason`.
@@ -286,23 +286,26 @@ pub trait IntPropagationActions<Context: ?Sized>: IntDecisionActions<Context> {
 		&self,
 		ctx: &mut Context,
 		val: IntVal,
-		reason: impl ReasonBuilder<Context, Self::Atom>,
-	) -> Result<(), Self::Conflict>;
+		reason: impl ReasonBuilder<Context, Context::Atom>,
+	) -> Result<(), Context::Conflict>;
 }
 
 /// Actions available to [`Constraint`] implementations in
 /// [`ReasoningEngine::PropagationCtx`] for integer decision variables.
 ///
 /// Generally these actions are used in [`Constraint::simplify`].
-pub trait IntSimplificationActions<Context: ?Sized>: IntPropagationActions<Context> {
+pub trait IntSimplificationActions<Context>: IntPropagationActions<Context>
+where
+	Context: ReasoningContext + ?Sized,
+{
 	/// Enforce that the given integer expression takes a value in in the given
 	/// set.
 	fn set_domain(
 		&self,
 		ctx: &mut Context,
 		domain: &IntSetVal,
-		reason: impl ReasonBuilder<Context, Self::Atom>,
-	) -> Result<(), Self::Conflict>;
+		reason: impl ReasonBuilder<Context, Context::Atom>,
+	) -> Result<(), Context::Conflict>;
 
 	/// Enforce that a given integer expression cannot take any of the values in
 	/// the given set.
@@ -310,21 +313,16 @@ pub trait IntSimplificationActions<Context: ?Sized>: IntPropagationActions<Conte
 		&self,
 		ctx: &mut Context,
 		values: &IntSetVal,
-		reason: impl ReasonBuilder<Context, Self::Atom>,
-	) -> Result<(), Self::Conflict>;
+		reason: impl ReasonBuilder<Context, Context::Atom>,
+	) -> Result<(), Context::Conflict>;
 
 	/// Mark two integer decisions as being equivalent, ensuring the two use the
 	/// same internal representation.
-	fn unify(&self, ctx: &mut Context, other: impl Into<Self>) -> Result<(), Self::Conflict>;
+	fn unify(&self, ctx: &mut Context, other: impl Into<Self>) -> Result<(), Context::Conflict>;
 }
 
 /// General actions that can be performed in [`ReasoningEngine::PropagationCtx`]
-pub trait PropagationActions: DecisionActions {
-	/// Type used to represent an atom in an reason for propagation.
-	type Atom: BoolOperations;
-	/// Type used to represent a conflict that occurs during propagation.
-	type Conflict;
-
+pub trait PropagationActions: DecisionActions + ReasoningContext {
 	/// Declare that given reason (seen as a conjunction of atoms) is represents
 	/// a conflict in the current state (requiring backtracking).
 	///
@@ -338,6 +336,13 @@ pub trait PropagationActions: DecisionActions {
 	fn deferred_reason(&self, data: u64) -> LazyReason;
 }
 
+pub trait ReasoningContext {
+	/// Type used to represent an atom in an reason for propagation.
+	type Atom: BoolOperations;
+	/// Type used to represent a conflict that occurs during propagation.
+	type Conflict;
+}
+
 /// Trait for environments that support constraint propagation and decision
 /// variable pruning to simplify the current problem state.
 pub trait ReasoningEngine {
@@ -349,16 +354,20 @@ pub trait ReasoningEngine {
 	/// The context given to the constraint propagator when they are asked to
 	/// explain a reason for a change they made using
 	/// [`PropagationActions::deferred_reason`].
-	type ExplanationCtx<'a>: TrailingActions;
+	type ExplanationCtx<'a>: ReasoningContext<Atom = Self::Atom, Conflict = Self::Conflict>
+		+ TrailingActions;
 	/// The context given to constraint propagators to attach themselves to
 	/// changes in the state of the reasoning engine or decision variables.
-	type InitializationCtx<'a>: InitActions;
+	type InitializationCtx<'a>: ReasoningContext<Atom = Self::Atom, Conflict = Self::Conflict>
+		+ InitActions;
 	/// The context given to constraint propagators when they are advised of a
 	/// change in the state of the reasoning engine or decision variables.
-	type NotificationCtx<'a>: TrailingActions;
+	type NotificationCtx<'a>: ReasoningContext<Atom = Self::Atom, Conflict = Self::Conflict>
+		+ TrailingActions;
 	/// The context given to constraint propagators when they are asked to
 	/// propagate changes based on the constraint they enforce.
-	type PropagationCtx<'a>: PropagationActions<Atom = Self::Atom, Conflict = Self::Conflict>;
+	type PropagationCtx<'a>: ReasoningContext<Atom = Self::Atom, Conflict = Self::Conflict>
+		+ PropagationActions<Atom = Self::Atom, Conflict = Self::Conflict>;
 }
 
 /// Actions that can be performed when reformulating a [`Model`] object into a
@@ -446,15 +455,18 @@ pub trait TrailingActions {
 	fn trailed_int(&self, i: TrailedInt) -> IntVal;
 }
 
+impl ReasoningContext for dyn ReformulationActions + '_ {
+	type Atom = BoolView;
+	type Conflict = Conflict<RawLit>;
+}
+
 impl IntDecisionActions<dyn ReformulationActions + '_> for IntVarRef {
-	fn lit(&self, ctx: &mut (dyn ReformulationActions + '_), meaning: IntLitMeaning) -> Self::Atom {
+	fn lit(&self, ctx: &mut (dyn ReformulationActions + '_), meaning: IntLitMeaning) -> BoolView {
 		ctx.int_lit(*self, meaning)
 	}
 }
 
 impl IntInspectionActions<dyn ReformulationActions + '_> for IntVarRef {
-	type Atom = BoolView;
-
 	fn domain(&self, ctx: &dyn ReformulationActions) -> IntSetVal {
 		ctx.int_domain(*self)
 	}
@@ -463,11 +475,7 @@ impl IntInspectionActions<dyn ReformulationActions + '_> for IntVarRef {
 		ctx.check_int_in_domain(*self, val)
 	}
 
-	fn lit_meaning(
-		&self,
-		ctx: &dyn ReformulationActions,
-		lit: Self::Atom,
-	) -> Option<IntLitMeaning> {
+	fn lit_meaning(&self, ctx: &dyn ReformulationActions, lit: BoolView) -> Option<IntLitMeaning> {
 		ctx.int_lit_meaning(*self, lit)
 	}
 
@@ -475,15 +483,11 @@ impl IntInspectionActions<dyn ReformulationActions + '_> for IntVarRef {
 		ctx.int_lower_bound(*self)
 	}
 
-	fn lower_bound_lit(&self, ctx: &dyn ReformulationActions) -> Self::Atom {
+	fn lower_bound_lit(&self, ctx: &dyn ReformulationActions) -> BoolView {
 		ctx.int_lower_bound_lit(*self)
 	}
 
-	fn try_lit(
-		&self,
-		ctx: &dyn ReformulationActions,
-		meaning: IntLitMeaning,
-	) -> Option<Self::Atom> {
+	fn try_lit(&self, ctx: &dyn ReformulationActions, meaning: IntLitMeaning) -> Option<BoolView> {
 		ctx.try_int_lit(*self, meaning)
 	}
 
@@ -491,8 +495,23 @@ impl IntInspectionActions<dyn ReformulationActions + '_> for IntVarRef {
 		ctx.int_upper_bound(*self)
 	}
 
-	fn upper_bound_lit(&self, ctx: &dyn ReformulationActions) -> Self::Atom {
+	fn upper_bound_lit(&self, ctx: &dyn ReformulationActions) -> BoolView {
 		ctx.int_upper_bound_lit(*self)
+	}
+
+	fn bounds(&self, ctx: &dyn ReformulationActions) -> (IntVal, IntVal) {
+		let lb = self.lower_bound(ctx);
+		let ub = self.upper_bound(ctx);
+		(lb, ub)
+	}
+
+	fn val(&self, ctx: &dyn ReformulationActions) -> Option<IntVal> {
+		let (lb, ub) = self.bounds(ctx);
+		if lb == ub {
+			Some(lb)
+		} else {
+			None
+		}
 	}
 }
 
@@ -520,9 +539,185 @@ impl ClauseDatabase for ReformulationClauseDatabaseWrapper<'_> {
 impl<T> BoolOperations for T where T: Clone + fmt::Debug + Eq + Hash + Not<Output = Self> + 'static {}
 impl<T> IntOperations for T where T: Clone + fmt::Debug + Eq + Hash + 'static {}
 
-impl<C> BoolInspectionActions<C> for bool {
-	fn val(&self, _: &C) -> Option<bool> {
+impl<Ctx> BoolInspectionActions<Ctx> for bool {
+	fn val(&self, _: &Ctx) -> Option<bool> {
 		Some(*self)
+	}
+}
+
+impl<Ctx> IntInspectionActions<Ctx> for IntVal
+where
+	Ctx: ReasoningContext + ?Sized,
+	Ctx::Atom: From<bool>,
+{
+	fn domain(&self, _: &Ctx) -> IntSetVal {
+		(*self..=*self).into()
+	}
+
+	fn in_domain(&self, _: &Ctx, val: IntVal) -> bool {
+		*self == val
+	}
+
+	fn lit_meaning(&self, _: &Ctx, _: Ctx::Atom) -> Option<IntLitMeaning> {
+		None
+	}
+
+	fn lower_bound(&self, _: &Ctx) -> IntVal {
+		*self
+	}
+
+	fn lower_bound_lit(&self, _: &Ctx) -> Ctx::Atom {
+		true.into()
+	}
+
+	fn try_lit(&self, _: &Ctx, meaning: IntLitMeaning) -> Option<Ctx::Atom> {
+		Some(
+			match meaning {
+				IntLitMeaning::Eq(v) => *self == v,
+				IntLitMeaning::NotEq(v) => *self != v,
+				IntLitMeaning::GreaterEq(v) => *self >= v,
+				IntLitMeaning::Less(v) => *self < v,
+			}
+			.into(),
+		)
+	}
+
+	fn upper_bound(&self, _: &Ctx) -> IntVal {
+		*self
+	}
+
+	fn upper_bound_lit(&self, _: &Ctx) -> Ctx::Atom {
+		true.into()
+	}
+
+	fn val(&self, _: &Ctx) -> Option<IntVal> {
+		Some(*self)
+	}
+
+	fn bounds(&self, _: &Ctx) -> (IntVal, IntVal) {
+		(*self, *self)
+	}
+}
+
+impl<Ctx> IntDecisionActions<Ctx> for IntVal
+where
+	Ctx: ReasoningContext + ?Sized,
+	Ctx::Atom: From<bool>,
+{
+	fn lit(&self, ctx: &mut Ctx, meaning: IntLitMeaning) -> Ctx::Atom {
+		self.try_lit(ctx, meaning).unwrap()
+	}
+}
+
+impl<Ctx> IntExplanationActions<Ctx> for IntVal
+where
+	Ctx: ReasoningContext + ?Sized,
+	Ctx::Atom: From<bool>,
+{
+	fn lit_relaxed(&self, ctx: &Ctx, meaning: IntLitMeaning) -> (Ctx::Atom, IntLitMeaning) {
+		(self.try_lit(ctx, meaning).unwrap(), meaning)
+	}
+}
+
+impl<Ctx> IntPropagationActions<Ctx> for IntVal
+where
+	Ctx: PropagationActions + ?Sized,
+	Ctx::Atom: From<bool>,
+{
+	fn set_lower_bound(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		if val > *self {
+			Err(ctx.declare_conflict(reason))
+		} else {
+			Ok(())
+		}
+	}
+
+	fn set_not_eq(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		if val == *self {
+			Err(ctx.declare_conflict(reason))
+		} else {
+			Ok(())
+		}
+	}
+
+	fn set_upper_bound(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		if val < *self {
+			Err(ctx.declare_conflict(reason))
+		} else {
+			Ok(())
+		}
+	}
+
+	fn set_val(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		if val != *self {
+			Err(ctx.declare_conflict(reason))
+		} else {
+			Ok(())
+		}
+	}
+}
+
+impl<Ctx> IntSimplificationActions<Ctx> for IntVal
+where
+	Ctx: PropagationActions + ?Sized,
+	Ctx::Atom: From<bool>,
+{
+	fn set_domain(
+		&self,
+		ctx: &mut Ctx,
+		domain: &IntSetVal,
+		reason: impl ReasonBuilder<Ctx, <Ctx as ReasoningContext>::Atom>,
+	) -> Result<(), <Ctx as ReasoningContext>::Conflict> {
+		if !domain.contains(self) {
+			Err(ctx.declare_conflict(reason))
+		} else {
+			Ok(())
+		}
+	}
+
+	fn set_not_in_set(
+		&self,
+		ctx: &mut Ctx,
+		values: &IntSetVal,
+		reason: impl ReasonBuilder<Ctx, <Ctx as ReasoningContext>::Atom>,
+	) -> Result<(), <Ctx as ReasoningContext>::Conflict> {
+		if values.contains(self) {
+			Err(ctx.declare_conflict(reason))
+		} else {
+			Ok(())
+		}
+	}
+
+	fn unify(
+		&self,
+		ctx: &mut Ctx,
+		other: impl Into<Self>,
+	) -> Result<(), <Ctx as ReasoningContext>::Conflict> {
+		if self == &other.into() {
+			Ok(())
+		} else {
+			Err(ctx.declare_conflict([]))
+		}
 	}
 }
 

--- a/crates/huub/src/branchers.rs
+++ b/crates/huub/src/branchers.rs
@@ -7,7 +7,7 @@ use pindakaas::Lit as RawLit;
 use crate::{
 	actions::{
 		BoolInspectionActions, BrancherInitActions, DecisionActions, IntDecisionActions,
-		IntInspectionActions,
+		IntInspectionActions, ReasoningContext,
 	},
 	solver::{
 		solving_context::SolvingContext, trail::TrailedInt, BoolView, BoolViewInner, IntLitMeaning,
@@ -207,9 +207,10 @@ impl IntBrancher {
 	}
 }
 
-impl<D: DecisionActions> Brancher<D> for IntBrancher
+impl<D> Brancher<D> for IntBrancher
 where
-	IntView: IntDecisionActions<D, Atom = BoolView>,
+	D: DecisionActions + ReasoningContext<Atom = BoolView>,
+	IntView: IntDecisionActions<D>,
 {
 	fn decide(&mut self, actions: &mut D) -> Decision {
 		let begin = actions.trailed_int(self.next) as usize;

--- a/crates/huub/src/constraints.rs
+++ b/crates/huub/src/constraints.rs
@@ -114,11 +114,8 @@ pub trait ModelBoolView<E>
 where
 	E: ReasoningEngine,
 	Self: SolverBoolView<E>
-		+ for<'a> BoolSimplificationActions<
-			E::PropagationCtx<'a>,
-			Atom = E::Atom,
-			Conflict = E::Conflict,
-		> + Into<BoolDecision>,
+		+ for<'a> BoolSimplificationActions<E::PropagationCtx<'a>>
+		+ Into<BoolDecision>,
 {
 }
 
@@ -127,11 +124,8 @@ pub trait ModelIntView<E>
 where
 	E: ReasoningEngine,
 	Self: SolverIntView<E>
-		+ for<'a> IntSimplificationActions<
-			E::PropagationCtx<'a>,
-			Atom = E::Atom,
-			Conflict = E::Conflict,
-		> + Into<IntDecision>,
+		+ for<'a> IntSimplificationActions<E::PropagationCtx<'a>>
+		+ Into<IntDecision>,
 {
 }
 
@@ -254,11 +248,8 @@ where
 	Self: for<'a> BoolInitActions<E::InitializationCtx<'a>>
 		+ for<'a> BoolInspectionActions<E::ExplanationCtx<'a>>
 		+ for<'a> BoolInspectionActions<E::NotificationCtx<'a>>
-		+ for<'a> BoolPropagationActions<
-			E::PropagationCtx<'a>,
-			Atom = E::Atom,
-			Conflict = E::Conflict,
-		> + Into<E::Atom>,
+		+ for<'a> BoolPropagationActions<E::PropagationCtx<'a>>
+		+ Into<E::Atom>,
 {
 }
 
@@ -267,14 +258,15 @@ pub trait SolverIntView<E>
 where
 	E: ReasoningEngine + ?Sized,
 	Self: for<'a> IntInitActions<E::InitializationCtx<'a>>
-		+ for<'a> IntExplanationActions<E::ExplanationCtx<'a>, Atom = E::Atom>
-		+ for<'a> IntInspectionActions<E::NotificationCtx<'a>, Atom = E::Atom>
-		+ for<'a> IntPropagationActions<E::PropagationCtx<'a>, Atom = E::Atom, Conflict = E::Conflict>,
+		+ for<'a> IntExplanationActions<E::ExplanationCtx<'a>>
+		+ for<'a> IntInspectionActions<E::NotificationCtx<'a>>
+		+ for<'a> IntPropagationActions<E::PropagationCtx<'a>>,
 {
 }
 
 impl<C, A, const N: usize> ReasonBuilder<C, A> for &[A; N]
 where
+	C: ?Sized,
 	A: Clone,
 {
 	fn build_reason(self, ctx: &mut C) -> Result<Reason<A>, bool> {
@@ -284,6 +276,7 @@ where
 
 impl<C, A> ReasonBuilder<C, A> for &[A]
 where
+	C: ?Sized,
 	A: Clone,
 {
 	fn build_reason(self, _: &mut C) -> Result<Reason<A>, bool> {
@@ -291,7 +284,10 @@ where
 	}
 }
 
-impl<C, A, const N: usize> ReasonBuilder<C, A> for [A; N] {
+impl<C, A, const N: usize> ReasonBuilder<C, A> for [A; N]
+where
+	C: ?Sized,
+{
 	fn build_reason(self, _: &mut C) -> Result<Reason<A>, bool> {
 		Reason::from_iter(self)
 	}
@@ -301,11 +297,8 @@ impl<E, B> ModelBoolView<E> for B
 where
 	E: ReasoningEngine,
 	B: SolverBoolView<E>
-		+ for<'a> BoolSimplificationActions<
-			E::PropagationCtx<'a>,
-			Atom = E::Atom,
-			Conflict = E::Conflict,
-		> + Into<BoolDecision>,
+		+ for<'a> BoolSimplificationActions<E::PropagationCtx<'a>>
+		+ Into<BoolDecision>,
 {
 }
 
@@ -315,11 +308,8 @@ where
 	Self: for<'a> BoolInitActions<E::InitializationCtx<'a>>
 		+ for<'a> BoolInspectionActions<E::ExplanationCtx<'a>>
 		+ for<'a> BoolInspectionActions<E::NotificationCtx<'a>>
-		+ for<'a> BoolPropagationActions<
-			E::PropagationCtx<'a>,
-			Atom = E::Atom,
-			Conflict = E::Conflict,
-		> + Into<E::Atom>,
+		+ for<'a> BoolPropagationActions<E::PropagationCtx<'a>>
+		+ Into<E::Atom>,
 {
 }
 
@@ -401,6 +391,7 @@ impl<Atom: Debug> fmt::Display for Conflict<Atom> {
 
 impl<C, A, F, I> ReasonBuilder<C, A> for F
 where
+	C: ?Sized,
 	F: FnOnce(&mut C) -> I,
 	I: IntoIterator<Item = A>,
 {
@@ -413,11 +404,8 @@ impl<E, I> ModelIntView<E> for I
 where
 	E: ReasoningEngine,
 	I: SolverIntView<E>
-		+ for<'a> IntSimplificationActions<
-			E::PropagationCtx<'a>,
-			Atom = E::Atom,
-			Conflict = E::Conflict,
-		> + Into<IntDecision>,
+		+ for<'a> IntSimplificationActions<E::PropagationCtx<'a>>
+		+ Into<IntDecision>,
 {
 }
 
@@ -425,13 +413,16 @@ impl<E, I> SolverIntView<E> for I
 where
 	E: ReasoningEngine + ?Sized,
 	I: for<'a> IntInitActions<E::InitializationCtx<'a>>
-		+ for<'a> IntExplanationActions<E::ExplanationCtx<'a>, Atom = E::Atom>
-		+ for<'a> IntInspectionActions<E::NotificationCtx<'a>, Atom = E::Atom>
-		+ for<'a> IntPropagationActions<E::PropagationCtx<'a>, Atom = E::Atom, Conflict = E::Conflict>,
+		+ for<'a> IntExplanationActions<E::ExplanationCtx<'a>>
+		+ for<'a> IntInspectionActions<E::NotificationCtx<'a>>
+		+ for<'a> IntPropagationActions<E::PropagationCtx<'a>>,
 {
 }
 
-impl<A, C> ReasonBuilder<C, A> for LazyReason {
+impl<A, C> ReasonBuilder<C, A> for LazyReason
+where
+	C: ?Sized,
+{
 	fn build_reason(self, _: &mut C) -> Result<Reason<A>, bool> {
 		Ok(Reason::Lazy(self))
 	}

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -11,13 +11,14 @@ use tracing::trace;
 
 use crate::{
 	actions::{
-		InitActions, IntDecisionActions, IntInspectionActions, ReasoningEngine,
+		InitActions, IntDecisionActions, IntInspectionActions, ReasoningContext, ReasoningEngine,
 		ReformulationActions,
 	},
 	constraints::{
 		BoxedPropagator, Constraint, ModelIntView, Propagator, ReasonBuilder, SimplificationStatus,
 		SolverIntView,
 	},
+	helpers::static_dispatch::static_dispatch,
 	reformulate::ReformulationError,
 	solver::{activation_list::IntPropCond, queue::PriorityLevel, IntLitMeaning, IntView},
 	Conjunction, IntVal,
@@ -169,6 +170,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 		skip_task: Option<usize>,
 	) -> Vec<usize>
 	where
+		Ctx: ReasoningContext + ?Sized,
 		I1: IntInspectionActions<Ctx>,
 		I2: IntInspectionActions<Ctx>,
 		I3: IntInspectionActions<Ctx>,
@@ -232,6 +234,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 	/// Get the earliest completion time of the task `i`.
 	fn earliest_completion_time<C>(&self, ctx: &mut C, i: usize) -> i64
 	where
+		C: ReasoningContext + ?Sized,
 		I1: IntInspectionActions<C>,
 		I2: IntInspectionActions<C>,
 	{
@@ -242,6 +245,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 	/// Get the earliest start time of the task `i`.
 	fn earliest_start_time<C>(&self, ctx: &mut C, i: usize) -> i64
 	where
+		C: ReasoningContext + ?Sized,
 		I1: IntInspectionActions<C>,
 	{
 		self.start_times[i].lower_bound(ctx)
@@ -252,17 +256,18 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 	/// (1) relevant tasks (including the target task) that have compulsory
 	/// parts at the given time point, which are used to cover the required
 	/// resource usage, (2) and the resource capacity at its upper bound.
-	fn explain_limit_usage<Ctx, Atom>(
+	fn explain_limit_usage<Ctx>(
 		&self,
 		task_no: usize,
 		time_point: i64,
 		usage_limit: i64,
-	) -> impl ReasonBuilder<Ctx, Atom> + '_
+	) -> impl ReasonBuilder<Ctx, Ctx::Atom> + '_
 	where
-		I1: IntDecisionActions<Ctx, Atom = Atom>,
-		I2: IntDecisionActions<Ctx, Atom = Atom>,
-		I3: IntDecisionActions<Ctx, Atom = Atom>,
-		I4: IntDecisionActions<Ctx, Atom = Atom>,
+		Ctx: ReasoningContext + ?Sized,
+		I1: IntDecisionActions<Ctx>,
+		I2: IntDecisionActions<Ctx>,
+		I3: IntDecisionActions<Ctx>,
+		I4: IntDecisionActions<Ctx>,
 	{
 		move |ctx: &mut Ctx| {
 			trace!(
@@ -317,16 +322,17 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 	/// Construct a reason for why the resource usage is over `to_cover` at a
 	/// specific `time_point`. Refer to Schutt et al. (2011) for details on the
 	/// explanation construction.
-	fn explain_overload_time_point<Ctx, Atom>(
+	fn explain_overload_time_point<Ctx>(
 		&self,
 		to_cover: i64,
 		time_point: i64,
-	) -> impl ReasonBuilder<Ctx, Atom> + '_
+	) -> impl ReasonBuilder<Ctx, Ctx::Atom> + '_
 	where
-		I1: IntDecisionActions<Ctx, Atom = Atom>,
-		I2: IntDecisionActions<Ctx, Atom = Atom>,
-		I3: IntDecisionActions<Ctx, Atom = Atom>,
-		I4: IntDecisionActions<Ctx, Atom = Atom>,
+		Ctx: ReasoningContext + ?Sized,
+		I1: IntDecisionActions<Ctx>,
+		I2: IntDecisionActions<Ctx>,
+		I3: IntDecisionActions<Ctx>,
+		I4: IntDecisionActions<Ctx>,
 	{
 		move |ctx: &mut Ctx| {
 			let relevant_tasks = self.collect_compulsory_tasks(ctx, to_cover, time_point, None);
@@ -369,17 +375,18 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 	/// Construct a reason for the task sweeping explanation.
 	/// Refer to Schutt et al. (2011) for details on the explanation
 	/// construction.
-	fn explain_sweeping_time<Ctx, Atom>(
+	fn explain_sweeping_time<Ctx>(
 		&self,
 		task_no: usize,
 		propagation_rule: CumulativePropagationRule,
 		time_point: i64,
-	) -> impl ReasonBuilder<Ctx, Atom> + '_
+	) -> impl ReasonBuilder<Ctx, Ctx::Atom> + '_
 	where
-		I1: IntDecisionActions<Ctx, Atom = Atom>,
-		I2: IntDecisionActions<Ctx, Atom = Atom>,
-		I3: IntDecisionActions<Ctx, Atom = Atom>,
-		I4: IntDecisionActions<Ctx, Atom = Atom>,
+		Ctx: ReasoningContext + ?Sized,
+		I1: IntDecisionActions<Ctx>,
+		I2: IntDecisionActions<Ctx>,
+		I3: IntDecisionActions<Ctx>,
+		I4: IntDecisionActions<Ctx>,
 	{
 		move |ctx: &mut Ctx| {
 			let capacity_ub = self.capacity.upper_bound(ctx);
@@ -450,6 +457,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 	/// Get the latest completion time of the task `i`.
 	fn latest_completion_time<C>(&self, ctx: &mut C, i: usize) -> i64
 	where
+		C: ReasoningContext + ?Sized,
 		I1: IntInspectionActions<C>,
 		I2: IntInspectionActions<C>,
 	{
@@ -460,6 +468,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 	/// Get the latest start time of the task `i`.
 	fn latest_start_time<C>(&self, ctx: &mut C, i: usize) -> i64
 	where
+		C: ReasoningContext + ?Sized,
 		I1: IntInspectionActions<C>,
 	{
 		self.start_times[i].upper_bound(ctx)
@@ -771,12 +780,9 @@ impl CumulativeTimeTable<IntView, IntView, IntView, IntView> {
 	) where
 		E: AddAssign<BoxedPropagator> + ?Sized,
 	{
-		*solver += Box::new(CumulativeTimeTable::new(
-			start_times,
-			durations,
-			usages,
-			capacity,
-		));
+		static_dispatch!([VecIntView |> start_times, VecIntView |> durations, VecIntView |> usages, IntView |> capacity], |s,d,u,c| {
+			*solver += Box::new(CumulativeTimeTable::new(s,d,u,c));
+		})
 	}
 }
 

--- a/crates/huub/src/constraints/disjunctive_strict.rs
+++ b/crates/huub/src/constraints/disjunctive_strict.rs
@@ -9,12 +9,14 @@ use tracing::trace;
 use crate::{
 	actions::{
 		ConstructionActions, InitActions, IntDecisionActions, IntInspectionActions,
-		PropagationActions, ReasoningEngine, ReformulationActions, TrailingActions,
+		PropagationActions, ReasoningContext, ReasoningEngine, ReformulationActions,
+		TrailingActions,
 	},
 	constraints::{
 		BoxedPropagator, Constraint, ModelIntView, Propagator, ReasonBuilder, SimplificationStatus,
 		SolverIntView,
 	},
+	helpers::static_dispatch::static_dispatch,
 	reformulate::ReformulationError,
 	solver::{
 		activation_list::IntPropCond, queue::PriorityLevel, trail::TrailedInt, IntLitMeaning,
@@ -318,6 +320,7 @@ impl<I> DisjunctiveStrictPropagator<I> {
 	/// Return the (current) earliest completion time of task `i`.
 	fn earliest_completion_time<Ctx>(&self, ctx: &mut Ctx, i: usize) -> IntVal
 	where
+		Ctx: ReasoningContext + ?Sized,
 		I: IntInspectionActions<Ctx>,
 	{
 		self.earliest_start_time(ctx, i) + self.durations[i]
@@ -326,6 +329,7 @@ impl<I> DisjunctiveStrictPropagator<I> {
 	/// Return the (current) earliest start time of task `i`.
 	fn earliest_start_time<Ctx>(&self, ctx: &mut Ctx, i: usize) -> IntVal
 	where
+		Ctx: ReasoningContext + ?Sized,
 		I: IntInspectionActions<Ctx>,
 	{
 		self.start_times[i].lower_bound(ctx)
@@ -464,12 +468,13 @@ impl<I> DisjunctiveStrictPropagator<I> {
 	/// Explain resource overload within the time window
 	/// [`earliest_start`,`time_bound`]. For details, refer to the CPAIOR paper
 	/// by Vilim (2005).
-	fn explain_overload_checking<Ctx, Atom>(
+	fn explain_overload_checking<Ctx>(
 		&self,
 		time_bound: i64,
-	) -> impl ReasonBuilder<Ctx, Atom> + '_
+	) -> impl ReasonBuilder<Ctx, Ctx::Atom> + '_
 	where
-		I: IntDecisionActions<Ctx, Atom = Atom>,
+		Ctx: ReasoningContext + ?Sized,
+		I: IntDecisionActions<Ctx>,
 	{
 		move |ctx: &mut Ctx| {
 			let binding_task = self.ot_tree.binding_task(time_bound, 0);
@@ -568,6 +573,7 @@ impl<I> DisjunctiveStrictPropagator<I> {
 	/// Return the (current) latest completion time of task `i`.
 	fn latest_completion_time<Ctx>(&self, ctx: &mut Ctx, i: usize) -> IntVal
 	where
+		Ctx: ReasoningContext + ?Sized,
 		I: IntInspectionActions<Ctx>,
 	{
 		self.latest_start_time(ctx, i) + self.durations[i]
@@ -576,6 +582,7 @@ impl<I> DisjunctiveStrictPropagator<I> {
 	/// Return the (current) latest start time of task `i`.
 	fn latest_start_time<Ctx>(&self, ctx: &mut Ctx, i: usize) -> IntVal
 	where
+		Ctx: ReasoningContext + ?Sized,
 		I: IntInspectionActions<Ctx>,
 	{
 		self.start_times[i].upper_bound(ctx)
@@ -1106,15 +1113,17 @@ impl DisjunctiveStrictPropagator<IntView> {
 	) where
 		E: AddAssign<BoxedPropagator> + ConstructionActions + ?Sized,
 	{
-		let b = Box::new(Self::new(
-			solver,
-			start_times,
-			durations,
-			edge_finding_enabled,
-			not_last_enabled,
-			detectable_precedence_enabled,
-		));
-		*solver += b;
+		static_dispatch!([VecIntView |> start_times], |s| {
+			let b = Box::new(DisjunctiveStrictPropagator::new(
+				solver,
+				s,
+				durations,
+				edge_finding_enabled,
+				not_last_enabled,
+				detectable_precedence_enabled,
+			));
+			*solver += b;
+		})
 	}
 }
 

--- a/crates/huub/src/constraints/int_abs.rs
+++ b/crates/huub/src/constraints/int_abs.rs
@@ -10,12 +10,14 @@ use pindakaas::Lit as RawLit;
 
 use crate::{
 	actions::{
-		ConstructionActions, InitActions, IntDecisionActions, ReasoningEngine, ReformulationActions,
+		ConstructionActions, InitActions, IntDecisionActions, ReasoningContext, ReasoningEngine,
+		ReformulationActions,
 	},
 	constraints::{
 		BoxedPropagator, Constraint, ModelBoolView, ModelIntView, Propagator, SimplificationStatus,
 		SolverBoolView, SolverIntView,
 	},
+	helpers::static_dispatch::static_dispatch,
 	reformulate::ReformulationError,
 	solver::{
 		activation_list::IntPropCond, queue::PriorityLevel, BoolView, BoolViewInner, IntLitMeaning,
@@ -42,18 +44,26 @@ impl IntAbsBounds<IntView, IntView, RawLit> {
 	/// Create a new [`IntAbsBounds`] propagator and post it in the solver.
 	pub(crate) fn post<E>(solver: &mut E, origin: IntView, abs: IntView)
 	where
-		E: AddAssign<BoxedPropagator> + ConstructionActions + ?Sized,
-		IntView: IntDecisionActions<E, Atom = BoolView>,
+		E: AddAssign<BoxedPropagator>
+			+ ConstructionActions
+			+ ReasoningContext<Atom = BoolView>
+			+ ?Sized,
+		IntView: IntDecisionActions<E>,
 	{
 		let BoolViewInner::Lit(origin_positive) = origin.lit(solver, IntLitMeaning::GreaterEq(0)).0
 		else {
 			panic!("origin variable in absolute value constraint is known positive or negative");
 		};
-		*solver += Box::new(Self {
-			origin,
-			abs,
-			origin_positive,
-		});
+		static_dispatch!(
+			[IntView |> origin, IntView |> abs],
+			|origin, abs| {
+				*solver += Box::new(IntAbsBounds {
+					origin,
+					abs,
+					origin_positive,
+				});
+			}
+		);
 	}
 }
 

--- a/crates/huub/src/constraints/int_all_different.rs
+++ b/crates/huub/src/constraints/int_all_different.rs
@@ -14,6 +14,7 @@ use crate::{
 	constraints::{
 		BoxedPropagator, Constraint, ModelIntView, Propagator, SimplificationStatus, SolverIntView,
 	},
+	helpers::static_dispatch::static_dispatch,
 	reformulate::ReformulationError,
 	solver::{
 		activation_list::{IntEvent, IntPropCond},
@@ -481,7 +482,9 @@ impl IntAllDifferentBounds<IntView> {
 	where
 		E: AddAssign<BoxedPropagator> + ?Sized,
 	{
-		*solver += Box::new(Self::new(vars));
+		static_dispatch!([VecIntView |> vars], |vars| {
+			*solver += Box::new(IntAllDifferentBounds::new(vars));
+		})
 	}
 }
 
@@ -513,10 +516,12 @@ impl IntAllDifferentValue<IntView> {
 	where
 		E: AddAssign<BoxedPropagator> + ?Sized,
 	{
-		*solver += Box::new(Self {
-			vars: vars.clone(),
-			action_list: Vec::new(),
-		});
+		static_dispatch!([VecIntView |> vars], |vars| {
+			*solver += Box::new(IntAllDifferentValue {
+				vars,
+				action_list: Vec::new(),
+			});
+		})
 	}
 }
 

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -5,22 +5,23 @@
 use std::{iter::once, ops::AddAssign};
 
 use itertools::Itertools;
-use pindakaas::{ClauseDatabase, ClauseDatabaseTools, Unsatisfiable};
+use pindakaas::{ClauseDatabase, ClauseDatabaseTools, Lit as RawLit, Unsatisfiable};
 use rustc_hash::FxHashMap;
 
 use crate::{
 	actions::{
-		ConstructionActions, InitActions, IntDecisionActions, IntInspectionActions,
-		IntSimplificationActions, ReasoningEngine, ReformulationActions, SimplificationActions,
-		TrailingActions,
+		BoolInspectionActions, ConstructionActions, InitActions, IntDecisionActions,
+		IntInspectionActions, IntSimplificationActions, ReasoningContext, ReasoningEngine,
+		ReformulationActions, SimplificationActions, TrailingActions,
 	},
 	constraints::{
 		BoxedPropagator, Constraint, ModelIntView, Propagator, SimplificationStatus, SolverIntView,
 	},
+	helpers::static_dispatch::static_dispatch,
 	reformulate::ReformulationError,
 	solver::{
-		activation_list::IntPropCond, queue::PriorityLevel, trail::TrailedInt, BoolView,
-		IntLitMeaning, IntView,
+		activation_list::IntPropCond, int_var::IntVarRef, queue::PriorityLevel, trail::TrailedInt,
+		BoolView, IntLitMeaning, IntView,
 	},
 	IntDecision, IntSetVal, IntVal,
 };
@@ -55,7 +56,7 @@ impl<I1, I2, I3> IntArrayElementBounds<I1, I2, I3> {
 	/// solver.
 	pub(crate) fn new<E>(engine: &mut E, collection: Vec<I1>, index: I2, result: I3) -> Self
 	where
-		E: ConstructionActions + ?Sized,
+		E: ConstructionActions + ReasoningContext + ?Sized,
 		I1: IntInspectionActions<E>,
 		I2: IntInspectionActions<E>,
 	{
@@ -103,8 +104,14 @@ impl IntArrayElementBounds<IntView, IntView, IntView> {
 		result: IntView,
 	) -> Result<(), Unsatisfiable>
 	where
-		E: AddAssign<BoxedPropagator> + ClauseDatabase + ConstructionActions + ?Sized,
-		IntView: IntDecisionActions<E, Atom = BoolView>,
+		E: AddAssign<BoxedPropagator>
+			+ ClauseDatabase
+			+ ConstructionActions
+			+ ReasoningContext<Atom = BoolView>
+			+ ?Sized,
+		IntView: IntDecisionActions<E>,
+		IntVarRef: IntInspectionActions<E>,
+		RawLit: BoolInspectionActions<E>,
 	{
 		// Remove out-of-bound values from the index variables
 		let index_ub = index.lit(solver, IntLitMeaning::Less(collection.len() as IntVal));
@@ -112,8 +119,10 @@ impl IntArrayElementBounds<IntView, IntView, IntView> {
 		solver.add_clause([index_ub])?;
 		solver.add_clause([index_lb])?;
 
-		let me = Self::new(solver, collection, index, result);
-		*solver += Box::new(me);
+		static_dispatch!([VecIntView |> collection, IntView |> index, IntView |> result], |c,i,r| {
+			let me = IntArrayElementBounds::new(solver, c, i, r);
+			*solver += Box::new(me);
+		});
 
 		Ok(())
 	}

--- a/crates/huub/src/constraints/int_array_minimum.rs
+++ b/crates/huub/src/constraints/int_array_minimum.rs
@@ -11,6 +11,7 @@ use crate::{
 	constraints::{
 		BoxedPropagator, Constraint, ModelIntView, Propagator, SimplificationStatus, SolverIntView,
 	},
+	helpers::static_dispatch::static_dispatch,
 	reformulate::ReformulationError,
 	solver::{activation_list::IntPropCond, queue::PriorityLevel, IntLitMeaning, IntView},
 };
@@ -31,9 +32,8 @@ impl IntArrayMinimumBounds<IntView, IntView> {
 	where
 		E: AddAssign<BoxedPropagator> + ?Sized,
 	{
-		*solver += Box::new(Self {
-			vars: vars.clone(),
-			min,
+		static_dispatch!([VecIntView |> vars, IntView |> min], |vars, min| {
+			*solver += Box::new(IntArrayMinimumBounds { vars, min });
 		});
 	}
 }

--- a/crates/huub/src/constraints/int_div.rs
+++ b/crates/huub/src/constraints/int_div.rs
@@ -4,6 +4,7 @@
 
 use std::{
 	mem,
+	num::NonZero,
 	ops::{AddAssign, Neg},
 };
 
@@ -12,18 +13,18 @@ use pindakaas::{ClauseDatabase, ClauseDatabaseTools, Unsatisfiable};
 use crate::{
 	actions::{
 		InitActions, IntDecisionActions, IntInspectionActions, IntPropagationActions,
-		ReasoningEngine, ReformulationActions,
+		ReasoningContext, ReasoningEngine, ReformulationActions,
 	},
 	constraints::{
 		BoxedPropagator, Constraint, ModelBoolView, ModelIntView, Propagator, SimplificationStatus,
 		SolverIntView,
 	},
-	helpers::div_ceil,
+	helpers::{div_ceil, static_dispatch::static_dispatch},
 	reformulate::ReformulationError,
 	solver::{
 		activation_list::IntPropCond, queue::PriorityLevel, BoolView, IntLitMeaning, IntView,
 	},
-	BoolDecision, BoolFormula, IntDecision, NonZeroIntVal,
+	BoolDecision, BoolFormula, IntDecision,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -98,7 +99,7 @@ impl<I1, I2, I3> IntDivBounds<I1, I2, I3> {
 			}
 		}
 
-		if let Some(res_ub_inc) = NonZeroIntVal::new(res_ub + 1) {
+		if let Some(res_ub_inc) = NonZero::new(res_ub + 1) {
 			let new_denom_lb = div_ceil(num_lb + 1, res_ub_inc);
 			if new_denom_lb > denom_lb {
 				denominator.set_lower_bound(
@@ -172,8 +173,8 @@ impl IntDivBounds<IntView, IntView, IntView> {
 		result: IntView,
 	) -> Result<(), Unsatisfiable>
 	where
-		E: AddAssign<BoxedPropagator> + ClauseDatabase + ?Sized,
-		IntView: IntDecisionActions<E, Atom = BoolView>,
+		E: AddAssign<BoxedPropagator> + ClauseDatabase + ReasoningContext<Atom = BoolView> + ?Sized,
+		IntView: IntDecisionActions<E>,
 	{
 		// Ensure the consistency of the signs of the three variables using the
 		// following clauses.
@@ -198,12 +199,16 @@ impl IntDivBounds<IntView, IntView, IntView> {
 			solver.add_clause([!num_neg, !denom_pos, res_neg])?;
 		}
 
-		*solver += Box::new(Self {
-			numerator,
-			denominator,
-			result,
-		});
-
+		static_dispatch!(
+			[IntView |> numerator, IntView |> denominator, IntView |> result],
+			|numerator, denominator, result| {
+				*solver += Box::new(IntDivBounds {
+					numerator,
+					denominator,
+					result,
+				});
+			}
+		);
 		Ok(())
 	}
 }

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -3,7 +3,7 @@
 //! constraint enforce a condition on the sum of (linear transformations of)
 //! integer decision variables.
 
-use std::ops::AddAssign;
+use std::{num::NonZero, ops::AddAssign};
 
 use itertools::{Either, Itertools};
 use pindakaas::{
@@ -15,14 +15,14 @@ use crate::{
 	actions::{
 		BoolInitActions, BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions,
 		ConstructionActions, InitActions, IntDecisionActions, IntInitActions, IntInspectionActions,
-		IntPropagationActions, IntSimplificationActions, PropagationActions, ReasoningEngine,
-		ReformulationActions, SimplificationActions, TrailingActions,
+		IntPropagationActions, IntSimplificationActions, PropagationActions, ReasoningContext,
+		ReasoningEngine, ReformulationActions, SimplificationActions, TrailingActions,
 	},
 	constraints::{
 		BoxedPropagator, Constraint, ModelBoolView, ModelIntView, Propagator, ReasonBuilder,
 		SimplificationStatus, SolverBoolView, SolverIntView,
 	},
-	helpers::opt_field::OptField,
+	helpers::{opt_field::OptField, static_dispatch::static_dispatch},
 	reformulate::ReformulationError,
 	solver::{
 		activation_list::{IntEvent, IntPropCond},
@@ -30,7 +30,8 @@ use crate::{
 		trail::TrailedInt,
 		BoolView, BoolViewInner, IntView, IntViewInner,
 	},
-	BoolDecision, BoolFormula, Conjunction, IntDecision, IntVal, LinearTransform, NonZeroIntVal,
+	views::linear_bool_view::LinearBoolView,
+	BoolDecision, BoolFormula, Conjunction, IntDecision, IntVal,
 };
 
 /// Representation of an integer equality constraint that cannot be unified.
@@ -487,11 +488,11 @@ where
 			let bool_terms: Vec<(RawLit, IntVal)> = terms
 				.iter()
 				.map(|&v| {
-					let IntViewInner::Bool { transformer, lit } = v.0 else {
+					let IntViewInner::Bool(lin) = v.0 else {
 						unreachable!()
 					};
-					offset += transformer.offset;
-					(lit, transformer.scale.into())
+					offset += lin.offset;
+					(lin.var, lin.scale.into())
 				})
 				.collect();
 			let bool_lin = BoolLinExp::from_terms(&bool_terms);
@@ -527,12 +528,11 @@ where
 			(
 				lin.iter_terms()
 					.map(|(lit, coeff)| {
-						IntView(IntViewInner::Bool {
-							transformer: LinearTransform::scaled(
-								NonZeroIntVal::new(coeff).unwrap(),
-							),
+						IntView(IntViewInner::Bool(LinearBoolView::new(
+							NonZero::new(coeff).unwrap(),
+							0,
 							lit,
-						})
+						)))
 					})
 					.collect_vec(),
 				op,
@@ -605,7 +605,7 @@ impl IntLinearLessEqBounds<IntView> {
 	/// solver.
 	pub fn post<E>(solver: &mut E, vars: impl IntoIterator<Item = IntView>, mut max: IntVal)
 	where
-		E: AddAssign<BoxedPropagator> + ConstructionActions + ?Sized,
+		E: AddAssign<BoxedPropagator> + ConstructionActions + ReasoningContext + ?Sized,
 		IntView: IntInspectionActions<E>,
 	{
 		let vars: Vec<IntView> = vars
@@ -620,10 +620,12 @@ impl IntLinearLessEqBounds<IntView> {
 			})
 			.collect();
 
-		*solver += Box::new(Self {
-			terms: vars.clone(),
-			max,
-			reification: Default::default(),
+		static_dispatch!([VecIntView |> vars], |terms| {
+			*solver += Box::new(IntLinearLessEqBounds {
+				terms,
+				max,
+				reification: Default::default(),
+			});
 		});
 	}
 }
@@ -723,7 +725,7 @@ impl IntLinearLessEqImpBounds<IntView, RawLit> {
 		mut max: IntVal,
 		reification: BoolView,
 	) where
-		E: AddAssign<BoxedPropagator> + ConstructionActions + ?Sized,
+		E: AddAssign<BoxedPropagator> + ConstructionActions + ReasoningContext + ?Sized,
 		IntView: IntInspectionActions<E>,
 	{
 		let reification = match reification.0 {
@@ -745,10 +747,12 @@ impl IntLinearLessEqImpBounds<IntView, RawLit> {
 			})
 			.collect();
 
-		*solver += Box::new(Self {
-			terms: vars.clone(),
-			max,
-			reification: OptField::new(reification),
+		static_dispatch!([VecIntView |> vars], |terms| {
+			*solver += Box::new(IntLinearLessEqImpBounds {
+				terms,
+				max,
+				reification: OptField::new(reification),
+			});
 		});
 	}
 }
@@ -762,7 +766,7 @@ impl IntLinearNotEqImpValue<IntView, RawLit> {
 		mut violation: IntVal,
 		reification: BoolView,
 	) where
-		E: AddAssign<BoxedPropagator> + ConstructionActions + ?Sized,
+		E: AddAssign<BoxedPropagator> + ConstructionActions + ReasoningContext + ?Sized,
 		IntView: IntInspectionActions<E>,
 	{
 		let reification = match reification.0 {
@@ -786,11 +790,13 @@ impl IntLinearNotEqImpValue<IntView, RawLit> {
 			.collect();
 		let num_fixed = solver.new_trailed_int(0);
 
-		*solver += Box::new(Self {
-			terms: vars.clone(),
-			violation,
-			num_fixed,
-			reification: OptField::new(reification),
+		static_dispatch!([VecIntView |> vars], |terms| {
+			*solver += Box::new(IntLinearNotEqImpValue {
+				terms,
+				violation,
+				num_fixed,
+				reification: OptField::new(reification),
+			});
 		});
 	}
 }
@@ -800,7 +806,7 @@ impl IntLinearNotEqValue<IntView> {
 	/// solver.
 	pub fn post<E>(solver: &mut E, vars: impl IntoIterator<Item = IntView>, mut violation: IntVal)
 	where
-		E: AddAssign<BoxedPropagator> + ConstructionActions + ?Sized,
+		E: AddAssign<BoxedPropagator> + ConstructionActions + ReasoningContext + ?Sized,
 		IntView: IntInspectionActions<E>,
 	{
 		let vars: Vec<IntView> = vars
@@ -816,11 +822,13 @@ impl IntLinearNotEqValue<IntView> {
 			.collect();
 		let num_fixed = solver.new_trailed_int(0);
 
-		*solver += Box::new(Self {
-			terms: vars.clone(),
-			violation,
-			num_fixed,
-			reification: Default::default(),
+		static_dispatch!([VecIntView |> vars], |terms| {
+			*solver += Box::new(IntLinearNotEqValue {
+				terms,
+				violation,
+				num_fixed,
+				reification: Default::default(),
+			});
 		});
 	}
 }
@@ -840,10 +848,11 @@ impl<const R: usize, IV, BV> IntLinearNotEqValueImpl<R, IV, BV> {
 	/// Helper function to construct the reason for propagation given the index
 	/// of the variable in the list of variables to sum or the length of the
 	/// list, if explaining the reification.
-	fn reason<Ctx, A>(&self, data: usize) -> impl ReasonBuilder<Ctx, A> + '_
+	fn reason<Ctx>(&self, data: usize) -> impl ReasonBuilder<Ctx, Ctx::Atom> + '_
 	where
-		IV: IntDecisionActions<Ctx, Atom = A>,
-		BV: Clone + Into<A>,
+		Ctx: ReasoningContext + ?Sized,
+		IV: IntDecisionActions<Ctx>,
+		BV: Clone + Into<Ctx::Atom>,
 	{
 		move |ctx: &mut Ctx| {
 			let mut conj: Vec<_> = self
@@ -943,6 +952,8 @@ where
 
 #[cfg(test)]
 mod tests {
+	use std::num::NonZero;
+
 	use expect_test::expect;
 	use rangelist::RangeList;
 	use tracing_test::traced_test;
@@ -955,7 +966,7 @@ mod tests {
 			int_var::{EncodingType, IntVar},
 			Solver,
 		},
-		BoolDecision, Model, NonZeroIntVal,
+		BoolDecision, Model,
 	};
 
 	#[test]
@@ -994,11 +1005,7 @@ mod tests {
 			EncodingType::Lazy,
 		);
 
-		IntLinearLessEqBounds::post(
-			&mut slv,
-			vec![a * NonZeroIntVal::new(-2).unwrap(), -b, -c],
-			-6,
-		);
+		IntLinearLessEqBounds::post(&mut slv, vec![a * NonZero::new(-2).unwrap(), -b, -c], -6);
 
 		slv.expect_solutions(
 			&[a, b, c],
@@ -1046,7 +1053,7 @@ mod tests {
 			EncodingType::Lazy,
 		);
 
-		IntLinearLessEqBounds::post(&mut slv, vec![a * NonZeroIntVal::new(2).unwrap(), b, c], 6);
+		IntLinearLessEqBounds::post(&mut slv, vec![a * NonZero::new(2).unwrap(), b, c], 6);
 
 		slv.expect_solutions(
 			&[a, b, c],
@@ -1095,7 +1102,7 @@ mod tests {
 			EncodingType::Eager,
 		);
 
-		IntLinearNotEqValue::post(&mut slv, vec![a * NonZeroIntVal::new(2).unwrap(), b, c], 6);
+		IntLinearNotEqValue::post(&mut slv, vec![a * NonZero::new(2).unwrap(), b, c], 6);
 
 		slv.expect_solutions(
 			&[a, b, c],

--- a/crates/huub/src/constraints/int_pow.rs
+++ b/crates/huub/src/constraints/int_pow.rs
@@ -8,13 +8,14 @@ use pindakaas::{ClauseDatabase, ClauseDatabaseTools, Unsatisfiable};
 
 use crate::{
 	actions::{
-		InitActions, IntDecisionActions, IntInspectionActions, ReasoningEngine,
+		InitActions, IntDecisionActions, IntInspectionActions, ReasoningContext, ReasoningEngine,
 		ReformulationActions,
 	},
 	constraints::{
 		BoxedPropagator, CachedReason, Constraint, ModelIntView, Propagator, SimplificationStatus,
 		SolverIntView,
 	},
+	helpers::static_dispatch::static_dispatch,
 	reformulate::ReformulationError,
 	solver::{
 		activation_list::IntPropCond, queue::PriorityLevel, BoolView, IntLitMeaning, IntView,
@@ -293,8 +294,8 @@ impl IntPowBounds<IntView, IntView, IntView> {
 		result: IntView,
 	) -> Result<(), Unsatisfiable>
 	where
-		E: AddAssign<BoxedPropagator> + ClauseDatabase + ?Sized,
-		IntView: IntDecisionActions<E, Atom = BoolView>,
+		E: AddAssign<BoxedPropagator> + ClauseDatabase + ReasoningContext<Atom = BoolView> + ?Sized,
+		IntView: IntDecisionActions<E>,
 	{
 		// Ensure that if the base is negative, then the exponent cannot be zero
 		let (exp_lb, exp_ub) = exponent.bounds(solver);
@@ -318,11 +319,16 @@ impl IntPowBounds<IntView, IntView, IntView> {
 			solver.add_clause(clause)?;
 		}
 
-		*solver += Box::new(Self {
-			base,
-			exponent,
-			result,
-		});
+		static_dispatch!(
+			[IntView |> base, IntView |> exponent, IntView |> result],
+			|base, exponent, result| {
+				*solver += Box::new(IntPowBounds {
+					base,
+					exponent,
+					result,
+				});
+			}
+		);
 		Ok(())
 	}
 }

--- a/crates/huub/src/constraints/int_times.rs
+++ b/crates/huub/src/constraints/int_times.rs
@@ -2,17 +2,20 @@
 //! that the product of two integer variables is equal to a third integer
 //! variable.
 
-use std::ops::{AddAssign, Mul};
+use std::{
+	num::NonZero,
+	ops::{AddAssign, Mul},
+};
 
 use crate::{
 	actions::{InitActions, IntSimplificationActions, ReasoningEngine, ReformulationActions},
 	constraints::{
 		BoxedPropagator, Constraint, ModelIntView, Propagator, SimplificationStatus, SolverIntView,
 	},
-	helpers::{div_ceil, div_floor},
+	helpers::{div_ceil, div_floor, static_dispatch::static_dispatch},
 	reformulate::ReformulationError,
 	solver::{activation_list::IntPropCond, queue::PriorityLevel, IntView},
-	IntDecision, IntVal, NonZeroIntVal,
+	IntDecision, IntVal,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -33,11 +36,16 @@ impl IntTimesBounds<IntView, IntView, IntView> {
 	where
 		E: AddAssign<BoxedPropagator> + ?Sized,
 	{
-		*solver += Box::new(Self {
-			factor1,
-			factor2,
-			product,
-		});
+		static_dispatch!(
+			[IntView |> factor1, IntView |> factor2, IntView |> product],
+			|factor1, factor2, product| {
+				*solver += Box::new(IntTimesBounds {
+					factor1,
+					factor2,
+					product,
+				})
+			}
+		);
 	}
 }
 
@@ -133,7 +141,7 @@ where
 			let min = bounds
 				.iter()
 				.map(|(z, y)| {
-					let y = NonZeroIntVal::new(*y).unwrap();
+					let y = NonZero::new(*y).unwrap();
 					div_ceil(*z, y)
 				})
 				.min()
@@ -143,7 +151,7 @@ where
 			let max = bounds
 				.iter()
 				.map(|(z, y)| {
-					let y = NonZeroIntVal::new(*y).unwrap();
+					let y = NonZero::new(*y).unwrap();
 					div_floor(*z, y)
 				})
 				.max()
@@ -166,7 +174,7 @@ where
 			let min = bounds
 				.iter()
 				.map(|(z, x)| {
-					let y = NonZeroIntVal::new(*x).unwrap();
+					let y = NonZero::new(*x).unwrap();
 					div_ceil(*z, y)
 				})
 				.min()
@@ -176,7 +184,7 @@ where
 			let max = bounds
 				.iter()
 				.map(|(z, x)| {
-					let y = NonZeroIntVal::new(*x).unwrap();
+					let y = NonZero::new(*x).unwrap();
 					div_floor(*z, y)
 				})
 				.max()

--- a/crates/huub/src/constraints/int_value_precede.rs
+++ b/crates/huub/src/constraints/int_value_precede.rs
@@ -7,18 +7,22 @@ use std::{
 	ops::AddAssign,
 };
 
+use pindakaas::Lit as RawLit;
+
 use crate::{
 	actions::{
-		ConstructionActions, InitActions, IntDecisionActions, IntInspectionActions,
-		ReasoningEngine, ReformulationActions, TrailingActions,
+		BoolInspectionActions, ConstructionActions, InitActions, IntDecisionActions,
+		IntInspectionActions, ReasoningContext, ReasoningEngine, ReformulationActions,
+		TrailingActions,
 	},
 	constraints::{
 		BoxedPropagator, Constraint, ModelIntView, Propagator, SimplificationStatus, SolverIntView,
 	},
+	helpers::static_dispatch::static_dispatch,
 	reformulate::ReformulationError,
 	solver::{
-		activation_list::IntPropCond, queue::PriorityLevel, trail::TrailedInt, IntLitMeaning,
-		IntView,
+		activation_list::IntPropCond, int_var::IntVarRef, queue::PriorityLevel, trail::TrailedInt,
+		IntLitMeaning, IntView,
 	},
 	Conjunction, IntVal,
 };
@@ -80,13 +84,14 @@ impl<I> IntSeqPrecedeChainBounds<I> {
 	/// Lower bound explanation: Could not have this value earlier (=upper bound
 	/// explanation) and some later value requires the lower bound (recursive
 	/// lower bound).
-	fn explain_lower<Ctx, Atom>(
+	fn explain_lower<Ctx>(
 		&self,
 		i: usize,
 		k: IntVal,
-	) -> impl FnOnce(&mut Ctx) -> Conjunction<Atom> + '_
+	) -> impl FnOnce(&mut Ctx) -> Conjunction<Ctx::Atom> + '_
 	where
-		I: IntDecisionActions<Ctx, Atom = Atom>,
+		Ctx: ReasoningContext + ?Sized,
+		I: IntDecisionActions<Ctx>,
 	{
 		move |ctx: &mut Ctx| {
 			let mut reason = Vec::new();
@@ -120,13 +125,14 @@ impl<I> IntSeqPrecedeChainBounds<I> {
 	}
 
 	/// Upper bound explanation: All previous elements are smaller.
-	fn explain_upper<Ctx, Atom>(
+	fn explain_upper<Ctx>(
 		&self,
 		i: usize,
 		k: IntVal,
-	) -> impl FnOnce(&mut Ctx) -> Conjunction<Atom> + '_
+	) -> impl FnOnce(&mut Ctx) -> Conjunction<Ctx::Atom> + '_
 	where
-		I: IntDecisionActions<Ctx, Atom = Atom>,
+		Ctx: ReasoningContext + ?Sized,
+		I: IntDecisionActions<Ctx>,
 	{
 		move |ctx: &mut Ctx| {
 			self.vars
@@ -201,7 +207,7 @@ impl<I> IntSeqPrecedeChainBounds<I> {
 	/// solver.
 	pub fn new<E>(engine: &mut E, vars: Vec<I>) -> Self
 	where
-		E: ConstructionActions + ?Sized,
+		E: ConstructionActions + ReasoningContext + ?Sized,
 		I: IntInspectionActions<E>,
 	{
 		let n = vars.len();
@@ -344,8 +350,11 @@ impl IntSeqPrecedeChainBounds<IntView> {
 	/// solver.
 	pub fn post<E>(solver: &mut E, mut vars: Vec<IntView>)
 	where
-		E: AddAssign<BoxedPropagator> + ConstructionActions + ?Sized,
+		E: AddAssign<BoxedPropagator> + ConstructionActions + ReasoningContext + ?Sized,
+		E::Atom: From<bool> + From<RawLit>,
 		IntView: IntInspectionActions<E>,
+		IntVarRef: IntInspectionActions<E>,
+		RawLit: BoolInspectionActions<E>,
 	{
 		// Variables that do not allow positive values are irrelevant.
 		vars.retain(|&v| v.upper_bound(solver) > 0);
@@ -354,8 +363,10 @@ impl IntSeqPrecedeChainBounds<IntView> {
 		}
 		vars.shrink_to_fit();
 
-		let con = IntSeqPrecedeChainBounds::new(solver, vars);
-		*solver += Box::new(con);
+		static_dispatch!([VecIntView |> vars], |vars| {
+			let con = IntSeqPrecedeChainBounds::new(solver, vars);
+			*solver += Box::new(con);
+		})
 	}
 }
 
@@ -455,13 +466,14 @@ impl<I> IntValuePrecedeChainValue<I> {
 	/// Lower bound explanation: Could not have this index earlier (=upper bound
 	/// explanation) and some later index requires the lower bound (recursive
 	/// lower bound).
-	fn explain_lower<Ctx, Atom>(
+	fn explain_lower<Ctx>(
 		&self,
 		i: usize,
 		j: usize,
-	) -> impl FnOnce(&mut Ctx) -> Conjunction<Atom> + '_
+	) -> impl FnOnce(&mut Ctx) -> Conjunction<Ctx::Atom> + '_
 	where
-		I: IntDecisionActions<Ctx, Atom = Atom>,
+		Ctx: ReasoningContext + ?Sized,
+		I: IntDecisionActions<Ctx>,
 	{
 		move |ctx: &mut Ctx| {
 			let mut reason = Vec::new();
@@ -519,13 +531,14 @@ impl<I> IntValuePrecedeChainValue<I> {
 
 	/// Upper bound explanation: All previous indices are smaller (exclude
 	/// values with larger index).
-	fn explain_upper<Ctx, Atom>(
+	fn explain_upper<Ctx>(
 		&self,
 		i: usize,
 		j: usize,
-	) -> impl FnOnce(&mut Ctx) -> Conjunction<Atom> + '_
+	) -> impl FnOnce(&mut Ctx) -> Conjunction<Ctx::Atom> + '_
 	where
-		I: IntDecisionActions<Ctx, Atom = Atom>,
+		Ctx: ReasoningContext + ?Sized,
+		I: IntDecisionActions<Ctx>,
 	{
 		move |ctx: &mut Ctx| {
 			self.vars
@@ -596,6 +609,7 @@ impl<I> IntValuePrecedeChainValue<I> {
 	/// the range of values, then all holes, finally values with lower index.
 	fn lowest_index<Ctx>(&self, ctx: &mut Ctx, i: usize) -> Option<usize>
 	where
+		Ctx: ReasoningContext + ?Sized,
 		I: IntInspectionActions<Ctx>,
 	{
 		let (lb, ub) = self.vars[i].bounds(ctx);
@@ -857,7 +871,7 @@ impl IntValuePrecedeChainValue<IntView> {
 	/// solver.
 	pub fn post<E>(solver: &mut E, values: Vec<IntVal>, mut vars: Vec<IntView>)
 	where
-		E: AddAssign<BoxedPropagator> + ConstructionActions + ?Sized,
+		E: AddAssign<BoxedPropagator> + ConstructionActions + ReasoningContext + ?Sized,
 		IntView: IntInspectionActions<E>,
 	{
 		// Variables that do not any tracked values are irrelevant.
@@ -908,21 +922,23 @@ impl IntValuePrecedeChainValue<IntView> {
 			mapping[(val - min_val) as usize] = Some(i + 1);
 		}
 
-		*solver += Box::new(Self {
-			values,
-			vars: vars.clone(),
-			initialized: false,
-			first,
-			last,
-			first_val,
-			max_last,
-			min_val,
-			max_val,
-			holes,
-			min_hole,
-			next_hole,
-			mapping,
-		});
+		static_dispatch!([VecIntView |> vars], |vars| {
+			*solver += Box::new(IntValuePrecedeChainValue {
+				values,
+				vars,
+				initialized: false,
+				first,
+				last,
+				first_val,
+				max_last,
+				min_val,
+				max_val,
+				holes,
+				min_hole,
+				next_hole,
+				mapping,
+			});
+		})
 	}
 }
 

--- a/crates/huub/src/flatzinc.rs
+++ b/crates/huub/src/flatzinc.rs
@@ -7,6 +7,7 @@ use std::{
 	fmt::{self, Debug, Display},
 	hash::Hash,
 	iter::once,
+	num::NonZero,
 	ops::{Deref, Not, RangeInclusive},
 	rc::Rc,
 };
@@ -32,7 +33,7 @@ use crate::{
 	reformulate::ReformulationError,
 	rel, seq_precede_chain_int, table_int, times_int, value_precede_chain_int, BoolDecision,
 	BoolDecisionInner, Branching, Decision, IntDecision, IntLinExpr, IntSetVal, IntVal, Model,
-	NonZeroIntVal, ValueSelection, VariableSelection,
+	ValueSelection, VariableSelection,
 };
 
 /// Domain assumed for integer decision variables that do not have a domain
@@ -740,7 +741,7 @@ where
 					break 'int_lin_eq;
 				}
 				let offset = sum / c;
-				let view = if let Some(scale) = NonZeroIntVal::new(-cy / c) {
+				let view = if let Some(scale) = NonZero::new(-cy / c) {
 					let y = lit_int_view(self, vy)?;
 					y * scale + offset
 				} else {
@@ -1083,9 +1084,7 @@ where
 						let lin_exp: IntLinExpr = vars
 							.into_iter()
 							.zip(coeffs.into_iter())
-							.filter_map(|(x, c)| {
-								NonZeroIntVal::new(c).map(|c| IntDecision::from(x) * c)
-							})
+							.filter_map(|(x, c)| NonZero::new(c).map(|c| IntDecision::from(x) * c))
 							.chain(once(-sum))
 							.sum();
 
@@ -1546,7 +1545,7 @@ where
 						let lin_exp: IntLinExpr = vars
 							.into_iter()
 							.zip(coeffs.into_iter())
-							.filter_map(|(x, c)| NonZeroIntVal::new(c).map(|c| x * c))
+							.filter_map(|(x, c)| NonZero::new(c).map(|c| x * c))
 							.sum();
 
 						self.prb.add_constraint(match c.id.deref() {
@@ -1586,7 +1585,7 @@ where
 						let lin_exp: IntLinExpr = vars
 							.into_iter()
 							.zip(coeffs.into_iter())
-							.filter_map(|(x, c)| NonZeroIntVal::new(c).map(|c| x * c))
+							.filter_map(|(x, c)| NonZero::new(c).map(|c| x * c))
 							.sum();
 
 						let lin = match c.id.deref() {

--- a/crates/huub/src/helpers.rs
+++ b/crates/huub/src/helpers.rs
@@ -3,12 +3,15 @@
 
 pub(crate) mod linear_transform;
 pub(crate) mod opt_field;
+pub(crate) mod static_dispatch;
 
-use crate::{IntVal, NonZeroIntVal};
+use std::num::NonZero;
+
+use crate::IntVal;
 
 #[inline]
 /// Integer division that rounds towards positive infinity.
-pub(crate) fn div_ceil(a: IntVal, b: NonZeroIntVal) -> IntVal {
+pub(crate) fn div_ceil(a: IntVal, b: NonZero<IntVal>) -> IntVal {
 	let d = a / b.get();
 	let r = a % b.get();
 	if (r > 0 && b.get() > 0) || (r < 0 && b.get() < 0) {
@@ -19,7 +22,7 @@ pub(crate) fn div_ceil(a: IntVal, b: NonZeroIntVal) -> IntVal {
 }
 
 /// Integer division that rounds towards negative infinity.
-pub(crate) fn div_floor(a: IntVal, b: NonZeroIntVal) -> IntVal {
+pub(crate) fn div_floor(a: IntVal, b: NonZero<IntVal>) -> IntVal {
 	let d = a / b.get();
 	let r = a % b.get();
 	if (r > 0 && b.get() < 0) || (r < 0 && b.get() > 0) {
@@ -31,24 +34,23 @@ pub(crate) fn div_floor(a: IntVal, b: NonZeroIntVal) -> IntVal {
 
 #[cfg(test)]
 mod tests {
-	use crate::{
-		helpers::{div_ceil, div_floor},
-		NonZeroIntVal,
-	};
+	use std::num::NonZero;
+
+	use crate::helpers::{div_ceil, div_floor};
 
 	#[test]
 	fn test_div_ceil() {
-		assert_eq!(div_ceil(8, NonZeroIntVal::new(3).unwrap()), 3);
-		assert_eq!(div_ceil(-8, NonZeroIntVal::new(-3).unwrap()), 3);
-		assert_eq!(div_ceil(8, NonZeroIntVal::new(-3).unwrap()), -2);
-		assert_eq!(div_ceil(-8, NonZeroIntVal::new(3).unwrap()), -2);
+		assert_eq!(div_ceil(8, NonZero::new(3).unwrap()), 3);
+		assert_eq!(div_ceil(-8, NonZero::new(-3).unwrap()), 3);
+		assert_eq!(div_ceil(8, NonZero::new(-3).unwrap()), -2);
+		assert_eq!(div_ceil(-8, NonZero::new(3).unwrap()), -2);
 	}
 
 	#[test]
 	fn test_div_floor() {
-		assert_eq!(div_floor(8, NonZeroIntVal::new(3).unwrap()), 2);
-		assert_eq!(div_floor(-8, NonZeroIntVal::new(-3).unwrap()), 2);
-		assert_eq!(div_floor(8, NonZeroIntVal::new(-3).unwrap()), -3);
-		assert_eq!(div_floor(-8, NonZeroIntVal::new(3).unwrap()), -3);
+		assert_eq!(div_floor(8, NonZero::new(3).unwrap()), 2);
+		assert_eq!(div_floor(-8, NonZero::new(-3).unwrap()), 2);
+		assert_eq!(div_floor(8, NonZero::new(-3).unwrap()), -3);
+		assert_eq!(div_floor(-8, NonZero::new(3).unwrap()), -3);
 	}
 }

--- a/crates/huub/src/helpers/linear_transform.rs
+++ b/crates/huub/src/helpers/linear_transform.rs
@@ -1,8 +1,11 @@
 //! Methods to perform linear transformations.
 
-use std::ops::{Add, Mul, Neg, RangeInclusive, Sub};
+use std::{
+	num::NonZero,
+	ops::{Add, Mul, Neg, RangeInclusive, Sub},
+};
 
-use crate::{helpers::div_ceil, solver::IntLitMeaning, IntSetVal, IntVal, NonZeroIntVal};
+use crate::{helpers::div_ceil, solver::IntLitMeaning, IntSetVal, IntVal};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// An integer linear transformation of a discrete value.
@@ -11,7 +14,7 @@ use crate::{helpers::div_ceil, solver::IntLitMeaning, IntSetVal, IntVal, NonZero
 /// * x + offset`. The transformation can also be reversed.
 pub(crate) struct LinearTransform {
 	/// The multiplicative scale.
-	pub(crate) scale: NonZeroIntVal,
+	pub(crate) scale: NonZero<IntVal>,
 	/// The additive offset.
 	pub(crate) offset: IntVal,
 }
@@ -31,7 +34,7 @@ impl LinearTransform {
 	/// Creates a new linear transformation with the given offset and no scale.
 	pub(crate) fn offset(offset: IntVal) -> Self {
 		Self {
-			scale: NonZeroIntVal::new(1).unwrap(),
+			scale: NonZero::new(1).unwrap(),
 			offset,
 		}
 	}
@@ -127,7 +130,7 @@ impl LinearTransform {
 	}
 
 	/// Creates a new linear transformation with the given scale and no offset.
-	pub(crate) fn scaled(scale: NonZeroIntVal) -> Self {
+	pub(crate) fn scaled(scale: NonZero<IntVal>) -> Self {
 		Self { scale, offset: 0 }
 	}
 
@@ -173,18 +176,18 @@ impl Add<IntVal> for LinearTransform {
 impl Default for LinearTransform {
 	fn default() -> Self {
 		Self {
-			scale: NonZeroIntVal::new(1).unwrap(),
+			scale: NonZero::new(1).unwrap(),
 			offset: 0,
 		}
 	}
 }
 
-impl Mul<NonZeroIntVal> for LinearTransform {
+impl Mul<NonZero<IntVal>> for LinearTransform {
 	type Output = Self;
 
-	fn mul(self, rhs: NonZeroIntVal) -> Self::Output {
+	fn mul(self, rhs: NonZero<IntVal>) -> Self::Output {
 		LinearTransform {
-			scale: NonZeroIntVal::new(self.scale.get() * rhs.get()).unwrap(),
+			scale: NonZero::new(self.scale.get() * rhs.get()).unwrap(),
 			offset: self.offset * rhs.get(),
 		}
 	}
@@ -195,7 +198,7 @@ impl Neg for LinearTransform {
 
 	fn neg(self) -> Self::Output {
 		Self {
-			scale: NonZeroIntVal::new(-self.scale.get()).unwrap(),
+			scale: NonZero::new(-self.scale.get()).unwrap(),
 			offset: -self.offset,
 		}
 	}
@@ -211,12 +214,14 @@ impl Sub<IntVal> for LinearTransform {
 
 #[cfg(test)]
 mod tests {
-	use crate::{IntLitMeaning, IntSetVal, LinearTransform, NonZeroIntVal};
+	use std::num::NonZero;
+
+	use crate::{IntLitMeaning, IntSetVal, LinearTransform};
 
 	#[test]
 	fn test_add() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(3).unwrap(),
+			scale: NonZero::new(3).unwrap(),
 			offset: 6,
 		};
 		let result = lt + 2;
@@ -227,7 +232,7 @@ mod tests {
 	#[test]
 	fn test_can_divide_by() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(6).unwrap(),
+			scale: NonZero::new(6).unwrap(),
 			offset: 12,
 		};
 		assert!(lt.can_divide_by(3));
@@ -245,13 +250,13 @@ mod tests {
 	#[test]
 	fn test_is_identity() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(1).unwrap(),
+			scale: NonZero::new(1).unwrap(),
 			offset: 0,
 		};
 		assert!(lt.is_identity());
 
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(2).unwrap(),
+			scale: NonZero::new(2).unwrap(),
 			offset: 0,
 		};
 		assert!(!lt.is_identity());
@@ -260,10 +265,10 @@ mod tests {
 	#[test]
 	fn test_mul() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(3).unwrap(),
+			scale: NonZero::new(3).unwrap(),
 			offset: 6,
 		};
-		let result = lt * NonZeroIntVal::new(2).unwrap();
+		let result = lt * NonZero::new(2).unwrap();
 		assert_eq!(result.scale.get(), 6);
 		assert_eq!(result.offset, 12);
 	}
@@ -271,7 +276,7 @@ mod tests {
 	#[test]
 	fn test_neg() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(3).unwrap(),
+			scale: NonZero::new(3).unwrap(),
 			offset: 6,
 		};
 		let result = -lt;
@@ -289,13 +294,13 @@ mod tests {
 	#[test]
 	fn test_positive_scale() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(3).unwrap(),
+			scale: NonZero::new(3).unwrap(),
 			offset: 0,
 		};
 		assert!(lt.positive_scale());
 
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(-3).unwrap(),
+			scale: NonZero::new(-3).unwrap(),
 			offset: 0,
 		};
 		assert!(!lt.positive_scale());
@@ -304,7 +309,7 @@ mod tests {
 	#[test]
 	fn test_rev_remains_integer() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(3).unwrap(),
+			scale: NonZero::new(3).unwrap(),
 			offset: 6,
 		};
 		assert!(lt.rev_remains_integer(9));
@@ -314,7 +319,7 @@ mod tests {
 	#[test]
 	fn test_rev_transform_int_set() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(2).unwrap(),
+			scale: NonZero::new(2).unwrap(),
 			offset: 4,
 		};
 		let set = IntSetVal::from_iter([4..=8]);
@@ -325,7 +330,7 @@ mod tests {
 	#[test]
 	fn test_rev_transform_lit() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(2).unwrap(),
+			scale: NonZero::new(2).unwrap(),
 			offset: 4,
 		};
 		assert_eq!(
@@ -348,7 +353,7 @@ mod tests {
 
 	#[test]
 	fn test_scaled() {
-		let lt = LinearTransform::scaled(NonZeroIntVal::new(3).unwrap());
+		let lt = LinearTransform::scaled(NonZero::new(3).unwrap());
 		assert_eq!(lt.scale.get(), 3);
 		assert_eq!(lt.offset, 0);
 	}
@@ -356,7 +361,7 @@ mod tests {
 	#[test]
 	fn test_sub() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(3).unwrap(),
+			scale: NonZero::new(3).unwrap(),
 			offset: 6,
 		};
 		let result = lt - 2;
@@ -367,7 +372,7 @@ mod tests {
 	#[test]
 	fn test_transform() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(3).unwrap(),
+			scale: NonZero::new(3).unwrap(),
 			offset: 6,
 		};
 		assert_eq!(lt.transform(2), 12);
@@ -376,7 +381,7 @@ mod tests {
 	#[test]
 	fn test_transform_lit() {
 		let lt = LinearTransform {
-			scale: NonZeroIntVal::new(2).unwrap(),
+			scale: NonZero::new(2).unwrap(),
 			offset: 4,
 		};
 		assert_eq!(lt.transform_lit(IntLitMeaning::Eq(1)), IntLitMeaning::Eq(6));

--- a/crates/huub/src/helpers/static_dispatch.rs
+++ b/crates/huub/src/helpers/static_dispatch.rs
@@ -1,0 +1,162 @@
+macro_rules! static_dispatch {
+	// Entry
+  (
+	  [ $( $ty:tt |> $e:expr ),+ $(,)? ], | $($x:ident),+ | $body:expr
+  ) => {
+	  static_dispatch!(@recur [ $( $ty |> $e ),+ ] ; [] ; | $($x),+ | $body)
+  };
+  // Recursive case: still have at least one enum to match
+  (@recur  [ IntView |> $head:expr $(, $ty:tt |> $tail:expr )* ] ; [ $($bound:ident),* ] ;
+	  | $($x:ident),+ | $body:expr
+  ) => {
+	  match $head.0 {
+		  $crate::solver::IntViewInner::Const(v) => {
+			  static_dispatch!(
+				  @recur
+				  [ $( $ty |> $tail ),* ] ;
+				  [ $($bound,)* v ] ;
+				  | $($x),+ | $body
+			  )
+		  }
+		  $crate::solver::IntViewInner::Linear(lin) if lin.scale.get() == 1 && lin.offset == 0 => {
+				let view = lin.var;
+			  static_dispatch!(
+				  @recur
+				  [ $( $ty |> $tail ),* ] ;
+				  [ $($bound,)* view ] ;
+				  | $($x),+ | $body
+			  )
+		  }
+		  $crate::solver::IntViewInner::Linear(lin) if lin.scale.get() == 1 => {
+				let view = $crate::views::offset_view::OffsetView::new(lin.offset, lin.var);
+			  static_dispatch!(
+				  @recur
+				  [ $( $ty |> $tail ),* ] ;
+				  [ $($bound,)* view ] ;
+				  | $($x),+ | $body
+			  )
+		  }
+		  $crate::solver::IntViewInner::Linear(lin) => {
+			  static_dispatch!(
+				  @recur
+				  [ $( $ty |> $tail ),* ] ;
+				  [ $($bound,)* lin ] ;
+				  | $($x),+ | $body
+			  )
+		  }
+			$crate::solver::IntViewInner::Bool(view) => {
+			  static_dispatch!(
+				  @recur
+				  [ $( $ty |> $tail ),* ] ;
+				  [ $($bound,)* view ] ;
+				  | $($x),+ | $body
+			  )
+		  }
+	  }
+  };
+  (@recur  [ VecIntView |> $head:expr $(, $ty:tt |> $tail:expr )* ] ; [ $($bound:ident),* ] ;
+	  | $($x:ident),+ | $body:expr
+  ) => {{
+  	let mut const_ = 0;
+   	let mut bool_ = 0;
+    let mut int = 0;
+    let mut offset = 0;
+    let mut scale = 0;
+    let orig: Vec<$crate::solver::IntView> = $head;
+    for view in &orig {
+      match view.0 {
+        $crate::solver::IntViewInner::Const(_) => const_ += 1,
+        $crate::solver::IntViewInner::Bool(_) => bool_ += 1,
+        $crate::solver::IntViewInner::Linear(lin) if lin.scale.get() == 1 && lin.offset == 0 => int +=1,
+        $crate::solver::IntViewInner::Linear(lin) if lin.scale.get() == 1 => offset += 1,
+        $crate::solver::IntViewInner::Linear(_) => scale += 1,
+      }
+    }
+    match (const_, bool_, int, offset, scale) {
+	    (_, 0, 0, 0, 0) => {
+				let views: Vec<_> = orig.into_iter().map(|v| {let $crate::solver::IntViewInner::Const(c) = v.0 else {unreachable!()}; c}).collect();
+        static_dispatch!(
+          @recur
+          [ $( $ty |> $tail ),* ] ;
+          [ $($bound,)* views ] ;
+          | $($x),+ | $body
+        )
+	    }
+	    (0, _, 0, 0, 0) => {
+				let views: Vec<_> = orig.into_iter().map(|v| {let $crate::solver::IntViewInner::Bool(view) = v.0 else {unreachable!()}; view}).collect();
+        static_dispatch!(
+          @recur
+          [ $( $ty |> $tail ),* ] ;
+          [ $($bound,)* views ] ;
+          | $($x),+ | $body
+        )
+	    }
+	    (0, 0, _, 0, 0) => {
+				let views: Vec<_> = orig.into_iter().map(|v| {let $crate::solver::IntViewInner::Linear(view) = v.0 else {unreachable!()}; view.var}).collect();
+        static_dispatch!(
+          @recur
+          [ $( $ty |> $tail ),* ] ;
+          [ $($bound,)* views ] ;
+          | $($x),+ | $body
+        )
+	    }
+	    (0, 0, _, _, 0) => {
+				let views: Vec<_> = orig.into_iter().map(|v| {let $crate::solver::IntViewInner::Linear(view) = v.0 else {unreachable!()}; $crate::views::offset_view::OffsetView::new(view.offset, view.var)}).collect();
+        static_dispatch!(
+          @recur
+          [ $( $ty |> $tail ),* ] ;
+          [ $($bound,)* views ] ;
+          | $($x),+ | $body
+        )
+	    }
+	    (0, 0, _, _, _) => {
+				let views: Vec<_> = orig.into_iter().map(|v| {let $crate::solver::IntViewInner::Linear(view) = v.0 else {unreachable!()}; view}).collect();
+        static_dispatch!(
+          @recur
+          [ $( $ty |> $tail ),* ] ;
+          [ $($bound,)* views ] ;
+          | $($x),+ | $body
+        )
+	    }
+	    _ => {
+        static_dispatch!(
+          @recur
+          [ $( $ty |> $tail ),* ] ;
+          [ $($bound,)* orig ] ;
+          | $($x),+ | $body
+        )
+	    }
+    }
+  }};
+  (@recur  [ BoolView |> $head:expr $(, $ty:tt |> $tail:expr )* ] ; [ $($bound:ident),* ] ;
+	  | $($x:ident),+ | $body:expr
+  ) => {
+	  match $head.0 {
+		  $crate::solver::BoolViewInner::Const(v) => {
+			  static_dispatch!(
+				  @recur
+				  [ $( $ty:ty |> $tail ),* ] ;
+				  [ $($bound,)* v ] ;
+				  | $($x),+ | $body
+			  )
+		  }
+		  $crate::solver::BoolViewInner::Lit(v) => {
+			  static_dispatch!(
+				  @recur
+				  [ $( $ty:ty |> $tail ),* ] ;
+				  [ $($bound,)* v ] ;
+				  | $($x),+ | $body
+			  )
+		  }
+	  }
+  };
+  // Base case: no enums left — execute the body with the collected values
+  (@recur [ ] ; [ $($vals:ident),* ] ;
+	  | $($x:ident),+ | $body:expr
+  ) => {{
+	  let ( $($x),* ) = ( $($vals),* );
+	  $body
+  }};
+}
+
+pub(crate) use static_dispatch;

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -74,6 +74,7 @@ pub mod reformulate;
 pub mod solver;
 #[cfg(test)]
 pub(crate) mod tests;
+pub(crate) mod views;
 
 use std::{
 	any::Any,
@@ -81,7 +82,7 @@ use std::{
 	hash::Hash,
 	iter::{repeat_n, repeat_with, Sum},
 	mem,
-	num::{NonZeroI32, NonZeroI64},
+	num::{NonZero, NonZeroI32, NonZeroI64},
 	ops::{Add, AddAssign, Deref, Mul, Neg, Not, Sub},
 };
 
@@ -103,8 +104,8 @@ use crate::{
 		BoolInitActions, BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions,
 		ConstructionActions, DecisionActions, InitActions, IntDecisionActions,
 		IntExplanationActions, IntInitActions, IntInspectionActions, IntPropagationActions,
-		IntSimplificationActions, PropagationActions, ReasoningEngine, SimplificationActions,
-		TrailingActions,
+		IntSimplificationActions, PropagationActions, ReasoningContext, ReasoningEngine,
+		SimplificationActions, TrailingActions,
 	},
 	branchers::{BoolBrancher, IntBrancher, WarmStartBrancher},
 	constraints::{
@@ -298,9 +299,6 @@ pub struct ModelInitContext<'a> {
 	/// enqueued.
 	decision_enqueue: Option<bool>,
 }
-
-/// Type alias for a non-zero parameter integer value.
-pub type NonZeroIntVal = NonZeroI64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Strategy for limiting the domain of a selected decision variable as part of
@@ -694,14 +692,11 @@ impl BoolInspectionActions<ModelInitContext<'_>> for BoolDecision {
 }
 
 impl BoolPropagationActions<Model> for BoolDecision {
-	type Atom = BoolDecision;
-	type Conflict = <Model as ReasoningEngine>::Conflict;
-
 	fn set(
 		&self,
 		ctx: &mut Model,
-		reason: impl ReasonBuilder<Model, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<Model, BoolDecision>,
+	) -> Result<(), Conflict<BoolDecision>> {
 		use BoolDecisionInner::*;
 
 		let var = self.resolve_alias(ctx);
@@ -733,14 +728,14 @@ impl BoolPropagationActions<Model> for BoolDecision {
 		ctx: &mut Model,
 		val: bool,
 		reason: impl ReasonBuilder<Model, BoolDecision>,
-	) -> Result<(), Self::Conflict> {
+	) -> Result<(), Conflict<BoolDecision>> {
 		let lit = if val { *self } else { !*self };
 		lit.set(ctx, reason)
 	}
 }
 
 impl BoolSimplificationActions<Model> for BoolDecision {
-	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Self::Conflict> {
+	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Conflict<BoolDecision>> {
 		use BoolDecisionInner::*;
 
 		let x = self.resolve_alias(ctx);
@@ -1114,18 +1109,18 @@ impl From<i64> for IntDecision {
 }
 
 impl IntDecisionActions<Model> for IntDecision {
-	fn lit(&self, ctx: &mut Model, meaning: IntLitMeaning) -> Self::Atom {
+	fn lit(&self, ctx: &mut Model, meaning: IntLitMeaning) -> BoolDecision {
 		IntInspectionActions::try_lit(self, ctx, meaning).unwrap()
 	}
 
-	fn val_lit(&self, ctx: &mut Model) -> Option<Self::Atom> {
+	fn val_lit(&self, ctx: &mut Model) -> Option<BoolDecision> {
 		let val = self.val(ctx)?;
 		Some(Self::eq(self, val))
 	}
 }
 
 impl IntExplanationActions<Model> for IntDecision {
-	fn lit_relaxed(&self, ctx: &Model, meaning: IntLitMeaning) -> (Self::Atom, IntLitMeaning) {
+	fn lit_relaxed(&self, ctx: &Model, meaning: IntLitMeaning) -> (BoolDecision, IntLitMeaning) {
 		(self.try_lit(ctx, meaning).unwrap(), meaning)
 	}
 }
@@ -1224,8 +1219,6 @@ impl IntInitActions<ModelInitContext<'_>> for IntDecision {
 }
 
 impl IntInspectionActions<Model> for IntDecision {
-	type Atom = <Model as ReasoningEngine>::Atom;
-
 	fn domain(&self, ctx: &Model) -> IntSetVal {
 		let var = self.resolve_alias(ctx);
 		match var.0 {
@@ -1292,7 +1285,7 @@ impl IntInspectionActions<Model> for IntDecision {
 		}
 	}
 
-	fn lit_meaning(&self, _ctx: &Model, lit: Self::Atom) -> Option<IntLitMeaning> {
+	fn lit_meaning(&self, _ctx: &Model, lit: BoolDecision) -> Option<IntLitMeaning> {
 		const BOOL_DEF_MEANING: IntLitMeaning = IntLitMeaning::GreaterEq(1);
 
 		match self.0 {
@@ -1381,12 +1374,12 @@ impl IntInspectionActions<Model> for IntDecision {
 		}
 	}
 
-	fn lower_bound_lit(&self, ctx: &Model) -> Self::Atom {
+	fn lower_bound_lit(&self, ctx: &Model) -> BoolDecision {
 		let lb = self.lower_bound(ctx);
 		self.geq(lb)
 	}
 
-	fn try_lit(&self, _: &Model, meaning: IntLitMeaning) -> Option<Self::Atom> {
+	fn try_lit(&self, _: &Model, meaning: IntLitMeaning) -> Option<BoolDecision> {
 		Some(match meaning {
 			IntLitMeaning::Eq(v) => self.eq(v),
 			IntLitMeaning::NotEq(v) => self.ne(v),
@@ -1428,15 +1421,28 @@ impl IntInspectionActions<Model> for IntDecision {
 		}
 	}
 
-	fn upper_bound_lit(&self, ctx: &Model) -> Self::Atom {
+	fn upper_bound_lit(&self, ctx: &Model) -> BoolDecision {
 		let ub = self.upper_bound(ctx);
 		self.leq(ub)
+	}
+
+	fn bounds(&self, ctx: &Model) -> (IntVal, IntVal) {
+		let lb = self.lower_bound(ctx);
+		let ub = self.upper_bound(ctx);
+		(lb, ub)
+	}
+
+	fn val(&self, ctx: &Model) -> Option<IntVal> {
+		let (lb, ub) = self.bounds(ctx);
+		if lb == ub {
+			Some(lb)
+		} else {
+			None
+		}
 	}
 }
 
 impl IntInspectionActions<ModelInitContext<'_>> for IntDecision {
-	type Atom = <Self as IntInspectionActions<Model>>::Atom;
-
 	fn domain(&self, ctx: &ModelInitContext<'_>) -> IntSetVal {
 		self.domain(ctx.model)
 	}
@@ -1445,7 +1451,7 @@ impl IntInspectionActions<ModelInitContext<'_>> for IntDecision {
 		self.in_domain(ctx.model, val)
 	}
 
-	fn lit_meaning(&self, ctx: &ModelInitContext<'_>, lit: Self::Atom) -> Option<IntLitMeaning> {
+	fn lit_meaning(&self, ctx: &ModelInitContext<'_>, lit: BoolDecision) -> Option<IntLitMeaning> {
 		self.lit_meaning(ctx.model, lit)
 	}
 
@@ -1453,11 +1459,11 @@ impl IntInspectionActions<ModelInitContext<'_>> for IntDecision {
 		self.lower_bound(ctx.model)
 	}
 
-	fn lower_bound_lit(&self, ctx: &ModelInitContext<'_>) -> Self::Atom {
+	fn lower_bound_lit(&self, ctx: &ModelInitContext<'_>) -> BoolDecision {
 		self.lower_bound_lit(ctx.model)
 	}
 
-	fn try_lit(&self, ctx: &ModelInitContext<'_>, meaning: IntLitMeaning) -> Option<Self::Atom> {
+	fn try_lit(&self, ctx: &ModelInitContext<'_>, meaning: IntLitMeaning) -> Option<BoolDecision> {
 		self.try_lit(ctx.model, meaning)
 	}
 
@@ -1465,20 +1471,26 @@ impl IntInspectionActions<ModelInitContext<'_>> for IntDecision {
 		self.upper_bound(ctx.model)
 	}
 
-	fn upper_bound_lit(&self, ctx: &ModelInitContext<'_>) -> Self::Atom {
+	fn upper_bound_lit(&self, ctx: &ModelInitContext<'_>) -> BoolDecision {
 		self.upper_bound_lit(ctx.model)
+	}
+
+	fn bounds(&self, ctx: &ModelInitContext<'_>) -> (IntVal, IntVal) {
+		self.bounds(ctx.model)
+	}
+
+	fn val(&self, ctx: &ModelInitContext<'_>) -> Option<IntVal> {
+		self.val(ctx.model)
 	}
 }
 
 impl IntPropagationActions<Model> for IntDecision {
-	type Conflict = <Model as ReasoningEngine>::Conflict;
-
 	fn set_lower_bound(
 		&self,
 		ctx: &mut Model,
 		lb: IntVal,
 		reason: impl ReasonBuilder<Model, BoolDecision>,
-	) -> Result<(), Self::Conflict> {
+	) -> Result<(), Conflict<BoolDecision>> {
 		use IntDecisionInner::*;
 
 		let var = self.resolve_alias(ctx);
@@ -1532,7 +1544,7 @@ impl IntPropagationActions<Model> for IntDecision {
 		ctx: &mut Model,
 		val: IntVal,
 		reason: impl ReasonBuilder<Model, BoolDecision>,
-	) -> Result<(), Self::Conflict> {
+	) -> Result<(), Conflict<BoolDecision>> {
 		self.set_not_in_set(ctx, &(val..=val).into(), reason)
 	}
 
@@ -1541,7 +1553,7 @@ impl IntPropagationActions<Model> for IntDecision {
 		ctx: &mut Model,
 		ub: IntVal,
 		reason: impl ReasonBuilder<Model, BoolDecision>,
-	) -> Result<(), Self::Conflict> {
+	) -> Result<(), Conflict<BoolDecision>> {
 		use IntDecisionInner::*;
 
 		let var = self.resolve_alias(ctx);
@@ -1595,7 +1607,7 @@ impl IntPropagationActions<Model> for IntDecision {
 		ctx: &mut Model,
 		val: IntVal,
 		reason: impl ReasonBuilder<Model, BoolDecision>,
-	) -> Result<(), Self::Conflict> {
+	) -> Result<(), Conflict<BoolDecision>> {
 		use IntDecisionInner::*;
 
 		let var = self.resolve_alias(ctx);
@@ -1643,8 +1655,8 @@ impl IntSimplificationActions<Model> for IntDecision {
 		&self,
 		ctx: &mut Model,
 		values: &IntSetVal,
-		reason: impl ReasonBuilder<Model, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<Model, BoolDecision>,
+	) -> Result<(), Conflict<BoolDecision>> {
 		use IntDecisionInner::*;
 
 		let var = self.resolve_alias(ctx);
@@ -1701,7 +1713,7 @@ impl IntSimplificationActions<Model> for IntDecision {
 		ctx: &mut Model,
 		values: &IntSetVal,
 		reason: impl ReasonBuilder<Model, BoolDecision>,
-	) -> Result<(), Self::Conflict> {
+	) -> Result<(), Conflict<BoolDecision>> {
 		use IntDecisionInner::*;
 
 		let var = self.resolve_alias(ctx);
@@ -1753,7 +1765,7 @@ impl IntSimplificationActions<Model> for IntDecision {
 			}
 		}
 	}
-	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Self::Conflict> {
+	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Conflict<BoolDecision>> {
 		use IntDecisionInner::*;
 
 		let x = self.resolve_alias(ctx);
@@ -1797,7 +1809,7 @@ impl IntSimplificationActions<Model> for IntDecision {
 				// x_scale * x + x_scale = y_scale * y + y_offset
 				// === x = (y_scale / x_scale) * y + ((y_offset - x_offset) / x_scale)
 				let trans_y = LinearTransform::scaled(
-					NonZeroIntVal::new(y_t.scale.get() / x_t.scale.get()).unwrap(),
+					NonZero::new(y_t.scale.get() / x_t.scale.get()).unwrap(),
 				) + (y_t.offset - x_t.offset) / x_t.scale.get();
 				let target = IntDecision(Var(y_i)) * trans_y.scale + trans_y.offset;
 				(x_i, target)
@@ -1955,15 +1967,15 @@ impl Mul<IntVal> for IntDecision {
 		if rhs == 0 {
 			0.into()
 		} else {
-			self.mul(NonZeroIntVal::new(rhs).unwrap())
+			self.mul(NonZero::new(rhs).unwrap())
 		}
 	}
 }
 
-impl Mul<NonZeroIntVal> for IntDecision {
+impl Mul<NonZero<IntVal>> for IntDecision {
 	type Output = Self;
 
-	fn mul(self, rhs: NonZeroIntVal) -> Self::Output {
+	fn mul(self, rhs: NonZero<IntVal>) -> Self::Output {
 		use IntDecisionInner::*;
 
 		IntDecision(match self.0 {
@@ -1983,7 +1995,7 @@ impl Neg for IntDecision {
 		use IntDecisionInner::*;
 
 		IntDecision(match self.0 {
-			Var(x) => Linear(LinearTransform::scaled(NonZeroIntVal::new(-1).unwrap()), x),
+			Var(x) => Linear(LinearTransform::scaled(NonZero::new(-1).unwrap()), x),
 			Const(v) => Const(-v),
 			Linear(t, x) => Linear(-t, x),
 			Bool(t, x) => Bool(-t, x),
@@ -2143,18 +2155,6 @@ impl ElementConstraint for IntVal {
 	}
 }
 
-impl IntDecisionActions<Model> for IntVal {
-	fn lit(&self, ctx: &mut Model, meaning: IntLitMeaning) -> Self::Atom {
-		self.try_lit(ctx, meaning).unwrap()
-	}
-}
-
-impl IntExplanationActions<Model> for IntVal {
-	fn lit_relaxed(&self, ctx: &Model, meaning: IntLitMeaning) -> (Self::Atom, IntLitMeaning) {
-		(self.try_lit(ctx, meaning).unwrap(), meaning)
-	}
-}
-
 impl IntInitActions<ModelInitContext<'_>> for IntVal {
 	fn advise_when(&self, _: &mut ModelInitContext<'_>, _: IntPropCond, _: u64) {
 		// Value will never change, so no advisor will ever be called
@@ -2162,185 +2162,6 @@ impl IntInitActions<ModelInitContext<'_>> for IntVal {
 
 	fn enqueue_when(&self, ctx: &mut ModelInitContext<'_>, _: IntPropCond) {
 		ctx.semantic_enqueue = true;
-	}
-}
-
-impl IntInspectionActions<Model> for IntVal {
-	type Atom = BoolDecision;
-
-	fn domain(&self, _: &Model) -> IntSetVal {
-		(*self..=*self).into()
-	}
-
-	fn in_domain(&self, _: &Model, val: IntVal) -> bool {
-		*self == val
-	}
-
-	fn lit_meaning(&self, _: &Model, _: Self::Atom) -> Option<IntLitMeaning> {
-		None
-	}
-
-	fn lower_bound(&self, _: &Model) -> IntVal {
-		*self
-	}
-
-	fn lower_bound_lit(&self, _: &Model) -> Self::Atom {
-		true.into()
-	}
-
-	fn try_lit(&self, _: &Model, meaning: IntLitMeaning) -> Option<Self::Atom> {
-		Some(
-			match meaning {
-				IntLitMeaning::Eq(v) => *self == v,
-				IntLitMeaning::NotEq(v) => *self != v,
-				IntLitMeaning::GreaterEq(v) => *self >= v,
-				IntLitMeaning::Less(v) => *self < v,
-			}
-			.into(),
-		)
-	}
-
-	fn upper_bound(&self, _: &Model) -> IntVal {
-		*self
-	}
-
-	fn upper_bound_lit(&self, _: &Model) -> Self::Atom {
-		true.into()
-	}
-}
-
-impl IntInspectionActions<ModelInitContext<'_>> for IntVal {
-	type Atom = BoolDecision;
-
-	fn domain(&self, _: &ModelInitContext<'_>) -> IntSetVal {
-		(*self..=*self).into()
-	}
-
-	fn in_domain(&self, _: &ModelInitContext<'_>, val: IntVal) -> bool {
-		*self == val
-	}
-
-	fn lit_meaning(&self, _: &ModelInitContext<'_>, _: Self::Atom) -> Option<IntLitMeaning> {
-		None
-	}
-
-	fn lower_bound(&self, _: &ModelInitContext<'_>) -> IntVal {
-		*self
-	}
-
-	fn lower_bound_lit(&self, _: &ModelInitContext<'_>) -> Self::Atom {
-		true.into()
-	}
-
-	fn try_lit(&self, _: &ModelInitContext<'_>, meaning: IntLitMeaning) -> Option<Self::Atom> {
-		Some(
-			match meaning {
-				IntLitMeaning::Eq(v) => *self == v,
-				IntLitMeaning::NotEq(v) => *self != v,
-				IntLitMeaning::GreaterEq(v) => *self >= v,
-				IntLitMeaning::Less(v) => *self < v,
-			}
-			.into(),
-		)
-	}
-
-	fn upper_bound(&self, _: &ModelInitContext<'_>) -> IntVal {
-		*self
-	}
-
-	fn upper_bound_lit(&self, _: &ModelInitContext<'_>) -> Self::Atom {
-		true.into()
-	}
-}
-
-impl IntPropagationActions<Model> for IntVal {
-	type Conflict = <Model as ReasoningEngine>::Conflict;
-
-	fn set_lower_bound(
-		&self,
-		ctx: &mut Model,
-		val: IntVal,
-		reason: impl ReasonBuilder<Model, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
-		if val > *self {
-			Err(ctx.declare_conflict(reason))
-		} else {
-			Ok(())
-		}
-	}
-
-	fn set_not_eq(
-		&self,
-		ctx: &mut Model,
-		val: IntVal,
-		reason: impl ReasonBuilder<Model, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
-		if val == *self {
-			Err(ctx.declare_conflict(reason))
-		} else {
-			Ok(())
-		}
-	}
-
-	fn set_upper_bound(
-		&self,
-		ctx: &mut Model,
-		val: IntVal,
-		reason: impl ReasonBuilder<Model, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
-		if val < *self {
-			Err(ctx.declare_conflict(reason))
-		} else {
-			Ok(())
-		}
-	}
-
-	fn set_val(
-		&self,
-		ctx: &mut Model,
-		val: IntVal,
-		reason: impl ReasonBuilder<Model, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
-		if val != *self {
-			Err(ctx.declare_conflict(reason))
-		} else {
-			Ok(())
-		}
-	}
-}
-
-impl IntSimplificationActions<Model> for IntVal {
-	fn set_domain(
-		&self,
-		ctx: &mut Model,
-		domain: &IntSetVal,
-		reason: impl ReasonBuilder<Model, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
-		if !domain.contains(self) {
-			Err(ctx.declare_conflict(reason))
-		} else {
-			Ok(())
-		}
-	}
-	fn set_not_in_set(
-		&self,
-		ctx: &mut Model,
-		values: &IntSetVal,
-		reason: impl ReasonBuilder<Model, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
-		if values.contains(self) {
-			Err(ctx.declare_conflict(reason))
-		} else {
-			Ok(())
-		}
-	}
-
-	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Self::Conflict> {
-		if *self != other.into() {
-			Err(ctx.declare_conflict([]))
-		} else {
-			Ok(())
-		}
 	}
 }
 
@@ -2752,10 +2573,10 @@ impl DecisionActions for Model {
 }
 
 impl PropagationActions for Model {
-	type Atom = BoolDecision;
-	type Conflict = <Model as ReasoningEngine>::Conflict;
-
-	fn declare_conflict(&mut self, reason: impl ReasonBuilder<Self, Self::Atom>) -> Self::Conflict {
+	fn declare_conflict(
+		&mut self,
+		reason: impl ReasonBuilder<Self, BoolDecision>,
+	) -> Conflict<BoolDecision> {
 		match reason.build_reason(self) {
 			Ok(reason) => Conflict {
 				subject: None,
@@ -2775,6 +2596,11 @@ impl PropagationActions for Model {
 			data,
 		}
 	}
+}
+
+impl ReasoningContext for Model {
+	type Atom = <Self as ReasoningEngine>::Atom;
+	type Conflict = <Self as ReasoningEngine>::Conflict;
 }
 
 impl ReasoningEngine for Model {
@@ -2842,6 +2668,11 @@ impl InitActions for ModelInitContext<'_> {
 	}
 }
 
+impl ReasoningContext for ModelInitContext<'_> {
+	type Atom = <Model as ReasoningEngine>::Atom;
+	type Conflict = <Model as ReasoningEngine>::Conflict;
+}
+
 impl BoolInitActions<ModelInitContext<'_>> for bool {
 	fn advise_when_fixed(&self, _: &mut ModelInitContext<'_>, _: u64) {
 		// Value does not change, so no advisor will ever be called
@@ -2852,15 +2683,12 @@ impl BoolInitActions<ModelInitContext<'_>> for bool {
 }
 
 impl BoolPropagationActions<Model> for bool {
-	type Atom = BoolDecision;
-	type Conflict = <Model as ReasoningEngine>::Conflict;
-
 	fn set_val(
 		&self,
 		ctx: &mut Model,
 		val: bool,
-		reason: impl ReasonBuilder<Model, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<Model, BoolDecision>,
+	) -> Result<(), Conflict<BoolDecision>> {
 		if *self != val {
 			return Err(ctx.declare_conflict(reason));
 		}

--- a/crates/huub/src/reformulate.rs
+++ b/crates/huub/src/reformulate.rs
@@ -33,6 +33,7 @@ use crate::{
 		trail::TrailedInt,
 		BoolView, BoolViewInner, IntView, IntViewInner, View,
 	},
+	views::linear_bool_view::LinearBoolView,
 	BoolDecision, BoolFormula, Clause, Decision, IntDecision, IntLitMeaning, IntSetVal, IntVal,
 	Model, Solver,
 };
@@ -620,10 +621,11 @@ impl ReformulationMap {
 			Bool(t, bv) => {
 				let bv = self.get_bool(slv, bv);
 				match bv.0 {
-					BoolViewInner::Lit(lit) => IntView(IntViewInner::Bool {
-						transformer: t,
-						lit,
-					}),
+					BoolViewInner::Lit(lit) => IntView(IntViewInner::Bool(if t.positive_scale() {
+						LinearBoolView::new(t.scale, t.offset, lit)
+					} else {
+						LinearBoolView::new(-t.scale, t.offset + t.scale.get(), !lit)
+					})),
 					BoolViewInner::Const(b) => t.transform(b as IntVal).into(),
 				}
 			}

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -14,7 +14,7 @@ use std::{
 	fmt::{self, Debug, Display, Formatter},
 	hash::Hash,
 	mem,
-	num::NonZeroI32,
+	num::{NonZero, NonZeroI32},
 	ops::{Add, AddAssign, Deref, Mul, Neg, Not},
 	rc::Rc,
 };
@@ -31,28 +31,29 @@ use pindakaas::{
 	BoolVal, ClauseDatabase, ClauseDatabaseTools, Lit as RawLit, Unsatisfiable,
 	Valuation as SatValuation,
 };
-use rangelist::RangeList;
 use tracing::debug;
 
 use crate::{
 	actions::{
 		BoolInspectionActions, BoolPropagationActions, BrancherInitActions, ConstructionActions,
 		DecisionActions, IntDecisionActions, IntExplanationActions, IntInspectionActions,
-		IntPropagationActions, TrailingActions,
+		IntPropagationActions, PropagationActions, ReasoningContext, ReasoningEngine,
+		TrailingActions,
 	},
 	branchers::BoxedBrancher,
-	constraints::{BoxedPropagator, Conflict, ReasonBuilder},
+	constraints::{BoxedPropagator, ReasonBuilder},
 	flatzinc::{FlatZincError, FlatZincStatistics},
 	reformulate::InitConfig,
 	solver::{
-		engine::{Engine, State},
+		engine::Engine,
 		initialization_context::InitializationContext,
 		int_var::{DirectStorage, IntVarRef, OrderStorage},
 		queue::PropagatorInfo,
 		solving_context::SolvingContext,
 		trail::TrailedInt,
 	},
-	Clause, IntSetVal, IntVal, LinearTransform, Model, NonZeroIntVal,
+	views::{linear_bool_view::LinearBoolView, linear_view::LinearView},
+	Clause, IntSetVal, IntVal, Model,
 };
 
 /// Trait implemented by the object given to the callback on detecting failure
@@ -130,26 +131,12 @@ pub struct IntView(pub(crate) IntViewInner);
 ///
 /// Note that this representation is not meant to be exposed to the user.
 pub(crate) enum IntViewInner {
-	/// (Raw) Integer Variable
-	/// Reference to location in the Engine's State
-	VarRef(IntVarRef),
 	/// Constant Integer Value
 	Const(IntVal),
 	/// Linear View of an Integer Variable
-	Linear {
-		/// Linear transformation on the integer value of the variable.
-		transformer: LinearTransform,
-		/// Reference to an integer variable.
-		var: IntVarRef,
-	},
+	Linear(LinearView<NonZero<IntVal>, IntVal, IntVarRef>),
 	/// Linear View of an Boolean Literal.
-	Bool {
-		/// Linear transformation on the integer value of the Boolean literal.
-		transformer: LinearTransform,
-		/// The Boolean literal that is being treated as an integer (`false` ->
-		/// `0` and `true` -> `1`).
-		lit: RawLit,
-	},
+	Bool(LinearBoolView<NonZero<IntVal>, IntVal, RawLit>),
 }
 
 /// An assumption checker that can be used when no assumptions are used.
@@ -251,32 +238,6 @@ pub enum View {
 	Int(IntView),
 }
 
-#[inline]
-/// Internal method used to propagate a boolean variable used as a integer
-/// given a literal description to be enforced.
-fn propagate_bool_lin<Ctx>(
-	ctx: &mut Ctx,
-	lit: RawLit,
-	lit_req: IntLitMeaning,
-	reason: impl ReasonBuilder<Ctx, BoolView>,
-) -> Result<(), Conflict<RawLit>>
-where
-	RawLit: BoolPropagationActions<Ctx, Atom = BoolView, Conflict = Conflict<RawLit>>,
-{
-	match lit_req {
-		IntLitMeaning::Eq(0) | IntLitMeaning::Less(1) | IntLitMeaning::NotEq(1) => {
-			lit.set_val(ctx, false, reason)
-		}
-		IntLitMeaning::Eq(1) | IntLitMeaning::GreaterEq(1) | IntLitMeaning::NotEq(0) => {
-			lit.set(ctx, reason)
-		}
-		IntLitMeaning::Eq(_) => Err(Conflict::new(ctx, None, reason)),
-		IntLitMeaning::GreaterEq(i) if i > 1 => Err(Conflict::new(ctx, None, reason)),
-		IntLitMeaning::Less(i) if i <= 0 => Err(Conflict::new(ctx, None, reason)),
-		IntLitMeaning::NotEq(_) | IntLitMeaning::GreaterEq(_) | IntLitMeaning::Less(_) => Ok(()),
-	}
-}
-
 /// Helper function that calls [`tracing::debug!`] on learned clauses.
 ///
 /// This function is used as part of the callback given to the SAT oracle.
@@ -319,10 +280,7 @@ impl Add<IntVal> for BoolView {
 
 	fn add(self, rhs: IntVal) -> Self::Output {
 		match self.0 {
-			BoolViewInner::Lit(lit) => IntView(IntViewInner::Bool {
-				transformer: LinearTransform::offset(rhs),
-				lit,
-			}),
+			BoolViewInner::Lit(lit) => IntView(IntViewInner::Bool(LinearBoolView::from(lit) + rhs)),
 			BoolViewInner::Const(b) => (b as IntVal + rhs).into(),
 		}
 	}
@@ -359,10 +317,9 @@ impl Mul<IntVal> for BoolView {
 	fn mul(self, rhs: IntVal) -> Self::Output {
 		match self.0 {
 			_ if rhs == 0 => IntView(IntViewInner::Const(0)),
-			BoolViewInner::Lit(lit) => IntView(IntViewInner::Bool {
-				transformer: LinearTransform::scaled(NonZeroIntVal::new(rhs).unwrap()),
-				lit,
-			}),
+			BoolViewInner::Lit(lit) => IntView(IntViewInner::Bool(
+				LinearBoolView::from(lit) * NonZero::new(rhs).unwrap(),
+			)),
 			BoolViewInner::Const(b) => (b as IntVal * rhs).into(),
 		}
 	}
@@ -452,13 +409,13 @@ impl Not for IntLitMeaning {
 }
 
 impl<Oracle: ExternalPropagation> IntDecisionActions<Solver<Oracle>> for IntVarRef {
-	fn lit(&self, ctx: &mut Solver<Oracle>, meaning: IntLitMeaning) -> Self::Atom {
+	fn lit(&self, ctx: &mut Solver<Oracle>, meaning: IntLitMeaning) -> BoolView {
 		let (mut actions, mut engine) = ctx.as_parts_mut();
 		let mut ctx = SolvingContext::new(&mut actions, &mut engine.state);
 		self.lit(&mut ctx, meaning)
 	}
 
-	fn val_lit(&self, ctx: &mut Solver<Oracle>) -> Option<Self::Atom> {
+	fn val_lit(&self, ctx: &mut Solver<Oracle>) -> Option<BoolView> {
 		let (mut actions, mut engine) = ctx.as_parts_mut();
 		let mut ctx = SolvingContext::new(&mut actions, &mut engine.state);
 		IntDecisionActions::val_lit(self, &mut ctx)
@@ -466,8 +423,6 @@ impl<Oracle: ExternalPropagation> IntDecisionActions<Solver<Oracle>> for IntVarR
 }
 
 impl<Oracle> IntInspectionActions<Solver<Oracle>> for IntVarRef {
-	type Atom = <IntVarRef as IntInspectionActions<State>>::Atom;
-
 	fn domain(&self, ctx: &Solver<Oracle>) -> IntSetVal {
 		self.domain(&ctx.engine.borrow().state)
 	}
@@ -476,7 +431,7 @@ impl<Oracle> IntInspectionActions<Solver<Oracle>> for IntVarRef {
 		self.in_domain(&ctx.engine.borrow().state, val)
 	}
 
-	fn lit_meaning(&self, ctx: &Solver<Oracle>, lit: Self::Atom) -> Option<IntLitMeaning> {
+	fn lit_meaning(&self, ctx: &Solver<Oracle>, lit: BoolView) -> Option<IntLitMeaning> {
 		self.lit_meaning(&ctx.engine.borrow().state, lit)
 	}
 
@@ -484,11 +439,11 @@ impl<Oracle> IntInspectionActions<Solver<Oracle>> for IntVarRef {
 		self.lower_bound(&ctx.engine.borrow().state)
 	}
 
-	fn lower_bound_lit(&self, ctx: &Solver<Oracle>) -> Self::Atom {
+	fn lower_bound_lit(&self, ctx: &Solver<Oracle>) -> BoolView {
 		self.lower_bound_lit(&ctx.engine.borrow().state)
 	}
 
-	fn try_lit(&self, ctx: &Solver<Oracle>, meaning: IntLitMeaning) -> Option<Self::Atom> {
+	fn try_lit(&self, ctx: &Solver<Oracle>, meaning: IntLitMeaning) -> Option<BoolView> {
 		self.try_lit(&ctx.engine.borrow().state, meaning)
 	}
 
@@ -496,8 +451,23 @@ impl<Oracle> IntInspectionActions<Solver<Oracle>> for IntVarRef {
 		self.upper_bound(&ctx.engine.borrow().state)
 	}
 
-	fn upper_bound_lit(&self, ctx: &Solver<Oracle>) -> Self::Atom {
+	fn upper_bound_lit(&self, ctx: &Solver<Oracle>) -> BoolView {
 		self.upper_bound_lit(&ctx.engine.borrow().state)
+	}
+
+	fn bounds(&self, ctx: &Solver<Oracle>) -> (IntVal, IntVal) {
+		let lb = self.lower_bound(ctx);
+		let ub = self.upper_bound(ctx);
+		(lb, ub)
+	}
+
+	fn val(&self, ctx: &Solver<Oracle>) -> Option<IntVal> {
+		let (lb, ub) = self.bounds(ctx);
+		if lb == ub {
+			Some(lb)
+		} else {
+			None
+		}
 	}
 }
 
@@ -507,9 +477,8 @@ impl IntView {
 	/// variable.
 	pub fn int_reverse_map_info(&self) -> (Option<usize>, bool) {
 		match self.0 {
-			IntViewInner::VarRef(v) => (Some(v.into()), false),
 			IntViewInner::Bool { .. } => (None, true),
-			IntViewInner::Linear { var, .. } => (Some(var.into()), true),
+			IntViewInner::Linear(lin) => (Some(lin.var.into()), true),
 			_ => (None, true),
 		}
 	}
@@ -519,15 +488,9 @@ impl IntView {
 		&self,
 		slv: &Solver<Oracle>,
 	) -> Vec<(NonZeroI32, IntLitMeaning)> {
-		let transformer = match self.0 {
-			IntViewInner::Bool { transformer, .. } | IntViewInner::Linear { transformer, .. } => {
-				transformer
-			}
-			_ => LinearTransform::default(),
-		};
 		match self.0 {
-			IntViewInner::VarRef(v) | IntViewInner::Linear { var: v, .. } => {
-				let var = &slv.engine.borrow().state.int_vars[v];
+			IntViewInner::Linear(lin) => {
+				let var = &slv.engine.borrow().state.int_vars[lin.var];
 				let mut lits = Vec::new();
 
 				if let OrderStorage::Eager { storage, .. } = &var.order_encoding {
@@ -536,7 +499,7 @@ impl IntView {
 					for (lit, val) in (*storage).zip(val_iter) {
 						let i: NonZeroI32 = lit.into();
 						let orig = IntLitMeaning::Less(val);
-						let lt = transformer.transform_lit(orig);
+						let lt = lin.transform_meaning(orig);
 						let geq = !lt;
 						lits.extend([(i, lt), (-i, geq)]);
 					}
@@ -549,17 +512,17 @@ impl IntView {
 					for (lit, val) in (*vars).zip(val_iter) {
 						let i: NonZeroI32 = lit.into();
 						let orig = IntLitMeaning::Eq(val);
-						let eq = transformer.transform_lit(orig);
+						let eq = lin.transform_meaning(orig);
 						let ne = !eq;
 						lits.extend([(i, eq), (-i, ne)]);
 					}
 				}
 				lits
 			}
-			IntViewInner::Bool { lit, .. } => {
-				let i: NonZeroI32 = lit.into();
-				let lb = IntLitMeaning::Eq(transformer.transform(0));
-				let ub = IntLitMeaning::Eq(transformer.transform(1));
+			IntViewInner::Bool(lin) => {
+				let i: NonZeroI32 = lin.var.into();
+				let lb = lin.transform_meaning(IntLitMeaning::Eq(0));
+				let ub = lin.transform_meaning(IntLitMeaning::Eq(1));
 				vec![(i, ub), (-i, lb)]
 			}
 			_ => Vec::new(),
@@ -572,22 +535,9 @@ impl Add<IntVal> for IntView {
 
 	fn add(self, rhs: IntVal) -> Self::Output {
 		Self(match self.0 {
-			IntViewInner::VarRef(var) => IntViewInner::Linear {
-				transformer: LinearTransform::offset(rhs),
-				var,
-			},
 			IntViewInner::Const(i) => IntViewInner::Const(i + rhs),
-			IntViewInner::Linear {
-				transformer: transform,
-				var,
-			} => IntViewInner::Linear {
-				transformer: transform + rhs,
-				var,
-			},
-			IntViewInner::Bool { transformer, lit } => IntViewInner::Bool {
-				transformer: transformer + rhs,
-				lit,
-			},
+			IntViewInner::Linear(lin) => IntViewInner::Linear(lin + rhs),
+			IntViewInner::Bool(lin) => IntViewInner::Bool(lin + rhs),
 		})
 	}
 }
@@ -595,10 +545,7 @@ impl Add<IntVal> for IntView {
 impl From<BoolView> for IntView {
 	fn from(value: BoolView) -> Self {
 		Self(match value.0 {
-			BoolViewInner::Lit(l) => IntViewInner::Bool {
-				transformer: LinearTransform::offset(0),
-				lit: l,
-			},
+			BoolViewInner::Lit(l) => IntViewInner::Bool(l.into()),
 			BoolViewInner::Const(c) => IntViewInner::Const(c as IntVal),
 		})
 	}
@@ -610,400 +557,161 @@ impl From<IntVal> for IntView {
 	}
 }
 
+impl From<IntVarRef> for IntView {
+	fn from(value: IntVarRef) -> Self {
+		Self(IntViewInner::Linear(value.into()))
+	}
+}
+
 impl<Ctx> IntDecisionActions<Ctx> for IntView
 where
-	Ctx: ?Sized,
-	IntVarRef: IntDecisionActions<Ctx, Atom = BoolView>,
+	Ctx: ReasoningContext<Atom = BoolView> + ?Sized,
+	IntVarRef: IntDecisionActions<Ctx>,
 	RawLit: BoolInspectionActions<Ctx>,
 	BoolView: BoolInspectionActions<Ctx>,
 {
-	fn lit(&self, ctx: &mut Ctx, mut meaning: IntLitMeaning) -> Self::Atom {
-		if let IntViewInner::Linear { transformer, .. } | IntViewInner::Bool { transformer, .. } =
-			self.0
-		{
-			match transformer.rev_transform_lit(meaning) {
-				Ok(m) => meaning = m,
-				Err(v) => return BoolView(BoolViewInner::Const(v)),
-			}
-		}
-
+	fn lit(&self, ctx: &mut Ctx, meaning: IntLitMeaning) -> Ctx::Atom {
 		match self.0 {
-			IntViewInner::VarRef(var) | IntViewInner::Linear { var, .. } => var.lit(ctx, meaning),
-			IntViewInner::Const(c) => BoolView(BoolViewInner::Const(match meaning {
-				IntLitMeaning::Eq(i) => c == i,
-				IntLitMeaning::NotEq(i) => c != i,
-				IntLitMeaning::GreaterEq(i) => c >= i,
-				IntLitMeaning::Less(i) => c < i,
-			})),
-			IntViewInner::Bool { lit, .. } => {
-				let (meaning, negated) =
-					if matches!(meaning, IntLitMeaning::NotEq(_) | IntLitMeaning::Less(_)) {
-						(!meaning, true)
-					} else {
-						(meaning, false)
-					};
-				let bv = BoolView(match meaning {
-					IntLitMeaning::Eq(0) => BoolViewInner::Lit(!lit),
-					IntLitMeaning::Eq(1) => BoolViewInner::Lit(lit),
-					IntLitMeaning::Eq(_) => BoolViewInner::Const(false),
-					IntLitMeaning::GreaterEq(1) => BoolViewInner::Lit(lit),
-					IntLitMeaning::GreaterEq(i) if i > 1 => BoolViewInner::Const(false),
-					IntLitMeaning::GreaterEq(_) => BoolViewInner::Const(true),
-					_ => unreachable!(),
-				});
-				if negated {
-					!bv
-				} else {
-					bv
-				}
-			}
+			IntViewInner::Linear(lin) => lin.lit(ctx, meaning),
+			IntViewInner::Const(c) => c.lit(ctx, meaning),
+			IntViewInner::Bool(lin) => lin.lit(ctx, meaning),
 		}
 	}
 }
 
 impl<Ctx> IntExplanationActions<Ctx> for IntView
 where
-	Ctx: ?Sized,
-	IntVarRef: IntExplanationActions<Ctx, Atom = BoolView>,
+	Ctx: ReasoningContext<Atom = BoolView> + ?Sized,
+	IntVarRef: IntExplanationActions<Ctx>,
 	RawLit: BoolInspectionActions<Ctx>,
 	BoolView: BoolInspectionActions<Ctx>,
 {
-	fn lit_relaxed(&self, ctx: &Ctx, mut meaning: IntLitMeaning) -> (BoolView, IntLitMeaning) {
-		debug_assert!(
-			!matches!(meaning, IntLitMeaning::Eq(_)),
-			"relaxed integer literals are not yet supported for IntLitMeaning::Eq(_)"
-		);
-		// Transform literal meaning if view is a linear transformation
-		if let IntViewInner::Linear { transformer, .. } | IntViewInner::Bool { transformer, .. } =
-			self.0
-		{
-			match transformer.rev_transform_lit(meaning) {
-				Ok(m) => meaning = m,
-				Err(v) => return (BoolView(BoolViewInner::Const(v)), meaning),
-			}
+	fn lit_relaxed(&self, ctx: &Ctx, meaning: IntLitMeaning) -> (BoolView, IntLitMeaning) {
+		match self.0 {
+			IntViewInner::Linear(lin) => lin.lit_relaxed(ctx, meaning),
+			IntViewInner::Const(c) => c.lit_relaxed(ctx, meaning),
+			IntViewInner::Bool(lin) => lin.lit_relaxed(ctx, meaning),
 		}
-
-		// Get the boolean view that is currently `true` and implies the requested
-		// `meaning`, as well as the actual (possibly relaxed) meaning that is
-		// represented.
-		let (bv, meaning) = match self.0 {
-			IntViewInner::VarRef(iv) | IntViewInner::Linear { var: iv, .. } => {
-				iv.lit_relaxed(ctx, meaning)
-			}
-			IntViewInner::Const(c) => (
-				BoolView(BoolViewInner::Const(match meaning {
-					IntLitMeaning::GreaterEq(i) => c >= i,
-					IntLitMeaning::Less(i) => c < i,
-					IntLitMeaning::Eq(i) => c == i,
-					IntLitMeaning::NotEq(i) => c != i,
-				})),
-				meaning,
-			),
-			IntViewInner::Bool { lit, .. } => {
-				let (b_meaning, negated) =
-					if matches!(meaning, IntLitMeaning::NotEq(_) | IntLitMeaning::Less(_)) {
-						(!meaning, true)
-					} else {
-						(meaning, false)
-					};
-				let bv = BoolView(match b_meaning {
-					IntLitMeaning::GreaterEq(1) => BoolViewInner::Lit(lit),
-					IntLitMeaning::GreaterEq(i) if i > 1 => BoolViewInner::Const(false),
-					IntLitMeaning::GreaterEq(_) => BoolViewInner::Const(true),
-					IntLitMeaning::Eq(0) => BoolViewInner::Lit(!lit),
-					IntLitMeaning::Eq(1) => BoolViewInner::Lit(lit),
-					IntLitMeaning::Eq(_) => BoolViewInner::Const(false),
-					_ => unreachable!(),
-				});
-				(if negated { !bv } else { bv }, meaning)
-			}
-		};
-
-		// Transform the meaning back to fit the original view if it was linearly
-		// transformed
-		let meaning = if let IntViewInner::Linear { transformer, .. }
-		| IntViewInner::Bool { transformer, .. } = self.0
-		{
-			transformer.transform_lit(meaning)
-		} else {
-			meaning
-		};
-		(bv, meaning)
 	}
 }
 
 impl<Ctx> IntInspectionActions<Ctx> for IntView
 where
-	Ctx: ?Sized,
-	IntVarRef: IntInspectionActions<Ctx, Atom = BoolView>,
+	Ctx: ReasoningContext<Atom = BoolView> + ?Sized,
+	IntVarRef: IntInspectionActions<Ctx>,
 	RawLit: BoolInspectionActions<Ctx>,
 	BoolView: BoolInspectionActions<Ctx>,
 {
-	type Atom = BoolView;
-
 	fn domain(&self, ctx: &Ctx) -> IntSetVal {
 		match self.0 {
-			IntViewInner::VarRef(iv) => iv.domain(ctx),
-			IntViewInner::Const(c) => (c..=c).into(),
-			IntViewInner::Linear { transformer, var } if transformer.positive_scale() => {
-				RangeList::from_sorted_ranges(
-					var.domain(ctx).iter().map(|r| {
-						transformer.transform(*r.start())..=transformer.transform(*r.end())
-					}),
-				)
-			}
-			IntViewInner::Linear { transformer, var } => RangeList::from_sorted_ranges(
-				var.domain(ctx)
-					.iter()
-					.rev()
-					.map(|r| transformer.transform(*r.end())..=transformer.transform(*r.start())),
-			),
-			IntViewInner::Bool { transformer, lit } => if let Some(v) = lit.val(ctx) {
-				let v = transformer.transform(v as IntVal);
-				v..=v
-			} else if transformer.positive_scale() {
-				transformer.transform(0)..=transformer.transform(1)
-			} else {
-				transformer.transform(1)..=transformer.transform(0)
-			}
-			.into(),
+			IntViewInner::Const(c) => c.domain(ctx),
+			IntViewInner::Linear(lin) => lin.domain(ctx),
+			IntViewInner::Bool(lin) => lin.domain(ctx),
 		}
 	}
 
 	fn in_domain(&self, ctx: &Ctx, val: IntVal) -> bool {
-		let (lb, ub) = self.bounds(ctx);
-		if lb <= val && val <= ub {
-			let eq_lit = self.try_lit(ctx, IntLitMeaning::Eq(val));
-			if let Some(eq_lit) = eq_lit {
-				eq_lit.val(ctx).unwrap_or(true)
-			} else {
-				true
-			}
-		} else {
-			false
+		match self.0 {
+			IntViewInner::Const(c) => c.in_domain(ctx, val),
+			IntViewInner::Linear(lin) => lin.in_domain(ctx, val),
+			IntViewInner::Bool(lin) => lin.in_domain(ctx, val),
 		}
 	}
 
-	fn lit_meaning(&self, ctx: &Ctx, lit: Self::Atom) -> Option<IntLitMeaning> {
+	fn lit_meaning(&self, ctx: &Ctx, lit: BoolView) -> Option<IntLitMeaning> {
 		match self.0 {
-			IntViewInner::VarRef(iv) | IntViewInner::Linear { var: iv, .. } => {
-				let mut meaning = iv.lit_meaning(ctx, lit)?;
-				if let IntViewInner::Linear { transformer, .. } = self.0 {
-					meaning = transformer.transform_lit(meaning);
-				}
-				Some(meaning)
-			}
-			IntViewInner::Const(_) => None,
-			IntViewInner::Bool {
-				lit: var_lit,
-				transformer,
-			} => {
-				let BoolViewInner::Lit(lit) = lit.0 else {
-					return None;
-				};
-				if lit.var() != var_lit.var() {
-					return None;
-				}
-				let mut meaning = IntLitMeaning::GreaterEq(1);
-				if var_lit != lit {
-					meaning = !meaning;
-				}
-				meaning = transformer.transform_lit(meaning);
-				Some(meaning)
-			}
+			IntViewInner::Linear(lin) => lin.lit_meaning(ctx, lit),
+			IntViewInner::Const(c) => c.lit_meaning(ctx, lit),
+			IntViewInner::Bool(lin) => lin.lit_meaning(ctx, lit),
 		}
 	}
 
 	fn lower_bound(&self, ctx: &Ctx) -> IntVal {
 		match self.0 {
-			IntViewInner::VarRef(var) => var.lower_bound(ctx),
-			IntViewInner::Const(c) => c,
-			IntViewInner::Linear { transformer, var } => {
-				transformer.transform(if transformer.positive_scale() {
-					var.lower_bound(ctx)
-				} else {
-					var.upper_bound(ctx)
-				})
-			}
-			IntViewInner::Bool { transformer, lit } => transformer
-				.transform(lit.val(ctx).unwrap_or(!transformer.positive_scale()) as IntVal),
+			IntViewInner::Const(c) => c.lower_bound(ctx),
+			IntViewInner::Linear(lin) => lin.lower_bound(ctx),
+			IntViewInner::Bool(lin) => lin.lower_bound(ctx),
 		}
 	}
 
 	fn lower_bound_lit(&self, ctx: &Ctx) -> BoolView {
 		match self.0 {
-			IntViewInner::VarRef(var) => var.lower_bound_lit(ctx),
-			IntViewInner::Linear { transformer, var } => {
-				if transformer.positive_scale() {
-					var.lower_bound_lit(ctx)
-				} else {
-					var.upper_bound_lit(ctx)
-				}
-			}
-			IntViewInner::Const(_) => BoolView(BoolViewInner::Const(true)),
-			IntViewInner::Bool { lit, transformer } => {
-				BoolView(match (lit.val(ctx), transformer.positive_scale()) {
-					(Some(true), true) => BoolViewInner::Lit(lit),
-					(Some(false), false) => BoolViewInner::Lit(!lit),
-					_ => BoolViewInner::Const(true),
-				})
-			}
+			IntViewInner::Linear(lin) => lin.lower_bound_lit(ctx),
+			IntViewInner::Const(c) => c.lower_bound_lit(ctx),
+			IntViewInner::Bool(lin) => lin.lower_bound_lit(ctx),
 		}
 	}
 
-	fn try_lit(&self, ctx: &Ctx, mut meaning: IntLitMeaning) -> Option<BoolView> {
-		if let IntViewInner::Linear { transformer, .. } | IntViewInner::Bool { transformer, .. } =
-			self.0
-		{
-			match transformer.rev_transform_lit(meaning) {
-				Ok(m) => meaning = m,
-				Err(v) => return Some(BoolView(BoolViewInner::Const(v))),
-			}
-		}
-
+	fn try_lit(&self, ctx: &Ctx, meaning: IntLitMeaning) -> Option<BoolView> {
 		match self.0 {
-			IntViewInner::VarRef(var) | IntViewInner::Linear { var, .. } => {
-				var.try_lit(ctx, meaning)
-			}
-			IntViewInner::Const(c) => Some(BoolView(BoolViewInner::Const(match meaning {
-				IntLitMeaning::Eq(i) => c == i,
-				IntLitMeaning::NotEq(i) => c != i,
-				IntLitMeaning::GreaterEq(i) => c >= i,
-				IntLitMeaning::Less(i) => c < i,
-			}))),
-			IntViewInner::Bool { lit, .. } => {
-				let (meaning, negated) =
-					if matches!(meaning, IntLitMeaning::NotEq(_) | IntLitMeaning::Less(_)) {
-						(!meaning, true)
-					} else {
-						(meaning, false)
-					};
-				let bv = BoolView(match meaning {
-					IntLitMeaning::Eq(0) => BoolViewInner::Lit(!lit),
-					IntLitMeaning::Eq(1) => BoolViewInner::Lit(lit),
-					IntLitMeaning::Eq(_) => BoolViewInner::Const(false),
-					IntLitMeaning::GreaterEq(1) => BoolViewInner::Lit(lit),
-					IntLitMeaning::GreaterEq(i) if i > 1 => BoolViewInner::Const(false),
-					IntLitMeaning::GreaterEq(_) => BoolViewInner::Const(true),
-					_ => unreachable!(),
-				});
-				Some(if negated { !bv } else { bv })
-			}
+			IntViewInner::Linear(lin) => lin.try_lit(ctx, meaning),
+			IntViewInner::Const(c) => c.try_lit(ctx, meaning),
+			IntViewInner::Bool(lin) => lin.try_lit(ctx, meaning),
 		}
 	}
 
 	fn upper_bound(&self, ctx: &Ctx) -> IntVal {
 		match self.0 {
-			IntViewInner::VarRef(var) => var.upper_bound(ctx),
-			IntViewInner::Const(c) => c,
-			IntViewInner::Linear { transformer, var } => {
-				transformer.transform(if transformer.positive_scale() {
-					var.upper_bound(ctx)
-				} else {
-					var.lower_bound(ctx)
-				})
-			}
-			IntViewInner::Bool { transformer, lit } => transformer
-				.transform(lit.val(ctx).unwrap_or(transformer.positive_scale()) as IntVal),
+			IntViewInner::Const(c) => c.upper_bound(ctx),
+			IntViewInner::Linear(lin) => lin.upper_bound(ctx),
+			IntViewInner::Bool(lin) => lin.upper_bound(ctx),
 		}
 	}
 
 	fn upper_bound_lit(&self, ctx: &Ctx) -> BoolView {
 		match self.0 {
-			IntViewInner::VarRef(var) => var.upper_bound_lit(ctx),
-			IntViewInner::Linear { transformer, var } => {
-				if transformer.positive_scale() {
-					var.upper_bound_lit(ctx)
-				} else {
-					var.lower_bound_lit(ctx)
-				}
-			}
-			IntViewInner::Const(_) => BoolView(BoolViewInner::Const(true)),
-			IntViewInner::Bool { lit, transformer } => {
-				BoolView(match (lit.val(ctx), transformer.positive_scale()) {
-					(Some(false), true) => BoolViewInner::Lit(!lit),
-					(Some(true), false) => BoolViewInner::Lit(lit),
-					_ => BoolViewInner::Const(true),
-				})
-			}
+			IntViewInner::Linear(lin) => lin.upper_bound_lit(ctx),
+			IntViewInner::Const(c) => c.upper_bound_lit(ctx),
+			IntViewInner::Bool(lin) => lin.upper_bound_lit(ctx),
+		}
+	}
+
+	fn bounds(&self, ctx: &Ctx) -> (IntVal, IntVal) {
+		match self.0 {
+			IntViewInner::Const(c) => c.bounds(ctx),
+			IntViewInner::Linear(lin) => lin.bounds(ctx),
+			IntViewInner::Bool(lin) => lin.bounds(ctx),
+		}
+	}
+
+	fn val(&self, ctx: &Ctx) -> Option<IntVal> {
+		match self.0 {
+			IntViewInner::Const(c) => c.val(ctx),
+			IntViewInner::Linear(lin) => lin.val(ctx),
+			IntViewInner::Bool(lin) => lin.val(ctx),
 		}
 	}
 }
 
 impl<Ctx> IntPropagationActions<Ctx> for IntView
 where
-	IntVarRef: IntPropagationActions<Ctx, Atom = BoolView, Conflict = Conflict<RawLit>>,
-	RawLit: BoolPropagationActions<Ctx, Atom = BoolView, Conflict = Conflict<RawLit>>,
+	Ctx: PropagationActions<Atom = BoolView> + ?Sized,
+	IntVarRef: IntPropagationActions<Ctx>,
+	RawLit: BoolPropagationActions<Ctx>,
 {
-	type Conflict = Conflict<RawLit>;
-
 	fn set_lower_bound(
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
 		reason: impl ReasonBuilder<Ctx, BoolView>,
-	) -> Result<(), Self::Conflict> {
+	) -> Result<(), Ctx::Conflict> {
 		match self.0 {
-			IntViewInner::VarRef(var) => var.set_lower_bound(ctx, val, reason),
-			IntViewInner::Linear { var, transformer } => match transformer
-				.rev_transform_lit(IntLitMeaning::GreaterEq(val))
-				.unwrap()
-			{
-				IntLitMeaning::Less(v) => var.set_upper_bound(ctx, v - 1, reason),
-				IntLitMeaning::GreaterEq(v) => var.set_lower_bound(ctx, v, reason),
-				_ => unreachable!(),
-			},
-			IntViewInner::Bool { lit, transformer } => propagate_bool_lin(
-				ctx,
-				lit,
-				transformer
-					.rev_transform_lit(IntLitMeaning::GreaterEq(val))
-					.unwrap(),
-				reason,
-			),
-			IntViewInner::Const(i) => {
-				if i < val {
-					Err(Conflict::new(ctx, None, reason))
-				} else {
-					Ok(())
-				}
-			}
+			IntViewInner::Linear(lin) => lin.set_lower_bound(ctx, val, reason),
+			IntViewInner::Bool(lin) => lin.set_lower_bound(ctx, val, reason),
+			IntViewInner::Const(c) => c.set_lower_bound(ctx, val, reason),
 		}
 	}
 
 	fn set_not_eq(
 		&self,
 		ctx: &mut Ctx,
-		mut val: IntVal,
+		val: IntVal,
 		reason: impl ReasonBuilder<Ctx, BoolView>,
-	) -> Result<(), Self::Conflict> {
-		if let IntViewInner::Linear { transformer, .. } | IntViewInner::Bool { transformer, .. } =
-			self.0
-		{
-			match transformer.rev_transform_lit(IntLitMeaning::NotEq(val)) {
-				Ok(IntLitMeaning::NotEq(v)) => val = v,
-				Err(v) => {
-					debug_assert!(v);
-					return Ok(());
-				}
-				_ => unreachable!(),
-			}
-		}
-
+	) -> Result<(), Ctx::Conflict> {
 		match self.0 {
-			IntViewInner::VarRef(var) | IntViewInner::Linear { var, .. } => {
-				var.set_not_eq(ctx, val, reason)
-			}
-			IntViewInner::Bool { lit, .. } => {
-				propagate_bool_lin(ctx, lit, IntLitMeaning::NotEq(val), reason)
-			}
-			IntViewInner::Const(i) => {
-				if i == val {
-					Err(Conflict::new(ctx, None, reason))
-				} else {
-					Ok(())
-				}
-			}
+			IntViewInner::Linear(lin) => lin.set_not_eq(ctx, val, reason),
+			IntViewInner::Bool(lin) => lin.set_not_eq(ctx, val, reason),
+			IntViewInner::Const(c) => c.set_not_eq(ctx, val, reason),
 		}
 	}
 
@@ -1012,93 +720,36 @@ where
 		ctx: &mut Ctx,
 		val: IntVal,
 		reason: impl ReasonBuilder<Ctx, BoolView>,
-	) -> Result<(), Self::Conflict> {
+	) -> Result<(), Ctx::Conflict> {
 		match self.0 {
-			IntViewInner::VarRef(var) => var.set_upper_bound(ctx, val, reason),
-			IntViewInner::Linear { var, transformer } => {
-				match transformer
-					.rev_transform_lit(IntLitMeaning::Less(val + 1))
-					.unwrap()
-				{
-					IntLitMeaning::Less(v) => var.set_upper_bound(ctx, v - 1, reason),
-					IntLitMeaning::GreaterEq(v) => var.set_lower_bound(ctx, v, reason),
-					_ => unreachable!(),
-				}
-			}
-			IntViewInner::Bool { lit, transformer } => propagate_bool_lin(
-				ctx,
-				lit,
-				transformer
-					.rev_transform_lit(IntLitMeaning::Less(val + 1))
-					.unwrap(),
-				reason,
-			),
-			IntViewInner::Const(i) => {
-				if i > val {
-					Err(Conflict::new(ctx, None, reason))
-				} else {
-					Ok(())
-				}
-			}
+			IntViewInner::Linear(lin) => lin.set_upper_bound(ctx, val, reason),
+			IntViewInner::Bool(lin) => lin.set_upper_bound(ctx, val, reason),
+			IntViewInner::Const(c) => c.set_upper_bound(ctx, val, reason),
 		}
 	}
 
 	fn set_val(
 		&self,
 		ctx: &mut Ctx,
-		mut val: IntVal,
+		val: IntVal,
 		reason: impl ReasonBuilder<Ctx, BoolView>,
-	) -> Result<(), Self::Conflict> {
-		if let IntViewInner::Linear { transformer, .. } | IntViewInner::Bool { transformer, .. } =
-			self.0
-		{
-			match transformer.rev_transform_lit(IntLitMeaning::Eq(val)) {
-				Ok(IntLitMeaning::Eq(v)) => val = v,
-				Err(v) => {
-					debug_assert!(!v);
-					return Err(Conflict::new(ctx, None, reason));
-				}
-				_ => unreachable!(),
-			}
-		}
-
+	) -> Result<(), Ctx::Conflict> {
 		match self.0 {
-			IntViewInner::VarRef(iv) | IntViewInner::Linear { var: iv, .. } => {
-				iv.set_val(ctx, val, reason)
-			}
-			IntViewInner::Bool { lit, .. } => {
-				propagate_bool_lin(ctx, lit, IntLitMeaning::Eq(val), reason)
-			}
-			IntViewInner::Const(i) => {
-				if i != val {
-					Err(Conflict::new(ctx, None, reason))
-				} else {
-					Ok(())
-				}
-			}
+			IntViewInner::Linear(lin) => lin.set_val(ctx, val, reason),
+			IntViewInner::Bool(lin) => lin.set_val(ctx, val, reason),
+			IntViewInner::Const(c) => c.set_val(ctx, val, reason),
 		}
 	}
 }
 
-impl Mul<NonZeroIntVal> for IntView {
+impl Mul<NonZero<IntVal>> for IntView {
 	type Output = Self;
 
-	fn mul(self, rhs: NonZeroIntVal) -> Self::Output {
+	fn mul(self, rhs: NonZero<IntVal>) -> Self::Output {
 		Self(match self.0 {
-			x if rhs.get() == 1 => x,
-			IntViewInner::VarRef(iv) => IntViewInner::Linear {
-				transformer: LinearTransform::scaled(rhs),
-				var: iv,
-			},
 			IntViewInner::Const(c) => IntViewInner::Const(c * rhs.get()),
-			IntViewInner::Linear { transformer, var } => IntViewInner::Linear {
-				transformer: transformer * rhs,
-				var,
-			},
-			IntViewInner::Bool { transformer, lit } => IntViewInner::Bool {
-				transformer: transformer * rhs,
-				lit,
-			},
+			IntViewInner::Linear(lin) => IntViewInner::Linear(lin * rhs),
+			IntViewInner::Bool(lin) => IntViewInner::Bool(lin * rhs),
 		})
 	}
 }
@@ -1108,22 +759,9 @@ impl Neg for IntView {
 
 	fn neg(self) -> Self::Output {
 		Self(match self.0 {
-			IntViewInner::VarRef(var) => IntViewInner::Linear {
-				transformer: LinearTransform::scaled(NonZeroIntVal::new(-1).unwrap()),
-				var,
-			},
 			IntViewInner::Const(i) => IntViewInner::Const(-i),
-			IntViewInner::Linear {
-				transformer: transform,
-				var,
-			} => IntViewInner::Linear {
-				transformer: -transform,
-				var,
-			},
-			IntViewInner::Bool { transformer, lit } => IntViewInner::Bool {
-				transformer: -transformer,
-				lit,
-			},
+			IntViewInner::Linear(lin) => IntViewInner::Linear(-lin),
+			IntViewInner::Bool(lin) => IntViewInner::Bool(-lin),
 		})
 	}
 }
@@ -1578,15 +1216,11 @@ impl<Oracle: ExternalPropagation> Solver<Oracle> {
 				BoolViewInner::Const(b) => b,
 			}),
 			View::Int(var) => Value::Int(match var.0 {
-				IntViewInner::VarRef(iv) => int_val(Ref::clone(&engine), iv),
 				IntViewInner::Const(i) => i,
-				IntViewInner::Linear {
-					transformer: transform,
-					var,
-				} => transform.transform(int_val(Ref::clone(&engine), var)),
-				IntViewInner::Bool { transformer, lit } => {
-					transformer.transform(sol.value(lit) as IntVal)
+				IntViewInner::Linear(lin) => {
+					lin.transform_val(int_val(Ref::clone(&engine), lin.var))
 				}
+				IntViewInner::Bool(lin) => lin.transform_val(sol.value(lin.var) as IntVal),
 			}),
 		}
 	}
@@ -1655,7 +1289,7 @@ impl<Oracle: ExternalPropagation> BrancherInitActions for Solver<Oracle> {
 	fn ensure_decidable(&mut self, view: View) {
 		match view {
 			View::Bool(BoolView(BoolViewInner::Lit(lit)))
-			| View::Int(IntView(IntViewInner::Bool { lit, .. })) => {
+			| View::Int(IntView(IntViewInner::Bool(LinearBoolView { var: lit, .. }))) => {
 				self.engine
 					.borrow_mut()
 					.state
@@ -1734,6 +1368,11 @@ impl<Oracle> TrailingActions for Solver<Oracle> {
 	fn trailed_int(&self, x: TrailedInt) -> IntVal {
 		self.engine.borrow().state.trailed_int(x)
 	}
+}
+
+impl<Oracle> ReasoningContext for Solver<Oracle> {
+	type Atom = <Engine as ReasoningEngine>::Atom;
+	type Conflict = <Engine as ReasoningEngine>::Conflict;
 }
 
 impl Value {

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -34,8 +34,8 @@ use tracing::{debug, trace, warn};
 
 use crate::{
 	actions::{
-		BoolInspectionActions, IntExplanationActions, IntInspectionActions, ReasoningEngine,
-		TrailingActions,
+		BoolInspectionActions, IntExplanationActions, IntInspectionActions, ReasoningContext,
+		ReasoningEngine, TrailingActions,
 	},
 	branchers::{BoxedBrancher, Decision},
 	constraints::{BoxedPropagator, Conflict, LazyReason, Reason},
@@ -47,9 +47,9 @@ use crate::{
 		queue::PropagatorQueue,
 		solving_context::SolvingContext,
 		trail::{Trail, TrailedInt},
-		BoolView, BoolViewInner, IntLitMeaning, IntView, IntViewInner, SolverConfiguration,
+		BoolView, BoolViewInner, IntLitMeaning, SolverConfiguration,
 	},
-	Clause, IntVal,
+	Clause, IntSetVal, IntVal,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -670,7 +670,6 @@ impl PropagatorExtension for Engine {
 				// (DEBUG ONLY) Check that all integers that where fixed by equality
 				// literals had their bound literals set to match.
 				for (iv, i) in mem::take(&mut self.state.check_int_fixed) {
-					let iv = IntView(IntViewInner::VarRef(iv));
 					debug_assert_eq!(iv.val(&self.state), Some(i));
 					let lb_lit = iv
 						.try_lit(&self.state, IntLitMeaning::GreaterEq(i))
@@ -722,50 +721,6 @@ impl ReasoningEngine for Engine {
 	type PropagationCtx<'a> = SolvingContext<'a>;
 }
 
-impl IntInspectionActions<State> for IntVal {
-	type Atom = BoolView;
-
-	fn domain(&self, _: &State) -> crate::IntSetVal {
-		(*self..=*self).into()
-	}
-
-	fn in_domain(&self, _: &State, val: IntVal) -> bool {
-		*self == val
-	}
-
-	fn lit_meaning(&self, _: &State, _: Self::Atom) -> Option<IntLitMeaning> {
-		None
-	}
-
-	fn lower_bound(&self, _: &State) -> IntVal {
-		*self
-	}
-
-	fn lower_bound_lit(&self, _: &State) -> Self::Atom {
-		true.into()
-	}
-
-	fn try_lit(&self, _: &State, meaning: IntLitMeaning) -> Option<Self::Atom> {
-		Some(
-			match meaning {
-				IntLitMeaning::Eq(v) => *self == v,
-				IntLitMeaning::NotEq(v) => *self != v,
-				IntLitMeaning::GreaterEq(v) => *self >= v,
-				IntLitMeaning::Less(v) => *self < v,
-			}
-			.into(),
-		)
-	}
-
-	fn upper_bound(&self, _: &State) -> IntVal {
-		*self
-	}
-
-	fn upper_bound_lit(&self, _: &State) -> Self::Atom {
-		true.into()
-	}
-}
-
 impl IntExplanationActions<State> for IntVarRef {
 	fn lit_relaxed(&self, ctx: &State, mut meaning: IntLitMeaning) -> (BoolView, IntLitMeaning) {
 		debug_assert!(
@@ -805,9 +760,7 @@ impl IntExplanationActions<State> for IntVarRef {
 }
 
 impl IntInspectionActions<State> for IntVarRef {
-	type Atom = BoolView;
-
-	fn domain(&self, ctx: &State) -> crate::IntSetVal {
+	fn domain(&self, ctx: &State) -> IntSetVal {
 		ctx.int_vars[*self].domain(&ctx.trail)
 	}
 
@@ -825,7 +778,7 @@ impl IntInspectionActions<State> for IntVarRef {
 		}
 	}
 
-	fn lit_meaning(&self, ctx: &State, lit: Self::Atom) -> Option<IntLitMeaning> {
+	fn lit_meaning(&self, ctx: &State, lit: BoolView) -> Option<IntLitMeaning> {
 		let BoolViewInner::Lit(lit) = lit.0 else {
 			return None;
 		};
@@ -854,6 +807,21 @@ impl IntInspectionActions<State> for IntVarRef {
 
 	fn upper_bound_lit(&self, ctx: &State) -> BoolView {
 		ctx.int_vars[*self].upper_bound_lit(&ctx.trail)
+	}
+
+	fn bounds(&self, ctx: &State) -> (IntVal, IntVal) {
+		let lb = self.lower_bound(ctx);
+		let ub = self.upper_bound(ctx);
+		(lb, ub)
+	}
+
+	fn val(&self, ctx: &State) -> Option<IntVal> {
+		let (lb, ub) = self.bounds(ctx);
+		if lb == ub {
+			Some(lb)
+		} else {
+			None
+		}
 	}
 }
 
@@ -1012,6 +980,11 @@ impl State {
 		self.config.vsids_only = enable;
 		self.vsids = enable;
 	}
+}
+
+impl ReasoningContext for State {
+	type Atom = <Engine as ReasoningEngine>::Atom;
+	type Conflict = <Engine as ReasoningEngine>::Conflict;
 }
 
 impl TrailingActions for State {

--- a/crates/huub/src/solver/initialization_context.rs
+++ b/crates/huub/src/solver/initialization_context.rs
@@ -2,20 +2,24 @@
 //! [`ReasoningEngine::PostingCtx`] to [`Propagator`] implementations when they
 //! are posted to a [`Solver`].
 
+use std::num::NonZero;
+
 use pindakaas::{Lit as RawLit, Var as RawVar};
 
 use crate::{
 	actions::{
 		BoolInitActions, BoolInspectionActions, InitActions, IntInitActions, IntInspectionActions,
+		ReasoningContext, ReasoningEngine,
 	},
 	solver::{
 		activation_list::{ActivationAction, IntPropCond},
-		engine::{AdvisorDef, PropRef, State},
+		engine::{AdvisorDef, Engine, PropRef, State},
 		int_var::IntVarRef,
 		queue::PriorityLevel,
-		BoolView, BoolViewInner, IntView, IntViewInner,
+		BoolView, BoolViewInner, IntLitMeaning, IntView, IntViewInner,
 	},
-	IntVal,
+	views::{linear_bool_view::LinearBoolView, linear_view::LinearView, offset_view::OffsetView},
+	IntSetVal, IntVal,
 };
 
 #[derive(Debug)]
@@ -143,54 +147,11 @@ impl IntInitActions<InitializationContext<'_>> for IntVal {
 	}
 }
 
-impl IntInspectionActions<InitializationContext<'_>> for IntVal {
-	type Atom = <Self as IntInspectionActions<State>>::Atom;
-
-	fn domain(&self, _: &InitializationContext<'_>) -> crate::IntSetVal {
-		(*self..=*self).into()
-	}
-
-	fn in_domain(&self, ctx: &InitializationContext<'_>, val: IntVal) -> bool {
-		self.in_domain(ctx.state, val)
-	}
-
-	fn lit_meaning(
-		&self,
-		ctx: &InitializationContext<'_>,
-		lit: Self::Atom,
-	) -> Option<super::IntLitMeaning> {
-		self.lit_meaning(ctx.state, lit)
-	}
-
-	fn lower_bound(&self, ctx: &InitializationContext<'_>) -> IntVal {
-		self.lower_bound(ctx.state)
-	}
-
-	fn lower_bound_lit(&self, ctx: &InitializationContext<'_>) -> Self::Atom {
-		self.lower_bound_lit(ctx.state)
-	}
-
-	fn try_lit(
-		&self,
-		ctx: &InitializationContext<'_>,
-		meaning: super::IntLitMeaning,
-	) -> Option<Self::Atom> {
-		self.try_lit(ctx.state, meaning)
-	}
-
-	fn upper_bound(&self, ctx: &InitializationContext<'_>) -> IntVal {
-		self.upper_bound(ctx.state)
-	}
-
-	fn upper_bound_lit(&self, ctx: &InitializationContext<'_>) -> Self::Atom {
-		self.upper_bound_lit(ctx.state)
-	}
-}
-
 impl IntInitActions<InitializationContext<'_>> for IntVarRef {
 	fn advise_when(&self, ctx: &mut InitializationContext<'_>, condition: IntPropCond, data: u64) {
-		IntView(IntViewInner::VarRef(*self)).advise_when(ctx, condition, data);
+		IntView(IntViewInner::Linear((*self).into())).advise_when(ctx, condition, data);
 	}
+
 	fn enqueue_when(&self, ctx: &mut InitializationContext<'_>, condition: IntPropCond) {
 		if self.val(ctx.state).is_some() {
 			ctx.semantic_enqueue = true;
@@ -206,9 +167,7 @@ impl IntInitActions<InitializationContext<'_>> for IntVarRef {
 }
 
 impl IntInspectionActions<InitializationContext<'_>> for IntVarRef {
-	type Atom = <Self as IntInspectionActions<State>>::Atom;
-
-	fn domain(&self, ctx: &InitializationContext<'_>) -> crate::IntSetVal {
+	fn domain(&self, ctx: &InitializationContext<'_>) -> IntSetVal {
 		self.domain(ctx.state)
 	}
 
@@ -216,11 +175,7 @@ impl IntInspectionActions<InitializationContext<'_>> for IntVarRef {
 		self.in_domain(ctx.state, val)
 	}
 
-	fn lit_meaning(
-		&self,
-		ctx: &InitializationContext<'_>,
-		lit: Self::Atom,
-	) -> Option<super::IntLitMeaning> {
+	fn lit_meaning(&self, ctx: &InitializationContext<'_>, lit: BoolView) -> Option<IntLitMeaning> {
 		self.lit_meaning(ctx.state, lit)
 	}
 
@@ -228,15 +183,11 @@ impl IntInspectionActions<InitializationContext<'_>> for IntVarRef {
 		self.lower_bound(ctx.state)
 	}
 
-	fn lower_bound_lit(&self, ctx: &InitializationContext<'_>) -> Self::Atom {
+	fn lower_bound_lit(&self, ctx: &InitializationContext<'_>) -> BoolView {
 		self.lower_bound_lit(ctx.state)
 	}
 
-	fn try_lit(
-		&self,
-		ctx: &InitializationContext<'_>,
-		meaning: super::IntLitMeaning,
-	) -> Option<Self::Atom> {
+	fn try_lit(&self, ctx: &InitializationContext<'_>, meaning: IntLitMeaning) -> Option<BoolView> {
 		self.try_lit(ctx.state, meaning)
 	}
 
@@ -244,35 +195,75 @@ impl IntInspectionActions<InitializationContext<'_>> for IntVarRef {
 		self.upper_bound(ctx.state)
 	}
 
-	fn upper_bound_lit(&self, ctx: &InitializationContext<'_>) -> Self::Atom {
+	fn upper_bound_lit(&self, ctx: &InitializationContext<'_>) -> BoolView {
 		self.upper_bound_lit(ctx.state)
+	}
+
+	fn bounds(&self, ctx: &InitializationContext<'_>) -> (IntVal, IntVal) {
+		self.bounds(ctx.state)
+	}
+
+	fn val(&self, ctx: &InitializationContext<'_>) -> Option<IntVal> {
+		self.val(ctx.state)
 	}
 }
 
 impl<'a> IntInitActions<InitializationContext<'a>> for IntView {
 	fn advise_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond, data: u64) {
-		let (var, cond, negated) = match self.0 {
-			IntViewInner::VarRef(var) => (var, condition, false),
-			IntViewInner::Linear { transformer, var } => {
-				let condition = match condition {
-					IntPropCond::LowerBound if !transformer.positive_scale() => {
-						IntPropCond::UpperBound
-					}
-					IntPropCond::UpperBound if !transformer.positive_scale() => {
-						IntPropCond::LowerBound
-					}
-					_ => condition,
-				};
-				(var, condition, !transformer.positive_scale())
+		match self.0 {
+			IntViewInner::Linear(lin) => {
+				lin.advise_when(ctx, condition, data);
 			}
 			IntViewInner::Const(_) => {
 				// The variable will never change, so we don't need to add an
 				// advisor.
-				return;
 			}
-			IntViewInner::Bool { lit, .. } => {
-				return ctx.add_lit_advisor(lit, data, true);
+			IntViewInner::Bool(lin) => {
+				lin.advise_when(ctx, condition, data);
 			}
+		}
+	}
+	fn enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
+		match self.0 {
+			IntViewInner::Const(_) => {
+				ctx.semantic_enqueue = true;
+				// No further change will happen, so we don't need to add the
+				// propagator to any activation lists.
+			}
+			IntViewInner::Linear(lin) => {
+				lin.enqueue_when(ctx, condition);
+			}
+			IntViewInner::Bool(lin) => {
+				lin.enqueue_when(ctx, condition);
+			}
+		}
+	}
+}
+
+impl<'a> IntInitActions<InitializationContext<'a>>
+	for LinearBoolView<NonZero<IntVal>, IntVal, RawLit>
+{
+	fn advise_when(&self, ctx: &mut InitializationContext<'a>, _: IntPropCond, data: u64) {
+		ctx.add_lit_advisor(self.var, data, true);
+	}
+
+	fn enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
+		if condition != IntPropCond::Fixed {
+			ctx.semantic_enqueue = true;
+		}
+		self.var.enqueue_when_fixed(ctx);
+	}
+}
+
+impl<'a> IntInitActions<InitializationContext<'a>>
+	for LinearView<NonZero<IntVal>, IntVal, IntVarRef>
+{
+	fn advise_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond, data: u64) {
+		let negated = self.scale.get() < 0;
+		let cond = match condition {
+			IntPropCond::LowerBound if self.scale.get() < 0 => IntPropCond::UpperBound,
+			IntPropCond::UpperBound if self.scale.get() < 0 => IntPropCond::LowerBound,
+			_ => condition,
 		};
 		let adv = ctx.state.advisors.push(AdvisorDef {
 			bool2int: false,
@@ -280,35 +271,29 @@ impl<'a> IntInitActions<InitializationContext<'a>> for IntView {
 			negated,
 			propagator: ctx.prop,
 		});
-		ctx.state.int_activation[var].add(ActivationAction::<_, PropRef>::Advise(adv), cond);
+		ctx.state.int_activation[self.var].add(ActivationAction::<_, PropRef>::Advise(adv), cond);
 	}
+
 	fn enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
-		match self.0 {
-			IntViewInner::VarRef(iv) => iv.enqueue_when(ctx, condition),
-			IntViewInner::Const(_) => {
-				ctx.semantic_enqueue = true;
-				// No further change will happen, so we don't need to add the
-				// propagator to any activation lists.
-			}
-			IntViewInner::Linear { transformer, var } => {
-				let condition = match condition {
-					IntPropCond::LowerBound if !transformer.positive_scale() => {
-						IntPropCond::UpperBound
-					}
-					IntPropCond::UpperBound if !transformer.positive_scale() => {
-						IntPropCond::LowerBound
-					}
-					_ => condition,
-				};
-				var.enqueue_when(ctx, condition);
-			}
-			IntViewInner::Bool { lit, .. } => {
-				if condition != IntPropCond::Fixed {
-					ctx.semantic_enqueue = true;
-				}
-				lit.enqueue_when_fixed(ctx);
-			}
-		}
+		let condition = match condition {
+			IntPropCond::LowerBound if self.scale.get() < 0 => IntPropCond::UpperBound,
+			IntPropCond::UpperBound if self.scale.get() < 0 => IntPropCond::LowerBound,
+			_ => condition,
+		};
+		self.var.enqueue_when(ctx, condition);
+	}
+}
+
+impl<'a, Var> IntInitActions<InitializationContext<'a>> for OffsetView<IntVal, Var>
+where
+	Var: IntInitActions<InitializationContext<'a>>,
+{
+	fn advise_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond, data: u64) {
+		self.var.advise_when(ctx, condition, data);
+	}
+
+	fn enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
+		self.var.enqueue_when(ctx, condition);
 	}
 }
 
@@ -350,4 +335,9 @@ impl BoolInitActions<InitializationContext<'_>> for bool {
 	fn enqueue_when_fixed(&self, ctx: &mut InitializationContext<'_>) {
 		ctx.semantic_enqueue = true;
 	}
+}
+
+impl ReasoningContext for InitializationContext<'_> {
+	type Atom = <Engine as ReasoningEngine>::Atom;
+	type Conflict = <Engine as ReasoningEngine>::Conflict;
 }

--- a/crates/huub/src/solver/int_var.rs
+++ b/crates/huub/src/solver/int_var.rs
@@ -3,7 +3,8 @@
 use std::{
 	collections::hash_map::{self, VacantEntry},
 	iter::{Map, Peekable},
-	ops::{Index, IndexMut, RangeBounds, RangeInclusive},
+	num::NonZero,
+	ops::{Index, IndexMut, Neg, RangeBounds, RangeInclusive},
 };
 
 use itertools::Itertools;
@@ -17,7 +18,8 @@ use rustc_hash::FxHashMap;
 use crate::{
 	actions::{BoolInspectionActions, TrailingActions},
 	solver::{trail::TrailedInt, BoolView, BoolViewInner, IntLitMeaning, IntView, IntViewInner},
-	IntSetVal, IntVal, LinearTransform, NonZeroIntVal, Solver,
+	views::{linear_bool_view::LinearBoolView, linear_view::LinearView},
+	IntSetVal, IntVal, Solver,
 };
 
 /// An entry in the [`DirectStorage`] that can be used to access the
@@ -481,6 +483,10 @@ impl IntVar {
 		T: TrailingActions,
 		RawLit: BoolInspectionActions<T>,
 	{
+		if v < self.upper_bound(trail) {
+			println!("{}", self.upper_bound(trail));
+			println!("What?!");
+		}
 		debug_assert!(v >= self.upper_bound(trail));
 		if v > *self.domain.upper_bound().unwrap() {
 			return (BoolView(BoolViewInner::Const(true)), v);
@@ -728,13 +734,12 @@ impl IntVar {
 		let ub = *domain.upper_bound().unwrap();
 		if orig_domain_len == Some(2) {
 			let lit = slv.oracle.new_lit();
-			return IntView(IntViewInner::Bool {
-				transformer: LinearTransform {
-					scale: NonZeroIntVal::new(ub - lb).unwrap(),
-					offset: lb,
-				},
+
+			return IntView(IntViewInner::Bool(LinearBoolView::new(
+				NonZero::new(ub - lb).unwrap(),
+				lb,
 				lit,
-			});
+			)));
 		}
 		debug_assert!(
 			direct_encoding != EncodingType::Eager || order_encoding == EncodingType::Eager
@@ -824,7 +829,7 @@ impl IntVar {
 			}
 		}
 
-		IntView(IntViewInner::VarRef(iv))
+		IntView(IntViewInner::Linear(iv.into()))
 	}
 
 	/// Notify that a new lower bound has been propagated for the variable,
@@ -986,6 +991,15 @@ impl IntVar {
 				})
 			}
 		}
+	}
+}
+
+impl Neg for IntVarRef {
+	type Output = LinearView<NonZero<IntVal>, IntVal, Self>;
+
+	fn neg(self) -> Self::Output {
+		let lin: LinearView<NonZero<IntVal>, IntVal, Self> = self.into();
+		-lin
 	}
 }
 
@@ -1381,6 +1395,7 @@ mod tests {
 			int_var::{EncodingType, IntVar, IntVarRef},
 			BoolView, BoolViewInner, IntLitMeaning, IntView, IntViewInner,
 		},
+		views::linear_view::LinearView,
 		Solver,
 	};
 
@@ -1408,10 +1423,9 @@ mod tests {
 		lits: impl IntoIterator<Item = BoolView>,
 		output: impl IntoIterator<Item = IntLitMeaning>,
 	) {
-		let view = IntView(IntViewInner::VarRef(iv));
 		for (req, expected) in input.into_iter().zip_eq(lits.into_iter().zip_eq(output)) {
-			let bv = view.lit(slv, req);
-			let m = view.lit_meaning(slv, bv).unwrap_or(req);
+			let bv = iv.lit(slv, req);
+			let m = iv.lit_meaning(slv, bv).unwrap_or(req);
 			assert_eq!((bv, m), expected, "given {req:?}");
 
 			let v = &mut slv.engine.borrow_mut().state.int_vars[iv];
@@ -1431,7 +1445,7 @@ mod tests {
 			EncodingType::Eager,
 			EncodingType::Eager,
 		);
-		let IntView(IntViewInner::VarRef(a)) = a else {
+		let IntView(IntViewInner::Linear(LinearView { var: a, .. })) = a else {
 			unreachable!()
 		};
 		let a = &mut slv.engine.borrow_mut().state.int_vars[a];
@@ -1490,7 +1504,7 @@ mod tests {
 			EncodingType::Eager,
 			EncodingType::Eager,
 		);
-		let IntView(IntViewInner::VarRef(a)) = a else {
+		let IntView(IntViewInner::Linear(LinearView { var: a, .. })) = a else {
 			unreachable!()
 		};
 		let a = &mut slv.engine.borrow_mut().state.int_vars[a];
@@ -1571,7 +1585,7 @@ mod tests {
 			EncodingType::Lazy,
 			EncodingType::Lazy,
 		);
-		let IntView(IntViewInner::VarRef(a)) = a else {
+		let IntView(IntViewInner::Linear(LinearView { var: a, .. })) = a else {
 			unreachable!()
 		};
 		assert_lazy_lits_eq(

--- a/crates/huub/src/solver/solving_context.rs
+++ b/crates/huub/src/solver/solving_context.rs
@@ -12,17 +12,18 @@ use tracing::trace;
 use crate::{
 	actions::{
 		BoolInspectionActions, BoolPropagationActions, DecisionActions, IntDecisionActions,
-		IntInspectionActions, IntPropagationActions, PropagationActions, TrailingActions,
+		IntInspectionActions, IntPropagationActions, PropagationActions, ReasoningContext,
+		ReasoningEngine, TrailingActions,
 	},
 	constraints::{Conflict, LazyReason, Reason, ReasonBuilder},
 	solver::{
 		activation_list::IntEvent,
-		engine::{trace_new_lit, LitPropagation, PropRef, State},
+		engine::{trace_new_lit, Engine, LitPropagation, PropRef, State},
 		int_var::{IntVarRef, LazyLitDef},
 		trail::TrailedInt,
 		BoolView, BoolViewInner, BoxedPropagator,
 	},
-	IntLitMeaning, IntVal,
+	IntLitMeaning, IntSetVal, IntVal,
 };
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
@@ -59,14 +60,11 @@ pub struct SolvingContext<'a> {
 }
 
 impl<'a> BoolPropagationActions<SolvingContext<'a>> for BoolView {
-	type Atom = BoolView;
-	type Conflict = Conflict<RawLit>;
-
 	fn set(
 		&self,
 		ctx: &mut SolvingContext<'a>,
-		reason: impl ReasonBuilder<SolvingContext<'a>, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<SolvingContext<'a>, BoolView>,
+	) -> Result<(), Conflict<RawLit>> {
 		match self.0 {
 			BoolViewInner::Lit(lit) => lit.set(ctx, reason),
 			BoolViewInner::Const(false) => Err(Conflict::new(ctx, None, reason)),
@@ -79,7 +77,7 @@ impl<'a> BoolPropagationActions<SolvingContext<'a>> for BoolView {
 		ctx: &mut SolvingContext<'a>,
 		val: bool,
 		reason: impl ReasonBuilder<SolvingContext<'a>, BoolView>,
-	) -> Result<(), Self::Conflict> {
+	) -> Result<(), Conflict<RawLit>> {
 		if val { *self } else { !(*self) }.set(ctx, reason)
 	}
 }
@@ -108,9 +106,7 @@ impl IntDecisionActions<SolvingContext<'_>> for IntVarRef {
 }
 
 impl IntInspectionActions<SolvingContext<'_>> for IntVarRef {
-	type Atom = <IntVarRef as IntInspectionActions<State>>::Atom;
-
-	fn domain(&self, ctx: &SolvingContext<'_>) -> crate::IntSetVal {
+	fn domain(&self, ctx: &SolvingContext<'_>) -> IntSetVal {
 		self.domain(ctx.state)
 	}
 
@@ -118,7 +114,7 @@ impl IntInspectionActions<SolvingContext<'_>> for IntVarRef {
 		self.in_domain(ctx.state, val)
 	}
 
-	fn lit_meaning(&self, ctx: &SolvingContext<'_>, lit: Self::Atom) -> Option<IntLitMeaning> {
+	fn lit_meaning(&self, ctx: &SolvingContext<'_>, lit: BoolView) -> Option<IntLitMeaning> {
 		self.lit_meaning(ctx.state, lit)
 	}
 
@@ -126,11 +122,11 @@ impl IntInspectionActions<SolvingContext<'_>> for IntVarRef {
 		self.lower_bound(ctx.state)
 	}
 
-	fn lower_bound_lit(&self, ctx: &SolvingContext<'_>) -> Self::Atom {
+	fn lower_bound_lit(&self, ctx: &SolvingContext<'_>) -> BoolView {
 		self.lower_bound_lit(ctx.state)
 	}
 
-	fn try_lit(&self, ctx: &SolvingContext<'_>, meaning: IntLitMeaning) -> Option<Self::Atom> {
+	fn try_lit(&self, ctx: &SolvingContext<'_>, meaning: IntLitMeaning) -> Option<BoolView> {
 		self.try_lit(ctx.state, meaning)
 	}
 
@@ -138,20 +134,26 @@ impl IntInspectionActions<SolvingContext<'_>> for IntVarRef {
 		self.upper_bound(ctx.state)
 	}
 
-	fn upper_bound_lit(&self, ctx: &SolvingContext<'_>) -> Self::Atom {
+	fn upper_bound_lit(&self, ctx: &SolvingContext<'_>) -> BoolView {
 		self.upper_bound_lit(ctx.state)
+	}
+
+	fn bounds(&self, ctx: &SolvingContext<'_>) -> (IntVal, IntVal) {
+		self.bounds(ctx.state)
+	}
+
+	fn val(&self, ctx: &SolvingContext<'_>) -> Option<IntVal> {
+		self.val(ctx.state)
 	}
 }
 
 impl<'a> IntPropagationActions<SolvingContext<'a>> for IntVarRef {
-	type Conflict = Conflict<RawLit>;
-
 	fn set_lower_bound(
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<SolvingContext<'a>, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<SolvingContext<'a>, BoolView>,
+	) -> Result<(), Conflict<RawLit>> {
 		ctx.propagate_int(*self, IntLitMeaning::GreaterEq(val), reason)
 	}
 
@@ -159,8 +161,8 @@ impl<'a> IntPropagationActions<SolvingContext<'a>> for IntVarRef {
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<SolvingContext<'a>, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<SolvingContext<'a>, BoolView>,
+	) -> Result<(), Conflict<RawLit>> {
 		ctx.propagate_int(*self, IntLitMeaning::NotEq(val), reason)
 	}
 
@@ -168,8 +170,8 @@ impl<'a> IntPropagationActions<SolvingContext<'a>> for IntVarRef {
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<SolvingContext<'a>, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<SolvingContext<'a>, BoolView>,
+	) -> Result<(), Conflict<RawLit>> {
 		ctx.propagate_int(*self, IntLitMeaning::Less(val + 1), reason)
 	}
 
@@ -177,8 +179,8 @@ impl<'a> IntPropagationActions<SolvingContext<'a>> for IntVarRef {
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<SolvingContext<'a>, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<SolvingContext<'a>, BoolView>,
+	) -> Result<(), Conflict<RawLit>> {
 		ctx.propagate_int(*self, IntLitMeaning::Eq(val), reason)
 	}
 }
@@ -190,14 +192,11 @@ impl BoolInspectionActions<SolvingContext<'_>> for RawLit {
 }
 
 impl<'a> BoolPropagationActions<SolvingContext<'a>> for RawLit {
-	type Atom = BoolView;
-	type Conflict = Conflict<RawLit>;
-
 	fn set(
 		&self,
 		ctx: &mut SolvingContext<'a>,
-		reason: impl ReasonBuilder<SolvingContext<'a>, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<SolvingContext<'a>, BoolView>,
+	) -> Result<(), Conflict<RawLit>> {
 		match ctx.state.trail.sat_value(*self) {
 			Some(true) => Ok(()),
 			Some(false) => Err(Conflict::new(ctx, Some(*self), reason)),
@@ -212,8 +211,8 @@ impl<'a> BoolPropagationActions<SolvingContext<'a>> for RawLit {
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: bool,
-		reason: impl ReasonBuilder<SolvingContext<'a>, Self::Atom>,
-	) -> Result<(), Self::Conflict> {
+		reason: impl ReasonBuilder<SolvingContext<'a>, BoolView>,
+	) -> Result<(), Conflict<RawLit>> {
 		if val { *self } else { !(*self) }.set(ctx, reason)
 	}
 }
@@ -408,10 +407,7 @@ impl DecisionActions for SolvingContext<'_> {
 }
 
 impl PropagationActions for SolvingContext<'_> {
-	type Atom = BoolView;
-	type Conflict = Conflict<RawLit>;
-
-	fn declare_conflict(&mut self, reason: impl ReasonBuilder<Self, Self::Atom>) -> Self::Conflict {
+	fn declare_conflict(&mut self, reason: impl ReasonBuilder<Self, BoolView>) -> Conflict<RawLit> {
 		Conflict::new(self, None, reason)
 	}
 
@@ -431,4 +427,9 @@ impl TrailingActions for SolvingContext<'_> {
 	fn trailed_int(&self, x: TrailedInt) -> IntVal {
 		self.state.trailed_int(x)
 	}
+}
+
+impl ReasoningContext for SolvingContext<'_> {
+	type Atom = <Engine as ReasoningEngine>::Atom;
+	type Conflict = <Engine as ReasoningEngine>::Conflict;
 }

--- a/crates/huub/src/tests.rs
+++ b/crates/huub/src/tests.rs
@@ -1,3 +1,5 @@
+use std::num::NonZero;
+
 use expect_test::{expect, Expect};
 use itertools::Itertools;
 use pindakaas::propositional_logic::Formula;
@@ -13,8 +15,7 @@ use crate::{
 		int_var::{EncodingType, IntVar},
 		SolveResult, Value, View,
 	},
-	Decision, InitConfig, Model, NonZeroIntVal, ReformulationError, Solver, ValueSelection,
-	VariableSelection,
+	Decision, InitConfig, Model, ReformulationError, Solver, ValueSelection, VariableSelection,
 };
 
 #[test]
@@ -74,13 +75,13 @@ fn test_duplicate_propagation() {
 	IntLinearLessEqBounds::post(
 		&mut slv,
 		[
-			a * NonZeroIntVal::new(3).unwrap(),
+			a * NonZero::new(3).unwrap(),
 			b,
-			b * NonZeroIntVal::new(2).unwrap(),
+			b * NonZero::new(2).unwrap(),
 		],
 		3,
 	);
-	IntLinearNotEqValue::post(&mut slv, [a * NonZeroIntVal::new(3).unwrap(), b], 3);
+	IntLinearNotEqValue::post(&mut slv, [a * NonZero::new(3).unwrap(), b], 3);
 	IntBrancher::new_in(
 		&mut slv,
 		vec![a, b],

--- a/crates/huub/src/views.rs
+++ b/crates/huub/src/views.rs
@@ -1,0 +1,3 @@
+pub(crate) mod linear_bool_view;
+pub(crate) mod linear_view;
+pub(crate) mod offset_view;

--- a/crates/huub/src/views/linear_bool_view.rs
+++ b/crates/huub/src/views/linear_bool_view.rs
@@ -1,0 +1,395 @@
+use std::{
+	fmt::Debug,
+	hash::Hash,
+	num::NonZero,
+	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+};
+
+use rangelist::{IntervalIterator, RangeList};
+
+use crate::{
+	actions::{
+		BoolInspectionActions, BoolOperations, BoolPropagationActions, BoolSimplificationActions,
+		IntDecisionActions, IntExplanationActions, IntInspectionActions, IntPropagationActions,
+		IntSimplificationActions, PropagationActions, ReasoningContext,
+	},
+	constraints::ReasonBuilder,
+	helpers::{div_ceil, div_floor},
+	solver::IntLitMeaning,
+	views::offset_view::OffsetView,
+	IntSetVal, IntVal,
+};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct LinearBoolView<Scale, Offset, Var> {
+	pub(crate) scale: Scale,
+	pub(crate) offset: Offset,
+	pub(crate) var: Var,
+}
+
+impl<Var> LinearBoolView<NonZero<IntVal>, IntVal, Var> {
+	pub(crate) fn new(scale: NonZero<IntVal>, offset: IntVal, var: Var) -> Self {
+		assert!(
+			scale.get() >= 0,
+			"LinearPosView::new: scale must be positive"
+		);
+		Self { scale, offset, var }
+	}
+}
+
+impl<Var> LinearBoolView<NonZero<IntVal>, IntVal, Var> {
+	fn reverse_meaning(&self, meaning: IntLitMeaning) -> Result<IntLitMeaning, bool> {
+		match meaning {
+			IntLitMeaning::Eq(v) => self.try_reverse_val(v).map(IntLitMeaning::Eq).ok_or(false),
+			IntLitMeaning::NotEq(v) => self
+				.try_reverse_val(v)
+				.map(IntLitMeaning::NotEq)
+				.ok_or(true),
+			IntLitMeaning::GreaterEq(v) => Ok(IntLitMeaning::GreaterEq(self.reverse_val_ceil(v))),
+			IntLitMeaning::Less(v) => Ok(IntLitMeaning::Less(self.reverse_val_ceil(v))),
+		}
+	}
+
+	fn reverse_val_ceil(&self, val: IntVal) -> IntVal {
+		div_ceil(val - self.offset, self.scale)
+	}
+
+	fn reverse_val_floor(&self, val: IntVal) -> IntVal {
+		div_floor(val - self.offset, self.scale)
+	}
+
+	fn try_reverse_val(&self, val: IntVal) -> Option<IntVal> {
+		let val = val - self.offset;
+		if val % self.scale.get() == 0 {
+			Some(val / self.scale.get())
+		} else {
+			None
+		}
+	}
+
+	pub(crate) fn transform_val(&self, val: IntVal) -> IntVal {
+		self.scale.get() * val + self.offset
+	}
+
+	pub(crate) fn transform_meaning(&self, meaning: IntLitMeaning) -> IntLitMeaning {
+		match meaning {
+			IntLitMeaning::Eq(v) => IntLitMeaning::Eq(self.transform_val(v)),
+			IntLitMeaning::NotEq(v) => IntLitMeaning::NotEq(self.transform_val(v)),
+			IntLitMeaning::GreaterEq(v) => IntLitMeaning::GreaterEq(self.transform_val(v)),
+			IntLitMeaning::Less(v) => IntLitMeaning::Less(self.transform_val(v)),
+		}
+	}
+}
+
+impl<Ctx, Var> IntDecisionActions<Ctx> for LinearBoolView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Ctx::Atom: BoolOperations + From<bool> + From<Var>,
+	Var: BoolInspectionActions<Ctx>,
+{
+	fn lit(&self, ctx: &mut Ctx, meaning: IntLitMeaning) -> Ctx::Atom {
+		self.try_lit(ctx, meaning).unwrap()
+	}
+}
+
+impl<Ctx, Var> IntExplanationActions<Ctx> for LinearBoolView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Ctx::Atom: BoolOperations + From<bool> + From<Var>,
+	Var: BoolInspectionActions<Ctx>,
+{
+	fn lit_relaxed(&self, ctx: &Ctx, meaning: IntLitMeaning) -> (Ctx::Atom, IntLitMeaning) {
+		(self.try_lit(ctx, meaning).unwrap(), meaning)
+	}
+}
+
+impl<Ctx, Var> IntInspectionActions<Ctx> for LinearBoolView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Ctx::Atom: BoolOperations + From<bool> + From<Var>,
+	Var: BoolInspectionActions<Ctx>,
+{
+	fn domain(&self, ctx: &Ctx) -> IntSetVal {
+		if let Some(v) = self.var.val(ctx) {
+			RangeList::from_sorted_elements([self.transform_val(v as IntVal)])
+		} else {
+			RangeList::from_sorted_elements([self.offset, self.scale.get() + self.offset])
+		}
+	}
+
+	fn in_domain(&self, ctx: &Ctx, val: IntVal) -> bool {
+		let Some(val) = self.try_reverse_val(val) else {
+			return false;
+		};
+		if let Some(v) = self.var.val(ctx) {
+			v as IntVal == val
+		} else {
+			val == 0 || val == 1
+		}
+	}
+
+	fn lit_meaning(&self, _: &Ctx, lit: Ctx::Atom) -> Option<IntLitMeaning> {
+		let atom: Ctx::Atom = self.var.clone().into();
+		if atom == lit {
+			Some(self.transform_meaning(IntLitMeaning::Eq(1)))
+		} else if !atom == lit {
+			Some(self.transform_meaning(IntLitMeaning::Eq(0)))
+		} else {
+			None
+		}
+	}
+
+	fn lower_bound(&self, ctx: &Ctx) -> IntVal {
+		self.transform_val(self.var.val(ctx).unwrap_or(false) as IntVal)
+	}
+
+	fn lower_bound_lit(&self, ctx: &Ctx) -> Ctx::Atom {
+		if self.var.val(ctx) == Some(true) {
+			self.var.clone().into()
+		} else {
+			true.into()
+		}
+	}
+
+	fn try_lit(&self, _: &Ctx, meaning: IntLitMeaning) -> Option<Ctx::Atom> {
+		Some(match self.reverse_meaning(meaning) {
+			Ok(m) => match m {
+				IntLitMeaning::Eq(1) | IntLitMeaning::NotEq(0) | IntLitMeaning::GreaterEq(1) => {
+					self.var.clone().into()
+				}
+				IntLitMeaning::Eq(0) | IntLitMeaning::NotEq(1) | IntLitMeaning::Less(1) => {
+					(!self.var.clone()).into()
+				}
+				IntLitMeaning::Eq(_) => false.into(),
+				IntLitMeaning::NotEq(_) => true.into(),
+				IntLitMeaning::GreaterEq(v) if v <= 0 => true.into(),
+				IntLitMeaning::GreaterEq(_) => false.into(),
+				IntLitMeaning::Less(v) if v <= 0 => false.into(),
+				IntLitMeaning::Less(_) => true.into(),
+			},
+			Err(b) => b.into(),
+		})
+	}
+
+	fn upper_bound(&self, ctx: &Ctx) -> IntVal {
+		self.transform_val(self.var.val(ctx).unwrap_or(true) as IntVal)
+	}
+
+	fn upper_bound_lit(&self, ctx: &Ctx) -> Ctx::Atom {
+		if self.var.val(ctx) == Some(false) {
+			(!self.var.clone()).into()
+		} else {
+			true.into()
+		}
+	}
+
+	fn val(&self, ctx: &Ctx) -> Option<IntVal> {
+		Some(self.transform_val(self.var.val(ctx)? as IntVal))
+	}
+
+	fn bounds(&self, ctx: &Ctx) -> (IntVal, IntVal) {
+		let (lb, ub) = if let Some(val) = self.var.val(ctx) {
+			(val as IntVal, val as IntVal)
+		} else {
+			(0, 1)
+		};
+		(self.transform_val(lb), self.transform_val(ub))
+	}
+}
+
+impl<Ctx, Var> IntPropagationActions<Ctx> for LinearBoolView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: PropagationActions + ?Sized,
+	Ctx::Atom: BoolOperations + From<bool> + From<Var>,
+	Var: BoolPropagationActions<Ctx>,
+{
+	fn set_lower_bound(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		let val = self.reverse_val_ceil(val);
+		if val > 1 {
+			Err(ctx.declare_conflict(reason))
+		} else if val == 1 {
+			self.var.set(ctx, reason)
+		} else {
+			Ok(())
+		}
+	}
+
+	fn set_not_eq(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		let Some(val) = self.try_reverse_val(val) else {
+			return Ok(());
+		};
+		if val < 0 || val > 1 {
+			Ok(())
+		} else {
+			self.var.set_val(ctx, val != 1, reason)
+		}
+	}
+
+	fn set_upper_bound(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		let val = self.reverse_val_floor(val);
+		if val < 0 {
+			Err(ctx.declare_conflict(reason))
+		} else if val == 0 {
+			self.var.set_val(ctx, false, reason)
+		} else {
+			Ok(())
+		}
+	}
+
+	fn set_val(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		let Some(val) = self.try_reverse_val(val) else {
+			return Err(ctx.declare_conflict(reason));
+		};
+		if val < 0 || val > 1 {
+			Err(ctx.declare_conflict(reason))
+		} else {
+			self.var.set_val(ctx, val == 1, reason)
+		}
+	}
+}
+
+impl<Ctx, Var> IntSimplificationActions<Ctx> for LinearBoolView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: PropagationActions + ?Sized,
+	Ctx::Atom: BoolOperations + From<bool> + From<Var>,
+	Var: BoolSimplificationActions<Ctx>,
+{
+	fn set_domain(
+		&self,
+		ctx: &mut Ctx,
+		domain: &IntSetVal,
+		reason: impl ReasonBuilder<Ctx, <Ctx as ReasoningContext>::Atom>,
+	) -> Result<(), <Ctx as ReasoningContext>::Conflict> {
+		let lb = domain.contains(&self.offset);
+		let ub = domain.contains(&(self.offset + self.scale.get()));
+		if lb && ub {
+			Ok(())
+		} else if ub {
+			self.var.set(ctx, reason)
+		} else if lb {
+			self.var.set_val(ctx, false, reason)
+		} else {
+			Err(ctx.declare_conflict(reason))
+		}
+	}
+
+	fn set_not_in_set(
+		&self,
+		ctx: &mut Ctx,
+		values: &IntSetVal,
+		reason: impl ReasonBuilder<Ctx, <Ctx as ReasoningContext>::Atom>,
+	) -> Result<(), <Ctx as ReasoningContext>::Conflict> {
+		let lb = values.contains(&self.offset);
+		let ub = values.contains(&(self.offset + self.scale.get()));
+		if lb && ub {
+			Err(ctx.declare_conflict(reason))
+		} else if ub {
+			self.var.set_val(ctx, false, reason)
+		} else if lb {
+			self.var.set(ctx, reason)
+		} else {
+			Ok(())
+		}
+	}
+
+	fn unify(
+		&self,
+		ctx: &mut Ctx,
+		other: impl Into<Self>,
+	) -> Result<(), <Ctx as ReasoningContext>::Conflict> {
+		todo!()
+	}
+}
+
+impl<Var> From<Var> for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
+	fn from(var: Var) -> Self {
+		Self::new(NonZero::new(1).unwrap(), 0, var)
+	}
+}
+
+impl<Var> From<OffsetView<IntVal, Var>> for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
+	fn from(view: OffsetView<IntVal, Var>) -> Self {
+		Self::new(NonZero::new(1).unwrap(), view.offset, view.var)
+	}
+}
+
+impl<Var> AddAssign<IntVal> for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
+	fn add_assign(&mut self, rhs: IntVal) {
+		self.offset += rhs;
+	}
+}
+
+impl<Var> Add<IntVal> for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
+	type Output = Self;
+
+	fn add(mut self, rhs: IntVal) -> Self::Output {
+		self += rhs;
+		self
+	}
+}
+
+impl<Var> SubAssign<IntVal> for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
+	fn sub_assign(&mut self, rhs: IntVal) {
+		self.offset -= rhs;
+	}
+}
+
+impl<Var> Sub<IntVal> for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
+	type Output = Self;
+
+	fn sub(mut self, rhs: IntVal) -> Self::Output {
+		self -= rhs;
+		self
+	}
+}
+
+impl<Var: BoolOperations> Neg for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
+	type Output = Self;
+
+	fn neg(self) -> Self::Output {
+		self * NonZero::new(-1).unwrap()
+	}
+}
+
+impl<Var: BoolOperations> MulAssign<NonZero<IntVal>>
+	for LinearBoolView<NonZero<IntVal>, IntVal, Var>
+{
+	fn mul_assign(&mut self, rhs: NonZero<IntVal>) {
+		self.scale = NonZero::new(self.scale.get() * rhs.get()).unwrap();
+		self.offset *= rhs.get();
+		if self.scale.get() < 0 {
+			self.offset += self.scale.get();
+			self.scale = -self.scale;
+			self.var = !self.var.clone();
+		}
+	}
+}
+
+impl<Var: BoolOperations> Mul<NonZero<IntVal>> for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
+	type Output = Self;
+
+	fn mul(mut self, rhs: NonZero<IntVal>) -> Self::Output {
+		self *= rhs;
+		self
+	}
+}

--- a/crates/huub/src/views/linear_view.rs
+++ b/crates/huub/src/views/linear_view.rs
@@ -1,0 +1,352 @@
+use std::{
+	fmt::Debug,
+	hash::Hash,
+	mem,
+	num::NonZero,
+	ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+};
+
+use rangelist::RangeList;
+
+use crate::{
+	actions::{
+		IntDecisionActions, IntExplanationActions, IntInspectionActions, IntPropagationActions,
+		PropagationActions, ReasoningContext,
+	},
+	constraints::ReasonBuilder,
+	helpers::{div_ceil, div_floor},
+	solver::IntLitMeaning,
+	views::offset_view::OffsetView,
+	IntSetVal, IntVal,
+};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct LinearView<Scale, Offset, Var> {
+	pub(crate) scale: Scale,
+	pub(crate) offset: Offset,
+	pub(crate) var: Var,
+}
+
+impl<Scale, Offset, Var> LinearView<Scale, Offset, Var> {
+	pub(crate) fn new(scale: Scale, offset: Offset, var: Var) -> Self {
+		Self { scale, offset, var }
+	}
+}
+
+impl<Var> LinearView<NonZero<IntVal>, IntVal, Var> {
+	fn reverse_meaning(&self, meaning: IntLitMeaning) -> Result<IntLitMeaning, bool> {
+		match meaning {
+			IntLitMeaning::Eq(v) => self.try_reverse_val(v).map(IntLitMeaning::Eq).ok_or(false),
+			IntLitMeaning::NotEq(v) => self
+				.try_reverse_val(v)
+				.map(IntLitMeaning::NotEq)
+				.ok_or(true),
+			// -a*x + b >= i === a*x - b <= -i === x < (-i + 1 + b) / a
+			IntLitMeaning::GreaterEq(v) if self.scale.get() < 0 => Ok(IntLitMeaning::Less(
+				div_ceil(-v + 1 + self.offset, -self.scale),
+			)),
+			IntLitMeaning::GreaterEq(v) => Ok(IntLitMeaning::GreaterEq(div_ceil(
+				v - self.offset,
+				self.scale,
+			))),
+			// -a*x + b < i === a*x -b > -i === x >= (-i + 1 + b) / a
+			IntLitMeaning::Less(v) if self.scale.get() < 0 => Ok(IntLitMeaning::GreaterEq(
+				div_ceil(-v + 1 + self.offset, -self.scale),
+			)),
+			IntLitMeaning::Less(v) => {
+				Ok(IntLitMeaning::Less(div_ceil(v - self.offset, self.scale)))
+			}
+		}
+	}
+
+	fn reverse_val_ceil(&self, val: IntVal) -> IntVal {
+		div_ceil(val - self.offset, self.scale)
+	}
+
+	fn reverse_val_floor(&self, val: IntVal) -> IntVal {
+		div_floor(val - self.offset, self.scale)
+	}
+
+	fn try_reverse_val(&self, val: IntVal) -> Option<IntVal> {
+		let val = val - self.offset;
+		if val % self.scale.get() == 0 {
+			Some(val / self.scale.get())
+		} else {
+			None
+		}
+	}
+
+	pub(crate) fn transform_val(&self, val: IntVal) -> IntVal {
+		self.scale.get() * val + self.offset
+	}
+
+	pub(crate) fn transform_meaning(&self, meaning: IntLitMeaning) -> IntLitMeaning {
+		let neg_transform_val = |v| (v * -self.scale.get()) - self.offset;
+		match meaning {
+			IntLitMeaning::Eq(v) => IntLitMeaning::Eq(self.transform_val(v)),
+			IntLitMeaning::NotEq(v) => IntLitMeaning::NotEq(self.transform_val(v)),
+			IntLitMeaning::GreaterEq(v) if self.scale.get() < 0 => {
+				IntLitMeaning::Less(neg_transform_val(-v + 1))
+			}
+			IntLitMeaning::GreaterEq(v) => IntLitMeaning::GreaterEq(self.transform_val(v)),
+			IntLitMeaning::Less(v) if self.scale.get() < 0 => {
+				IntLitMeaning::GreaterEq(neg_transform_val(-v + 1))
+			}
+			IntLitMeaning::Less(v) => IntLitMeaning::Less(self.transform_val(v)),
+		}
+	}
+}
+
+impl<Ctx, Var> IntDecisionActions<Ctx> for LinearView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Ctx::Atom: From<bool>,
+	Var: IntDecisionActions<Ctx>,
+{
+	fn lit(&self, ctx: &mut Ctx, meaning: IntLitMeaning) -> Ctx::Atom {
+		match self.reverse_meaning(meaning) {
+			Ok(meaning) => self.var.lit(ctx, meaning),
+			Err(b) => b.into(),
+		}
+	}
+}
+
+impl<Ctx, Var> IntExplanationActions<Ctx> for LinearView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Ctx::Atom: From<bool>,
+	Var: IntExplanationActions<Ctx>,
+{
+	fn lit_relaxed(&self, ctx: &Ctx, meaning: IntLitMeaning) -> (Ctx::Atom, IntLitMeaning) {
+		match self.reverse_meaning(meaning) {
+			Ok(meaning) => {
+				let (atom, meaning) = self.var.lit_relaxed(ctx, meaning);
+				(atom.into(), self.transform_meaning(meaning))
+			}
+			Err(b) => (b.into(), meaning),
+		}
+	}
+}
+
+impl<Ctx, Var> IntInspectionActions<Ctx> for LinearView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Ctx::Atom: From<bool>,
+	Var: IntInspectionActions<Ctx>,
+{
+	fn domain(&self, ctx: &Ctx) -> IntSetVal {
+		let dom = self.var.domain(ctx);
+		if self.scale.get() == 1 {
+			RangeList::from_sorted_ranges(
+				dom.into_iter()
+					.map(|r| (r.start() + self.offset)..=(r.end() + self.offset)),
+			)
+		} else if self.scale.get() == -1 {
+			RangeList::from_sorted_ranges(
+				dom.into_iter()
+					.rev()
+					.map(|r| -r.end() + self.offset..=-r.start() + self.offset),
+			)
+		} else if self.scale.get() >= 0 {
+			RangeList::from_sorted_elements(
+				dom.into_iter().flatten().map(|v| self.transform_val(v)),
+			)
+		} else {
+			RangeList::from_sorted_elements(
+				dom.into_iter()
+					.rev()
+					.flatten()
+					.map(|v| self.transform_val(v)),
+			)
+		}
+	}
+
+	fn in_domain(&self, ctx: &Ctx, val: IntVal) -> bool {
+		let Some(val) = self.try_reverse_val(val) else {
+			return false;
+		};
+		self.var.in_domain(ctx, val)
+	}
+
+	fn lit_meaning(&self, ctx: &Ctx, lit: Ctx::Atom) -> Option<IntLitMeaning> {
+		Some(self.transform_meaning(self.var.lit_meaning(ctx, lit)?))
+	}
+
+	fn lower_bound(&self, ctx: &Ctx) -> IntVal {
+		self.transform_val(if self.scale.get() >= 0 {
+			self.var.lower_bound(ctx)
+		} else {
+			self.var.upper_bound(ctx)
+		})
+	}
+
+	fn lower_bound_lit(&self, ctx: &Ctx) -> Ctx::Atom {
+		if self.scale.get() >= 0 {
+			self.var.lower_bound_lit(ctx)
+		} else {
+			self.var.upper_bound_lit(ctx)
+		}
+	}
+
+	fn try_lit(&self, ctx: &Ctx, meaning: IntLitMeaning) -> Option<Ctx::Atom> {
+		match self.reverse_meaning(meaning) {
+			Ok(meaning) => self.try_lit(ctx, meaning),
+			Err(b) => Some(b.into()),
+		}
+	}
+
+	fn upper_bound(&self, ctx: &Ctx) -> IntVal {
+		self.transform_val(if self.scale.get() >= 0 {
+			self.var.upper_bound(ctx)
+		} else {
+			self.var.lower_bound(ctx)
+		})
+	}
+
+	fn upper_bound_lit(&self, ctx: &Ctx) -> Ctx::Atom {
+		if self.scale.get() >= 0 {
+			self.var.upper_bound_lit(ctx)
+		} else {
+			self.var.lower_bound_lit(ctx)
+		}
+	}
+
+	fn val(&self, ctx: &Ctx) -> Option<IntVal> {
+		Some(self.transform_val(self.var.val(ctx)?))
+	}
+
+	fn bounds(&self, ctx: &Ctx) -> (IntVal, IntVal) {
+		let (mut lb, mut ub) = self.var.bounds(ctx);
+		if self.scale.get() < 0 {
+			mem::swap(&mut lb, &mut ub);
+		}
+		(self.transform_val(lb), self.transform_val(ub))
+	}
+}
+
+impl<Ctx, Var> IntPropagationActions<Ctx> for LinearView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: PropagationActions + ?Sized,
+	Ctx::Atom: From<bool>,
+	Var: IntPropagationActions<Ctx>,
+{
+	fn set_lower_bound(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		if self.scale.get() >= 0 {
+			self.var
+				.set_lower_bound(ctx, self.reverse_val_ceil(val), reason)
+		} else {
+			self.var
+				.set_upper_bound(ctx, self.reverse_val_floor(val), reason)
+		}
+	}
+
+	fn set_not_eq(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		let Some(val) = self.try_reverse_val(val) else {
+			return Ok(());
+		};
+		self.var.set_not_eq(ctx, val, reason)
+	}
+
+	fn set_upper_bound(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		if self.scale.get() >= 0 {
+			self.var
+				.set_upper_bound(ctx, self.reverse_val_floor(val), reason)
+		} else {
+			self.var
+				.set_lower_bound(ctx, self.reverse_val_ceil(val), reason)
+		}
+	}
+
+	fn set_val(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		let Some(val) = self.try_reverse_val(val) else {
+			return Err(ctx.declare_conflict(reason));
+		};
+		self.var.set_val(ctx, val, reason)
+	}
+}
+
+impl<Var> From<Var> for LinearView<NonZero<IntVal>, IntVal, Var> {
+	fn from(var: Var) -> Self {
+		Self::new(NonZero::new(1).unwrap(), 0, var)
+	}
+}
+
+impl<Var> From<OffsetView<IntVal, Var>> for LinearView<NonZero<IntVal>, IntVal, Var> {
+	fn from(view: OffsetView<IntVal, Var>) -> Self {
+		Self::new(NonZero::new(1).unwrap(), view.offset, view.var)
+	}
+}
+
+impl<Var> Neg for LinearView<NonZero<IntVal>, IntVal, Var> {
+	type Output = Self;
+
+	fn neg(self) -> Self::Output {
+		self * NonZero::new(-1).unwrap()
+	}
+}
+
+impl<Var> AddAssign<IntVal> for LinearView<NonZero<IntVal>, IntVal, Var> {
+	fn add_assign(&mut self, rhs: IntVal) {
+		self.offset += rhs;
+	}
+}
+
+impl<Var> Add<IntVal> for LinearView<NonZero<IntVal>, IntVal, Var> {
+	type Output = Self;
+
+	fn add(mut self, rhs: IntVal) -> Self::Output {
+		self += rhs;
+		self
+	}
+}
+
+impl<Var> SubAssign<IntVal> for LinearView<NonZero<IntVal>, IntVal, Var> {
+	fn sub_assign(&mut self, rhs: IntVal) {
+		self.offset -= rhs;
+	}
+}
+
+impl<Var> Sub<IntVal> for LinearView<NonZero<IntVal>, IntVal, Var> {
+	type Output = Self;
+
+	fn sub(mut self, rhs: IntVal) -> Self::Output {
+		self -= rhs;
+		self
+	}
+}
+
+impl<Var> MulAssign<NonZero<IntVal>> for LinearView<NonZero<IntVal>, IntVal, Var> {
+	fn mul_assign(&mut self, rhs: NonZero<IntVal>) {
+		self.scale = NonZero::new(self.scale.get() * rhs.get()).unwrap();
+		self.offset *= rhs.get();
+	}
+}
+
+impl<Var> Mul<NonZero<IntVal>> for LinearView<NonZero<IntVal>, IntVal, Var> {
+	type Output = Self;
+
+	fn mul(mut self, rhs: NonZero<IntVal>) -> Self::Output {
+		self *= rhs;
+		self
+	}
+}

--- a/crates/huub/src/views/offset_view.rs
+++ b/crates/huub/src/views/offset_view.rs
@@ -1,0 +1,174 @@
+use std::{num::NonZero, ops::Neg};
+
+use rangelist::RangeList;
+
+use crate::{
+	actions::{
+		IntDecisionActions, IntExplanationActions, IntInspectionActions, IntPropagationActions,
+		ReasoningContext,
+	},
+	constraints::ReasonBuilder,
+	solver::IntLitMeaning,
+	views::linear_view::LinearView,
+	IntSetVal, IntVal,
+};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct OffsetView<Offset, Var> {
+	pub(crate) offset: Offset,
+	pub(crate) var: Var,
+}
+
+impl<Offset, Var> OffsetView<Offset, Var> {
+	pub(crate) fn new(offset: Offset, var: Var) -> Self {
+		Self { offset, var }
+	}
+}
+
+impl<Var> OffsetView<IntVal, Var> {
+	fn reverse_meaning(&self, meaning: IntLitMeaning) -> IntLitMeaning {
+		match meaning {
+			IntLitMeaning::Eq(v) => IntLitMeaning::Eq(v - self.offset),
+			IntLitMeaning::NotEq(v) => IntLitMeaning::NotEq(v - self.offset),
+			IntLitMeaning::GreaterEq(v) => IntLitMeaning::GreaterEq(v - self.offset),
+			IntLitMeaning::Less(v) => IntLitMeaning::Less(v - self.offset),
+		}
+	}
+}
+
+impl<Ctx, Var> IntInspectionActions<Ctx> for OffsetView<IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Var: IntInspectionActions<Ctx>,
+{
+	fn domain(&self, ctx: &Ctx) -> IntSetVal {
+		RangeList::from_sorted_ranges(
+			self.var
+				.domain(ctx)
+				.into_iter()
+				.map(|r| (r.start() + self.offset)..=(r.end() + self.offset)),
+		)
+	}
+
+	fn in_domain(&self, ctx: &Ctx, val: IntVal) -> bool {
+		self.var.in_domain(ctx, val - self.offset)
+	}
+
+	fn lit_meaning(&self, ctx: &Ctx, lit: Ctx::Atom) -> Option<IntLitMeaning> {
+		match self.var.lit_meaning(ctx, lit)? {
+			IntLitMeaning::Eq(v) => Some(IntLitMeaning::Eq(v + self.offset)),
+			IntLitMeaning::NotEq(v) => Some(IntLitMeaning::NotEq(v + self.offset)),
+			IntLitMeaning::GreaterEq(v) => Some(IntLitMeaning::GreaterEq(v + self.offset)),
+			IntLitMeaning::Less(v) => Some(IntLitMeaning::Less(v + self.offset)),
+		}
+	}
+
+	fn lower_bound(&self, ctx: &Ctx) -> IntVal {
+		self.var.lower_bound(ctx) + self.offset
+	}
+
+	fn lower_bound_lit(&self, ctx: &Ctx) -> Ctx::Atom {
+		self.var.lower_bound_lit(ctx)
+	}
+
+	fn try_lit(&self, ctx: &Ctx, meaning: IntLitMeaning) -> Option<Ctx::Atom> {
+		self.var.try_lit(ctx, self.reverse_meaning(meaning))
+	}
+
+	fn upper_bound(&self, ctx: &Ctx) -> IntVal {
+		self.var.upper_bound(ctx) + self.offset
+	}
+
+	fn upper_bound_lit(&self, ctx: &Ctx) -> Ctx::Atom {
+		self.var.upper_bound_lit(ctx)
+	}
+
+	fn bounds(&self, ctx: &Ctx) -> (IntVal, IntVal) {
+		let (lb, ub) = self.var.bounds(ctx);
+		(lb + self.offset, ub + self.offset)
+	}
+
+	fn val(&self, ctx: &Ctx) -> Option<IntVal> {
+		self.var.val(ctx).map(|v| v + self.offset)
+	}
+}
+
+impl<Ctx, Var> IntExplanationActions<Ctx> for OffsetView<IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Var: IntExplanationActions<Ctx>,
+{
+	fn lit_relaxed(&self, ctx: &Ctx, meaning: IntLitMeaning) -> (Ctx::Atom, IntLitMeaning) {
+		self.var.lit_relaxed(ctx, self.reverse_meaning(meaning))
+	}
+}
+
+impl<Ctx, Var> IntDecisionActions<Ctx> for OffsetView<IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Var: IntDecisionActions<Ctx>,
+{
+	fn lit(&self, ctx: &mut Ctx, meaning: IntLitMeaning) -> Ctx::Atom {
+		self.var.lit(ctx, self.reverse_meaning(meaning))
+	}
+}
+
+impl<Ctx, Var> IntPropagationActions<Ctx> for OffsetView<IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Var: IntPropagationActions<Ctx>,
+{
+	fn set_lower_bound(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		self.var.set_lower_bound(ctx, val - self.offset, reason)
+	}
+
+	fn set_not_eq(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		self.var.set_not_eq(ctx, val - self.offset, reason)
+	}
+
+	fn set_upper_bound(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		self.var.set_upper_bound(ctx, val - self.offset, reason)
+	}
+
+	fn set_val(
+		&self,
+		ctx: &mut Ctx,
+		val: IntVal,
+		reason: impl ReasonBuilder<Ctx, Ctx::Atom>,
+	) -> Result<(), Ctx::Conflict> {
+		self.var.set_val(ctx, val - self.offset, reason)
+	}
+}
+
+impl<Val: Default, Var> From<Var> for OffsetView<Val, Var> {
+	fn from(value: Var) -> Self {
+		Self {
+			offset: Val::default(),
+			var: value,
+		}
+	}
+}
+
+impl<Var> Neg for OffsetView<IntVal, Var> {
+	type Output = LinearView<NonZero<IntVal>, IntVal, Var>;
+
+	fn neg(self) -> Self::Output {
+		let lin: LinearView<NonZero<IntVal>, IntVal, Var> = self.into();
+		-lin
+	}
+}


### PR DESCRIPTION
This PR would add static dispatch for propagators when posting (when possible). This means that if a propagator takes an `IntView`, the dispatch would resolve it to be an `IntVal`, or `LinearView` or `LinearBoolView` before creating the `Propagator`.

The cost for this is that different versions of the propagator have to exists, e.g. `IntPow<LinearView, IntVal, IntVarRef>` and `IntPow<IntVal, IntVal, IntVal>`. This could even include some versions that cannot actually exist.

This also increases the compilation time for the library and executable. Presently, this looks like it might be prohibitive. 