### PR TITLE
perf: Optimize `ActivationList` iteration

### DIFF
--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -134,7 +134,7 @@ use crate::{
 	},
 	solver::{
 		IntLitMeaning, Solver,
-		activation_list::{ActivationAction, ActivationActionS, IntEvent, IntPropCond},
+		activation_list::{ActivationAction, IntEvent, IntPropCond},
 		queue::{PriorityLevel, PropagatorInfo, PropagatorQueue},
 		trail::TrailedInt,
 	},
@@ -1901,44 +1901,48 @@ impl IntSimplificationActions<Model> for IntDecision {
 					| BoolDecisionInner::IntLess(j, _),
 				),
 			) => {
-				for act in constraints.activated_by::<ModAdvisor, ConRef>(IntEvent::Fixed) {
-					if let ActivationAction::Advise(adv) = act {
-						let def = &mut ctx.advisors[adv];
-						def.bool2int = true;
-						def.condition = Some(match inner.0 {
-							BoolDecisionInner::IntEq(_, v) => IntLitMeaning::Eq(v),
-							BoolDecisionInner::IntGreaterEq(_, v) => IntLitMeaning::GreaterEq(v),
-							BoolDecisionInner::IntLess(_, v) => IntLitMeaning::Less(v),
-							BoolDecisionInner::IntNotEq(_, v) => IntLitMeaning::NotEq(v),
-							_ => unreachable!(),
-						});
-						def.negated = !lt.positive_scale();
-					}
-					let cond = if matches!(
-						inner.0,
-						BoolDecisionInner::IntEq(_, _) | BoolDecisionInner::IntNotEq(_, _)
-					) {
-						IntPropCond::Domain
-					} else {
-						IntPropCond::Bounds
-					};
-					ctx.int_vars[j].constraints.add(act, cond);
-				}
+				constraints.for_each_activated_by(
+					IntEvent::Fixed,
+					|act: ActivationAction<ModAdvisor, ConRef>| {
+						if let ActivationAction::Advise(adv) = act {
+							let def = &mut ctx.advisors[adv];
+							def.bool2int = true;
+							def.condition = Some(match inner.0 {
+								BoolDecisionInner::IntEq(_, v) => IntLitMeaning::Eq(v),
+								BoolDecisionInner::IntGreaterEq(_, v) => {
+									IntLitMeaning::GreaterEq(v)
+								}
+								BoolDecisionInner::IntLess(_, v) => IntLitMeaning::Less(v),
+								BoolDecisionInner::IntNotEq(_, v) => IntLitMeaning::NotEq(v),
+								_ => unreachable!(),
+							});
+							def.negated = !lt.positive_scale();
+						}
+						let cond = if matches!(
+							inner.0,
+							BoolDecisionInner::IntEq(_, _) | BoolDecisionInner::IntNotEq(_, _)
+						) {
+							IntPropCond::Domain
+						} else {
+							IntPropCond::Bounds
+						};
+						ctx.int_vars[j].constraints.add(act, cond);
+					},
+				);
 			}
 			// Move subscription to Boolean decision
 			Bool(lt, BoolDecision(BoolDecisionInner::Lit(l))) => {
 				let jdx = i32::from(l.var()) as usize - 1;
-				ctx.bool_vars[jdx].constraints.extend(
-					constraints.activated_by(IntEvent::Fixed).map(
-						|act: ActivationAction<ModAdvisor, ConRef>| -> ActivationActionS {
-							if let ActivationAction::Advise(adv) = act {
-								let def = &mut ctx.advisors[adv];
-								def.bool2int = true;
-								def.negated = !lt.positive_scale();
-							}
-							act.into()
-						},
-					),
+				constraints.for_each_activated_by(
+					IntEvent::Fixed,
+					|act: ActivationAction<ModAdvisor, ConRef>| {
+						if let ActivationAction::Advise(adv) = act {
+							let def = &mut ctx.advisors[adv];
+							def.bool2int = true;
+							def.negated = !lt.positive_scale();
+						}
+						ctx.bool_vars[jdx].constraints.push(act.into());
+					},
 				);
 			}
 			// Notify current subscriptions one more time, then forget about them.
@@ -2511,52 +2515,51 @@ impl Model {
 		};
 		let mut int_events = mem::take(&mut self.int_events);
 		for (iv, event) in int_events.drain() {
-			let v: Vec<_> = self.int_vars[iv].constraints.activated_by(event).collect();
-			for act in v {
-				match act {
-					ActivationAction::Advise(adv) => {
-						let x: &ModAdvisorDef = &self.advisors[adv];
-						let ModAdvisorDef {
-							con,
-							data,
-							negated,
-							bool2int,
-							condition,
-						} = x.clone();
-						let event = match event {
-							IntEvent::LowerBound if negated => IntEvent::UpperBound,
-							IntEvent::UpperBound if negated => IntEvent::LowerBound,
-							_ => event,
+			let constraints = mem::take(&mut self.int_vars[iv].constraints);
+			constraints.for_each_activated_by(event, |act| match act {
+				ActivationAction::Advise(adv) => {
+					let x: &ModAdvisorDef = &self.advisors[adv];
+					let ModAdvisorDef {
+						con,
+						data,
+						negated,
+						bool2int,
+						condition,
+					} = x.clone();
+					let event = match event {
+						IntEvent::LowerBound if negated => IntEvent::UpperBound,
+						IntEvent::UpperBound if negated => IntEvent::LowerBound,
+						_ => event,
+					};
+					let enqueue = if let Some(cond) = condition {
+						let iv = IntDecision(IntDecisionInner::Var(iv));
+						let triggered = match cond {
+							IntLitMeaning::Eq(v) | IntLitMeaning::NotEq(v) => {
+								iv.eq(v).val(self).is_some()
+							}
+							IntLitMeaning::GreaterEq(v) | IntLitMeaning::Less(v) => {
+								iv.geq(v).val(self).is_some()
+							}
 						};
-						let enqueue = if let Some(cond) = condition {
-							let iv = IntDecision(IntDecisionInner::Var(iv));
-							let triggered = match cond {
-								IntLitMeaning::Eq(v) | IntLitMeaning::NotEq(v) => {
-									iv.eq(v).val(self).is_some()
-								}
-								IntLitMeaning::GreaterEq(v) | IntLitMeaning::Less(v) => {
-									iv.geq(v).val(self).is_some()
-								}
-							};
-							if triggered {
-								if bool2int {
-									advise_of_int_change(self, con, data, IntEvent::Fixed)
-								} else {
-									advise_of_bool_change(self, con, data)
-								}
+						if triggered {
+							if bool2int {
+								advise_of_int_change(self, con, data, IntEvent::Fixed)
 							} else {
-								false
+								advise_of_bool_change(self, con, data)
 							}
 						} else {
-							advise_of_int_change(self, con, data, event)
-						};
-						if enqueue {
-							self.propagator_queue.enqueue_propagator(con);
+							false
 						}
+					} else {
+						advise_of_int_change(self, con, data, event)
+					};
+					if enqueue {
+						self.propagator_queue.enqueue_propagator(con);
 					}
-					ActivationAction::Enqueue(c) => self.propagator_queue.enqueue_propagator(c),
 				}
-			}
+				ActivationAction::Enqueue(c) => self.propagator_queue.enqueue_propagator(c),
+			});
+			self.int_vars[iv].constraints = constraints;
 		}
 		self.int_events = int_events;
 		let mut bool_events = mem::take(&mut self.bool_events);

--- a/crates/huub/src/solver/activation_list.rs
+++ b/crates/huub/src/solver/activation_list.rs
@@ -6,8 +6,6 @@ use std::{
 	ops::{Add, AddAssign},
 };
 
-use itertools::Itertools;
-
 use crate::{
 	ConRef, ModAdvisor,
 	solver::engine::{Advisor, PropRef},
@@ -138,35 +136,6 @@ impl From<ActivationAction<ModAdvisor, ConRef>> for ActivationActionS {
 }
 
 impl ActivationList {
-	/// Get an iterator over the list of propagators to be enqueued.
-	pub(crate) fn activated_by<'a, A, P>(
-		&'a self,
-		event: IntEvent,
-	) -> impl Iterator<Item = ActivationAction<A, P>> + 'a
-	where
-		ActivationAction<A, P>: From<ActivationActionS>,
-		A: 'a,
-		P: 'a,
-	{
-		let r1 = if event == IntEvent::LowerBound {
-			self.lower_bound_idx as usize..self.upper_bound_idx as usize
-		} else {
-			0..0
-		};
-		let r2 = match event {
-			IntEvent::Fixed => 0..,
-			// NOTE: Bounds (Event) should trigger both LowerBound and UpperBound conditions
-			IntEvent::Bounds => self.lower_bound_idx as usize..,
-			IntEvent::UpperBound => self.upper_bound_idx as usize..,
-			IntEvent::LowerBound => self.bounds_idx as usize..,
-			IntEvent::Domain => self.domain_idx as usize..,
-		};
-		self.activations[r1]
-			.iter()
-			.chain(self.activations[r2].iter())
-			.copied()
-			.map_into()
-	}
 	/// Add a propagator to the list of propagators to be enqueued based on the
 	/// given condition.
 	pub(crate) fn add<A, P>(&mut self, action: ActivationAction<A, P>, condition: IntPropCond)
@@ -254,6 +223,39 @@ impl ActivationList {
 			);
 		}
 	}
+
+	/// Iterate over the activation actions triggered by the given event and
+	/// execute the provided function for each of them.
+	///
+	/// This method does not enqueue or advise by itself; it simply delegates
+	/// handling to the provided function `f`.
+	pub(crate) fn for_each_activated_by<A, P, F>(&self, event: IntEvent, mut f: F)
+	where
+		ActivationAction<A, P>: From<ActivationActionS>,
+		F: FnMut(ActivationAction<A, P>),
+	{
+		if event == IntEvent::LowerBound {
+			for &act in
+				&self.activations[self.lower_bound_idx as usize..self.upper_bound_idx as usize]
+			{
+				f(act.into());
+			}
+			for &act in &self.activations[self.bounds_idx as usize..] {
+				f(act.into());
+			}
+		} else {
+			let start = match event {
+				IntEvent::Fixed => 0,
+				IntEvent::Bounds => self.lower_bound_idx as usize,
+				IntEvent::UpperBound => self.upper_bound_idx as usize,
+				IntEvent::LowerBound => unreachable!(),
+				IntEvent::Domain => self.domain_idx as usize,
+			};
+			for &act in &self.activations[start..] {
+				f(act.into());
+			}
+		}
+	}
 }
 
 impl Add<IntEvent> for IntEvent {
@@ -303,7 +305,10 @@ mod tests {
 			for (prop, cond) in list.iter() {
 				activation_list.add(ActivationAction::Enqueue(*prop), *cond);
 			}
-			let fixed: FxHashSet<_> = activation_list.activated_by(IntEvent::Fixed).collect();
+			let mut fixed = FxHashSet::default();
+			activation_list.for_each_activated_by(IntEvent::Fixed, |a: ActivationAction<_, _>| {
+				fixed.insert(a);
+			});
 			assert_eq!(
 				fixed,
 				FxHashSet::from_iter([
@@ -314,7 +319,10 @@ mod tests {
 					ActivationAction::Enqueue(PropRef::from(4))
 				])
 			);
-			let bounds: FxHashSet<_> = activation_list.activated_by(IntEvent::Bounds).collect();
+			let mut bounds = FxHashSet::default();
+			activation_list.for_each_activated_by(IntEvent::Bounds, |a: ActivationAction<_, _>| {
+				bounds.insert(a);
+			});
 			assert_eq!(
 				bounds,
 				FxHashSet::from_iter([
@@ -324,8 +332,13 @@ mod tests {
 					ActivationAction::Enqueue(PropRef::from(4))
 				])
 			);
-			let lower_bound: FxHashSet<_> =
-				activation_list.activated_by(IntEvent::LowerBound).collect();
+			let mut lower_bound = FxHashSet::default();
+			activation_list.for_each_activated_by(
+				IntEvent::LowerBound,
+				|a: ActivationAction<_, _>| {
+					lower_bound.insert(a);
+				},
+			);
 			assert_eq!(
 				lower_bound,
 				FxHashSet::from_iter([
@@ -334,8 +347,13 @@ mod tests {
 					ActivationAction::Enqueue(PropRef::from(4))
 				])
 			);
-			let upper_bound: FxHashSet<_> =
-				activation_list.activated_by(IntEvent::UpperBound).collect();
+			let mut upper_bound = FxHashSet::default();
+			activation_list.for_each_activated_by(
+				IntEvent::UpperBound,
+				|a: ActivationAction<_, _>| {
+					upper_bound.insert(a);
+				},
+			);
 			assert_eq!(
 				upper_bound,
 				FxHashSet::from_iter([
@@ -344,7 +362,10 @@ mod tests {
 					ActivationAction::Enqueue(PropRef::from(4))
 				])
 			);
-			let domain: FxHashSet<_> = activation_list.activated_by(IntEvent::Domain).collect();
+			let mut domain = FxHashSet::default();
+			activation_list.for_each_activated_by(IntEvent::Domain, |a: ActivationAction<_, _>| {
+				domain.insert(a);
+			});
 			assert_eq!(
 				domain,
 				FxHashSet::from_iter([ActivationAction::Enqueue(PropRef::from(4))])

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -373,7 +373,7 @@ impl PropagatorExtension for Engine {
 				ctx.state.int_vars[r].notify_upper_bound(&mut ctx.state.trail, lb);
 
 				let activation = mem::take(&mut ctx.state.int_activation[r]);
-				for action in activation.activated_by(IntEvent::Fixed) {
+				activation.for_each_activated_by(IntEvent::Fixed, |action| {
 					let prop = match action {
 						ActivationAction::Advise(adv) => {
 							let &AdvisorDef {
@@ -384,14 +384,14 @@ impl PropagatorExtension for Engine {
 								data,
 								IntEvent::Fixed,
 							) {
-								continue;
+								return;
 							}
 							propagator
 						}
 						ActivationAction::Enqueue(prop) => prop,
 					};
 					ctx.state.propagator_queue.enqueue_propagator(prop);
-				}
+				});
 				ctx.state.int_activation[r] = activation;
 			}
 		}
@@ -605,7 +605,7 @@ impl PropagatorExtension for Engine {
 				&& let Some((iv, event)) = iv_event
 			{
 				let activations = mem::take(&mut self.state.int_activation[iv]);
-				for action in activations.activated_by(event) {
+				activations.for_each_activated_by(event, |action| {
 					let prop = match action {
 						ActivationAction::Advise(adv) => {
 							let &AdvisorDef {
@@ -616,14 +616,14 @@ impl PropagatorExtension for Engine {
 							} = &self.state.advisors[adv];
 							let enqueue = self.notify_int_advisor(propagator, event, data, negated);
 							if !enqueue {
-								continue;
+								return;
 							}
 							propagator
 						}
 						ActivationAction::Enqueue(prop) => prop,
 					};
 					self.state.propagator_queue.enqueue_propagator(prop);
-				}
+				});
 				self.state.int_activation[iv] = activations;
 			}
 		}


### PR DESCRIPTION
Replaces `activated_by` iterator with `for_each_activated_by` internal iteration.
This removes the overhead of constructing and advancing chained iterators in the hot propagation loop.
It also allows for special handling of `LowerBound` events without iterator adapters.

Impact:
- Reduces iterator overhead in the core propagation loop.
- Avoids allocations/overhead associated with `map_into` and `chain`.
- Simplifies call sites slightly where actions are processed immediately.
