### PR TITLE
fix/vsids after conflict

### DIFF
--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -926,6 +926,7 @@ impl State {
 		{
 			debug_assert!(!self.vsids);
 			self.vsids = true;
+			self.config.vsids_after_conflict = None; // Only switch once
 			debug!(
 				vsids = self.vsids,
 				conflicts = self.statistics.conflicts,


### PR DESCRIPTION
- **fix: IntDecision::lt off by one error for Const variant**
- **fix: trigger vsids_after_conflict only once**
