### PR TITLE
update the default domain for unbounded integer variables

### DIFF
--- a/crates/huub/src/flatzinc.rs
+++ b/crates/huub/src/flatzinc.rs
@@ -37,7 +37,7 @@ use crate::{
 
 /// Domain assumed for integer decision variables that do not have a domain
 /// definition.
-const FULL_INT_DOMAIN: RangeInclusive<IntVal> = IntVal::MIN..=IntVal::MAX;
+const FULL_INT_DOMAIN: RangeInclusive<IntVal> = (i32::MIN as i64)..=(i32::MAX as i64);
 
 #[derive(Debug)]
 /// Errors that can occur when converting a [`FlatZinc`] instance to a [`Model`]


### PR DESCRIPTION
This issue causes Work Task Variation instances in the MiniZinc Challenge 2025 to become unsatisfiable. The fix updates the default domain for unbounded integer variables to [i32::MIN,i32::MAX] to avoid integer overflow/underflow during `IntLinear` constraint propagation.