### PR TITLE
fix: introduce wrapper type to distinguish un-aliased decisions

### DIFF
--- a/crates/huub-cli/src/main.rs
+++ b/crates/huub-cli/src/main.rs
@@ -8,7 +8,7 @@
 	unused_crate_dependencies,
 	reason = "other dependencies are used in the lib.rs file"
 )]
-use std::{convert::Infallible, fs, path::PathBuf, process::ExitCode};
+use std::{convert::Infallible, fs, path::PathBuf, process::ExitCode, sync::Arc};
 
 use huub_cli::Cli;
 use pico_args::Arguments;
@@ -130,17 +130,13 @@ fn main() -> ExitCode {
 	};
 	let result = match log_file {
 		Some(log_file) => {
-			let mut cli = cli.with_stderr(
-				move || {
-					fs::OpenOptions::new()
-						.create(true)
-						.write(true)
-						.truncate(true)
-						.open(&log_file)
-						.expect("Failed to open log file")
-				},
-				false,
-			);
+			let f = fs::OpenOptions::new()
+				.create(true)
+				.write(true)
+				.truncate(true)
+				.open(&log_file)
+				.expect("Failed to open log file");
+			let mut cli = cli.with_stderr(Arc::new(f), false);
 			cli.run()
 		}
 		None => cli.run(),

--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -23,7 +23,7 @@ use crate::{
 	},
 	constraints::{BoxedPropagator, Conflict, ReasonBuilder},
 	helpers::bytes::Bytes,
-	model::{self, decision::integer::Domain},
+	model::{self, decision::integer::Domain, resolved::Resolved},
 	solver::{
 		self, IntLitMeaning, Solver,
 		decision::integer::{EncodingType, IntDecision},
@@ -178,13 +178,13 @@ pub(crate) struct LoweringMapBuilder {
 	pub(crate) bool_map: Vec<Option<solver::View<bool>>>,
 	/// Set of integer decision for which the direct encoding should be created
 	/// eagerly.
-	pub(crate) int_eager_direct: FxHashSet<model::Decision<IntVal>>,
+	pub(crate) int_eager_direct: FxHashSet<Resolved<model::Decision<IntVal>>>,
 	/// The (default) maximum cardinality of the domain of an integer variable
 	/// before its order encoding is created lazily.
 	pub(crate) int_eager_limit: usize,
 	/// Set of integer decision for which the order encoding should be created
 	/// eagerly.
-	pub(crate) int_eager_order: FxHashSet<model::Decision<IntVal>>,
+	pub(crate) int_eager_order: FxHashSet<Resolved<model::Decision<IntVal>>>,
 	/// Map of integer decisions to integer views.
 	pub(crate) int_map: Vec<Option<solver::View<IntVal>>>,
 }
@@ -674,36 +674,43 @@ impl LoweringMapBuilder {
 			return v;
 		}
 
-		let def = &model.int_vars[iv.idx()];
-		let view = match &def.domain {
-			Domain::Domain(dom) => {
-				let direct_enc = if self.int_eager_direct.contains(&iv) {
-					EncodingType::Eager
-				} else {
-					EncodingType::Lazy
+		let r = iv.resolve_alias(model);
+		let view = match r.into_inner().0 {
+			Const(c) => c.into(),
+			Linear(lin) => {
+				let var = Resolved(lin.var);
+				let base = match self.int_map[var.idx()] {
+					Some(v) => v,
+					None => {
+						let def = &model.int_vars[var.idx()];
+						let Domain::Domain(dom) = &def.domain else {
+							unreachable!()
+						};
+						let direct_enc = if self.int_eager_direct.contains(&var) {
+							EncodingType::Eager
+						} else {
+							EncodingType::Lazy
+						};
+						let card = dom.card();
+						let order_enc = if self.int_eager_order.contains(&var)
+							|| self.int_eager_direct.contains(&var)
+							|| card.is_some() && card.unwrap() <= self.int_eager_limit
+						{
+							EncodingType::Eager
+						} else {
+							EncodingType::Lazy
+						};
+						let view = IntDecision::new_in(slv, dom.clone(), order_enc, direct_enc);
+						self.int_map[var.idx()] = Some(view);
+						view
+					}
 				};
-				let card = dom.card();
-				let order_enc = if self.int_eager_order.contains(&iv)
-					|| self.int_eager_direct.contains(&iv)
-					|| card.is_some() && card.unwrap() <= self.int_eager_limit
-				{
-					EncodingType::Eager
-				} else {
-					EncodingType::Lazy
-				};
-				IntDecision::new_in(slv, dom.clone(), order_enc, direct_enc)
+				base * lin.scale + lin.offset
 			}
-			Domain::Alias(alias) => match alias.0 {
-				Const(c) => c.into(),
-				Linear(lin) => {
-					let iv = self.get_or_create_int(model, slv, lin.var);
-					iv * lin.scale + lin.offset
-				}
-				Bool(lin) => {
-					let bv = self.get_or_create_bool(model, slv, lin.var);
-					bv * lin.scale + lin.offset
-				}
-			},
+			Bool(lin) => {
+				let bv = self.get_or_create_bool(model, slv, lin.var);
+				bv * lin.scale + lin.offset
+			}
 		};
 
 		self.int_map[iv.idx()] = Some(view);

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -4,6 +4,7 @@ pub(crate) mod decision;
 pub mod deserialize;
 pub mod expressions;
 mod initilization_context;
+pub(crate) mod resolved;
 pub(crate) mod view;
 
 use std::{
@@ -50,7 +51,7 @@ use crate::{
 			integer::{Domain, IntDecision},
 		},
 		initilization_context::ModelInitContext,
-		view::integer::IntView,
+		resolved::Resolved,
 	},
 	solver::{
 		IntLitMeaning, Solver,
@@ -436,26 +437,26 @@ impl Model {
 		}
 
 		// Determine encoding types for integer variables
-		let mut int_eager_direct = FxHashSet::<Decision<IntVal>>::default();
-		let int_eager_order = FxHashSet::<Decision<IntVal>>::default();
+		let mut int_eager_direct = FxHashSet::<Resolved<Decision<IntVal>>>::default();
+		let int_eager_order = FxHashSet::<Resolved<Decision<IntVal>>>::default();
 
 		for c in self.constraints.iter().flatten() {
 			let c: &dyn Constraint<Model> = c.as_ref();
 			let c: &dyn Any = c;
 			if let Some(c) = c.downcast_ref::<BoolDecisionArrayElement>() {
 				let index = c.index.resolve_alias(self);
-				if let IntView::Linear(lin) = index.0 {
-					int_eager_direct.insert(lin.var);
+				if let Some(var) = index.integer_decision() {
+					int_eager_direct.insert(var);
 				}
 			} else if let Some(c) = c.downcast_ref::<IntUnique>() {
 				for v in &c.prop.var {
 					let v = v.resolve_alias(self);
-					if let IntView::Linear(lin) = v.0 {
-						let Domain::Domain(dom) = &self.int_vars[lin.var.idx()].domain else {
+					if let Some(var) = v.integer_decision() {
+						let Domain::Domain(dom) = &self.int_vars[var.idx()].domain else {
 							unreachable!()
 						};
 						if dom.card() <= Some(c.prop.var.len() * 100 / 80) {
-							int_eager_direct.insert(lin.var);
+							int_eager_direct.insert(var);
 						}
 					}
 				}
@@ -463,22 +464,22 @@ impl Model {
 				c.downcast_ref::<IntArrayElementBounds<View<IntVal>, View<IntVal>, View<IntVal>>>()
 			{
 				let index = c.index.resolve_alias(self);
-				if let IntView::Linear(lin) = index.0 {
-					int_eager_direct.insert(lin.var);
+				if let Some(var) = index.integer_decision() {
+					int_eager_direct.insert(var);
 				}
 			} else if let Some(c) = c.downcast_ref::<IntTable>() {
 				for &v in &c.vars {
 					let v = v.resolve_alias(self);
-					if let IntView::Linear(lin) = v.0 {
-						int_eager_direct.insert(lin.var);
+					if let Some(var) = v.integer_decision() {
+						int_eager_direct.insert(var);
 					}
 				}
 			} else if let Some(c) =
 				c.downcast_ref::<IntValArrayElement<View<IntVal>, View<IntVal>>>()
 			{
 				let index = c.0.index.resolve_alias(self);
-				if let IntView::Linear(lin) = index.0 {
-					int_eager_direct.insert(lin.var);
+				if let Some(var) = index.integer_decision() {
+					int_eager_direct.insert(var);
 				}
 			}
 		}

--- a/crates/huub/src/model/decision/boolean.rs
+++ b/crates/huub/src/model/decision/boolean.rs
@@ -5,7 +5,10 @@ use std::ops::Not;
 use pindakaas::Lit as RawLit;
 
 use crate::{
-	actions::BoolInspectionActions,
+	actions::{
+		BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions, ReasoningContext,
+	},
+	constraints::ReasonBuilder,
 	model::{
 		Model,
 		decision::{Decision, DecisionReference, private},
@@ -46,8 +49,29 @@ impl Decision<bool> {
 
 impl BoolInspectionActions<Model> for Decision<bool> {
 	fn val(&self, ctx: &Model) -> Option<bool> {
-		let view: View<bool> = (*self).into();
-		view.val(ctx)
+		self.resolve_alias(ctx).val(ctx)
+	}
+}
+
+impl BoolPropagationActions<Model> for Decision<bool> {
+	fn fix(
+		&self,
+		ctx: &mut Model,
+		val: bool,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		self.resolve_alias(ctx).fix(ctx, val, reason)
+	}
+}
+
+impl BoolSimplificationActions<Model> for Decision<bool> {
+	fn unify(
+		&self,
+		ctx: &mut Model,
+		other: impl Into<View<bool>>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		let other = other.into().resolve_alias(ctx);
+		self.resolve_alias(ctx).unify(ctx, other)
 	}
 }
 

--- a/crates/huub/src/model/decision/integer.rs
+++ b/crates/huub/src/model/decision/integer.rs
@@ -14,6 +14,7 @@ use crate::{
 	model::{
 		AdvRef, ConRef, Decision, Model,
 		decision::{DecisionReference, private},
+		resolved::Resolved,
 		view::{View, boolean::BoolView, integer::IntView},
 	},
 	solver::{
@@ -49,25 +50,169 @@ impl Decision<IntVal> {
 	pub(crate) fn idx(&self) -> usize {
 		self.0 as usize
 	}
+}
 
+impl IntDecisionActions<Model> for Decision<IntVal> {
+	fn lit(&self, ctx: &mut Model, meaning: IntLitMeaning) -> View<bool> {
+		self.resolve_alias(ctx).lit(ctx, meaning)
+	}
+
+	fn val_lit(&self, ctx: &mut Model) -> Option<View<bool>> {
+		self.resolve_alias(ctx).val_lit(ctx)
+	}
+}
+
+impl IntInspectionActions<Model> for Decision<IntVal> {
+	fn bounds(&self, ctx: &Model) -> (IntVal, IntVal) {
+		self.resolve_alias(ctx).bounds(ctx)
+	}
+
+	fn domain(&self, ctx: &Model) -> IntSet {
+		self.resolve_alias(ctx).domain(ctx)
+	}
+
+	fn in_domain(&self, ctx: &Model, val: IntVal) -> bool {
+		self.resolve_alias(ctx).in_domain(ctx, val)
+	}
+
+	fn lit_meaning(
+		&self,
+		ctx: &Model,
+		lit: <Model as ReasoningContext>::Atom,
+	) -> Option<IntLitMeaning> {
+		self.resolve_alias(ctx).lit_meaning(ctx, lit)
+	}
+
+	fn max(&self, ctx: &Model) -> IntVal {
+		self.resolve_alias(ctx).max(ctx)
+	}
+
+	fn max_lit(&self, ctx: &Model) -> <Model as ReasoningContext>::Atom {
+		self.resolve_alias(ctx).max_lit(ctx)
+	}
+
+	fn min(&self, ctx: &Model) -> IntVal {
+		self.resolve_alias(ctx).min(ctx)
+	}
+
+	fn min_lit(&self, ctx: &Model) -> <Model as ReasoningContext>::Atom {
+		self.resolve_alias(ctx).min_lit(ctx)
+	}
+
+	fn try_lit(
+		&self,
+		ctx: &Model,
+		meaning: IntLitMeaning,
+	) -> Option<<Model as ReasoningContext>::Atom> {
+		self.resolve_alias(ctx).try_lit(ctx, meaning)
+	}
+
+	fn val(&self, ctx: &Model) -> Option<IntVal> {
+		self.resolve_alias(ctx).val(ctx)
+	}
+}
+
+impl IntPropagationActions<Model> for Decision<IntVal> {
+	fn fix(
+		&self,
+		ctx: &mut Model,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		self.resolve_alias(ctx).fix(ctx, val, reason)
+	}
+
+	fn remove_val(
+		&self,
+		ctx: &mut Model,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		self.resolve_alias(ctx).remove_val(ctx, val, reason)
+	}
+
+	fn tighten_max(
+		&self,
+		ctx: &mut Model,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		self.resolve_alias(ctx).tighten_max(ctx, val, reason)
+	}
+
+	fn tighten_min(
+		&self,
+		ctx: &mut Model,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		self.resolve_alias(ctx).tighten_min(ctx, val, reason)
+	}
+}
+
+impl IntSimplificationActions<Model> for Decision<IntVal> {
+	fn exclude(
+		&self,
+		ctx: &mut Model,
+		values: &IntSet,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		self.resolve_alias(ctx).exclude(ctx, values, reason)
+	}
+
+	fn restrict_domain(
+		&self,
+		ctx: &mut Model,
+		domain: &IntSet,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		self.resolve_alias(ctx).restrict_domain(ctx, domain, reason)
+	}
+
+	fn unify(
+		&self,
+		ctx: &mut Model,
+		other: impl Into<Self>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		let me = self.resolve_alias(ctx);
+		let other = other.into().resolve_alias(ctx);
+		me.unify(ctx, other)?;
+		Ok(())
+	}
+}
+
+impl IntDecision {
+	/// Create a new integer variable definition with the given domain.
+	pub(crate) fn with_domain(dom: IntSet) -> Self {
+		Self {
+			domain: Domain::Domain(dom),
+			constraints: Default::default(),
+		}
+	}
+}
+
+impl DecisionReference for IntVal {
+	type Ref = u32;
+}
+impl private::Sealed for IntVal {}
+
+impl Resolved<Decision<IntVal>> {
 	/// Internal method performing unification under the assumption that the
 	/// receiver is an integer decision index that is not already aliased, and
 	/// that it can be aliased to directly point to `other`.
 	pub(crate) fn unify_internal(
-		&self,
+		self,
 		ctx: &mut Model,
 		target: View<IntVal>,
 	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		debug_assert!(matches!(
-			ctx.int_vars[self.idx()].domain,
-			Domain::Domain(_) | Domain::Alias(View(IntView::Const(_)))
-		));
+		let idx = self.idx();
+		debug_assert!(matches!(ctx.int_vars[idx].domain, Domain::Domain(_)));
 
 		// Set the domain on the variable to be aliased to trigger subscription
 		// events.
 		self.restrict_domain(ctx, &target.domain(ctx), [])?;
 		// Change variable to point to the target
-		match mem::replace(&mut ctx.int_vars[self.idx()].domain, Domain::Alias(target)) {
+		match mem::replace(&mut ctx.int_vars[idx].domain, Domain::Alias(target)) {
 			// Restrict the domain of the target variable using the variable domain
 			// being aliased.
 			Domain::Domain(dom) => target.restrict_domain(ctx, &dom, [])?,
@@ -75,7 +220,7 @@ impl Decision<IntVal> {
 			_ => unreachable!(),
 		};
 		// Transfer any constraints from the aliased variable to the target variable
-		let constraints = mem::take(&mut ctx.int_vars[self.idx()].constraints);
+		let constraints = mem::take(&mut ctx.int_vars[idx].constraints);
 		// Move subscriptions to target decision variable
 		match target.0 {
 			IntView::Linear(lin) => {
@@ -136,203 +281,11 @@ impl Decision<IntVal> {
 	}
 }
 
-impl IntDecisionActions<Model> for Decision<IntVal> {
-	fn lit(&self, ctx: &mut Model, meaning: IntLitMeaning) -> View<bool> {
-		IntInspectionActions::try_lit(self, ctx, meaning).unwrap()
-	}
-
-	fn val_lit(&self, ctx: &mut Model) -> Option<View<bool>> {
-		let val = self.val(ctx)?;
-		Some(View(BoolView::IntEq(*self, val)))
-	}
-}
-
-impl IntInspectionActions<Model> for Decision<IntVal> {
-	fn bounds(&self, ctx: &Model) -> (IntVal, IntVal) {
-		match &ctx.int_vars[self.idx()].domain {
-			Domain::Domain(d) => (*d.lower_bound().unwrap(), *d.upper_bound().unwrap()),
-			Domain::Alias(alias) => alias.bounds(ctx),
-		}
-	}
-
-	fn domain(&self, ctx: &Model) -> IntSet {
-		match &ctx.int_vars[self.idx()].domain {
-			Domain::Domain(d) => d.clone(),
-			Domain::Alias(alias) => alias.domain(ctx),
-		}
-	}
-
-	fn in_domain(&self, ctx: &Model, val: IntVal) -> bool {
-		match &ctx.int_vars[self.idx()].domain {
-			Domain::Domain(d) => d.contains(&val),
-			Domain::Alias(alias) => alias.in_domain(ctx, val),
-		}
-	}
-
-	fn lit_meaning(
-		&self,
-		_: &Model,
-		lit: <Model as ReasoningContext>::Atom,
-	) -> Option<IntLitMeaning> {
-		match lit.0 {
-			BoolView::IntEq(idx, val) if idx == *self => Some(IntLitMeaning::Eq(val)),
-			BoolView::IntGreaterEq(idx, val) if idx == *self => Some(IntLitMeaning::GreaterEq(val)),
-			BoolView::IntLess(idx, val) if idx == *self => Some(IntLitMeaning::Less(val)),
-			BoolView::IntNotEq(idx, val) if idx == *self => Some(IntLitMeaning::NotEq(val)),
-			_ => None,
-		}
-	}
-
-	fn max(&self, ctx: &Model) -> IntVal {
-		match &ctx.int_vars[self.idx()].domain {
-			Domain::Domain(d) => *d.upper_bound().unwrap(),
-			Domain::Alias(alias) => alias.max(ctx),
-		}
-	}
-
-	fn max_lit(&self, ctx: &Model) -> <Model as ReasoningContext>::Atom {
-		match &ctx.int_vars[self.idx()].domain {
-			Domain::Domain(d) => d
-				.lower_bound()
-				.map(|&val| View(BoolView::IntLess(*self, val + 1)))
-				.unwrap(),
-			Domain::Alias(alias) => alias.max_lit(ctx),
-		}
-	}
-
-	fn min(&self, ctx: &Model) -> IntVal {
-		match &ctx.int_vars[self.idx()].domain {
-			Domain::Domain(d) => *d.lower_bound().unwrap(),
-			Domain::Alias(alias) => alias.min(ctx),
-		}
-	}
-
-	fn min_lit(&self, ctx: &Model) -> <Model as ReasoningContext>::Atom {
-		match &ctx.int_vars[self.idx()].domain {
-			Domain::Domain(d) => d
-				.lower_bound()
-				.map(|&val| View(BoolView::IntGreaterEq(*self, val)))
-				.unwrap(),
-			Domain::Alias(alias) => alias.min_lit(ctx),
-		}
-	}
-
-	fn try_lit(
-		&self,
-		ctx: &Model,
-		meaning: IntLitMeaning,
-	) -> Option<<Model as ReasoningContext>::Atom> {
-		match &ctx.int_vars[self.idx()].domain {
-			Domain::Domain(_) => Some(View(match meaning {
-				IntLitMeaning::Eq(v) => BoolView::IntEq(*self, v),
-				IntLitMeaning::NotEq(v) => BoolView::IntNotEq(*self, v),
-				IntLitMeaning::GreaterEq(v) => BoolView::IntGreaterEq(*self, v),
-				IntLitMeaning::Less(v) => BoolView::IntLess(*self, v),
-			})),
-			Domain::Alias(alias) => alias.try_lit(ctx, meaning),
-		}
-	}
-
-	fn val(&self, ctx: &Model) -> Option<IntVal> {
-		match &ctx.int_vars[self.idx()].domain {
-			Domain::Domain(d) => {
-				let (lb, ub) = (d.lower_bound().unwrap(), d.upper_bound().unwrap());
-				if lb == ub { Some(*lb) } else { None }
-			}
-			Domain::Alias(alias) => alias.val(ctx),
-		}
-	}
-}
-
-impl IntPropagationActions<Model> for Decision<IntVal> {
-	fn fix(
-		&self,
-		ctx: &mut Model,
-		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let def = &mut ctx.int_vars[self.idx()];
-		let Domain::Domain(dom) = &def.domain else {
-			unreachable!()
-		};
-		if dom.contains(&val) {
-			def.domain = Domain::Alias(val.into());
-			ctx.int_events.insert(self.0, IntEvent::Fixed);
-			Ok(())
-		} else {
-			Err(ctx.create_conflict(View(BoolView::IntEq(*self, val)), reason))
-		}
-	}
-
-	fn remove_val(
-		&self,
-		ctx: &mut Model,
-		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		self.exclude(ctx, &(val..=val).into(), reason)
-	}
-
-	fn tighten_max(
-		&self,
-		ctx: &mut Model,
-		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let def = &mut ctx.int_vars[self.idx()];
-		let Domain::Domain(dom) = &mut def.domain else {
-			unreachable!()
-		};
-		if val >= *dom.upper_bound().unwrap() {
-			return Ok(());
-		} else if val < *dom.lower_bound().unwrap() {
-			return Err(ctx.create_conflict(View(BoolView::IntLess(*self, val + 1)), reason));
-		}
-		if val != *dom.lower_bound().unwrap() {
-			dom.set_upper_bound(val);
-			ctx.int_events
-				.entry(self.0)
-				.and_modify(|v| *v += IntEvent::UpperBound)
-				.or_insert(IntEvent::UpperBound);
-		} else {
-			def.domain = Domain::Alias(val.into());
-			ctx.int_events.insert(self.0, IntEvent::Fixed);
-		};
-		Ok(())
-	}
-
-	fn tighten_min(
-		&self,
-		ctx: &mut Model,
-		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let def = &mut ctx.int_vars[self.idx()];
-		let Domain::Domain(dom) = &mut def.domain else {
-			unreachable!()
-		};
-		if val <= *dom.lower_bound().unwrap() {
-			return Ok(());
-		} else if val > *dom.upper_bound().unwrap() {
-			return Err(ctx.create_conflict(View(BoolView::IntGreaterEq(*self, val)), reason));
-		}
-		if val != *dom.upper_bound().unwrap() {
-			dom.set_lower_bound(val);
-			ctx.int_events
-				.entry(self.0)
-				.and_modify(|e| *e += IntEvent::LowerBound)
-				.or_insert(IntEvent::LowerBound);
-		} else {
-			def.domain = Domain::Alias(val.into());
-			ctx.int_events.insert(self.0, IntEvent::Fixed);
-		};
-		Ok(())
-	}
-}
-
-impl IntSimplificationActions<Model> for Decision<IntVal> {
-	fn exclude(
-		&self,
+impl Resolved<Decision<IntVal>> {
+	/// Consuming variant of [`IntSimplificationActions::exclude`] for
+	/// canonical integer decisions.
+	pub(crate) fn exclude(
+		self,
 		ctx: &mut Model,
 		values: &IntSet,
 		reason: impl ReasonBuilder<Model>,
@@ -343,7 +296,7 @@ impl IntSimplificationActions<Model> for Decision<IntVal> {
 		let diff: RangeList<_> = dom.diff(values);
 		if diff.is_empty() {
 			return Err(ctx.create_conflict(
-				View(BoolView::IntNotEq(*self, *values.lower_bound().unwrap())),
+				View(BoolView::IntNotEq(self.0, *values.lower_bound().unwrap())),
 				reason,
 			));
 		}
@@ -353,9 +306,9 @@ impl IntSimplificationActions<Model> for Decision<IntVal> {
 		if diff.card() == Some(1) {
 			let val = *diff.lower_bound().unwrap();
 			ctx.int_vars[self.idx()].domain = Domain::Alias(val.into());
-			ctx.int_events.insert(self.0, IntEvent::Fixed);
+			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
 		} else {
-			let entry = ctx.int_events.entry(self.0).or_insert(IntEvent::Domain);
+			let entry = ctx.int_events.entry(self.0.0).or_insert(IntEvent::Domain);
 			if dom.lower_bound().unwrap() == diff.lower_bound().unwrap() {
 				*entry += IntEvent::LowerBound;
 			}
@@ -368,8 +321,42 @@ impl IntSimplificationActions<Model> for Decision<IntVal> {
 		Ok(())
 	}
 
-	fn restrict_domain(
-		&self,
+	/// Consuming variant of [`IntPropagationActions::fix`] for canonical
+	/// integer decisions.
+	pub(crate) fn fix(
+		self,
+		ctx: &mut Model,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		let def = &mut ctx.int_vars[self.idx()];
+		let Domain::Domain(dom) = &def.domain else {
+			unreachable!()
+		};
+		if dom.contains(&val) {
+			def.domain = Domain::Alias(val.into());
+			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
+			Ok(())
+		} else {
+			Err(ctx.create_conflict(View(BoolView::IntEq(self.0, val)), reason))
+		}
+	}
+
+	/// Consuming variant of [`IntPropagationActions::remove_val`] for canonical
+	/// integer decisions.
+	pub(crate) fn remove_val(
+		self,
+		ctx: &mut Model,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		self.exclude(ctx, &(val..=val).into(), reason)
+	}
+
+	/// Consuming variant of [`IntSimplificationActions::restrict_domain`] for
+	/// canonical integer decisions.
+	pub(crate) fn restrict_domain(
+		self,
 		ctx: &mut Model,
 		domain: &IntSet,
 		reason: impl ReasonBuilder<Model>,
@@ -380,7 +367,7 @@ impl IntSimplificationActions<Model> for Decision<IntVal> {
 		let intersect: RangeList<_> = dom.intersect(domain);
 		if intersect.is_empty() {
 			return Err(ctx.create_conflict(
-				View(BoolView::IntNotEq(*self, *dom.lower_bound().unwrap())),
+				View(BoolView::IntNotEq(self.0, *dom.lower_bound().unwrap())),
 				reason,
 			));
 		} else if *dom == intersect {
@@ -389,9 +376,9 @@ impl IntSimplificationActions<Model> for Decision<IntVal> {
 		if intersect.card() == Some(1) {
 			let val = *intersect.lower_bound().unwrap();
 			ctx.int_vars[self.idx()].domain = Domain::Alias(val.into());
-			ctx.int_events.insert(self.0, IntEvent::Fixed);
+			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
 		} else {
-			let entry = ctx.int_events.entry(self.0).or_insert(IntEvent::Domain);
+			let entry = ctx.int_events.entry(self.0.0).or_insert(IntEvent::Domain);
 			if dom.lower_bound().unwrap() == intersect.lower_bound().unwrap() {
 				*entry += IntEvent::LowerBound;
 			}
@@ -404,27 +391,173 @@ impl IntSimplificationActions<Model> for Decision<IntVal> {
 		Ok(())
 	}
 
-	fn unify(
-		&self,
+	/// Consuming variant of [`IntPropagationActions::tighten_max`] for
+	/// canonical integer decisions.
+	pub(crate) fn tighten_max(
+		self,
 		ctx: &mut Model,
-		other: impl Into<Self>,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
 	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let other: Decision<IntVal> = other.into();
-		View::<IntVal>::from(*self).unify(ctx, other)
+		let def = &mut ctx.int_vars[self.idx()];
+		let Domain::Domain(dom) = &mut def.domain else {
+			unreachable!()
+		};
+		if val >= *dom.upper_bound().unwrap() {
+			return Ok(());
+		} else if val < *dom.lower_bound().unwrap() {
+			return Err(ctx.create_conflict(View(BoolView::IntLess(self.0, val + 1)), reason));
+		}
+		if val != *dom.lower_bound().unwrap() {
+			dom.set_upper_bound(val);
+			ctx.int_events
+				.entry(self.0.0)
+				.and_modify(|v| *v += IntEvent::UpperBound)
+				.or_insert(IntEvent::UpperBound);
+		} else {
+			def.domain = Domain::Alias(val.into());
+			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
+		};
+		Ok(())
+	}
+
+	/// Consuming variant of [`IntPropagationActions::tighten_min`] for
+	/// canonical integer decisions.
+	pub(crate) fn tighten_min(
+		self,
+		ctx: &mut Model,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		let def = &mut ctx.int_vars[self.idx()];
+		let Domain::Domain(dom) = &mut def.domain else {
+			unreachable!()
+		};
+		if val <= *dom.lower_bound().unwrap() {
+			return Ok(());
+		} else if val > *dom.upper_bound().unwrap() {
+			return Err(ctx.create_conflict(View(BoolView::IntGreaterEq(self.0, val)), reason));
+		}
+		if val != *dom.upper_bound().unwrap() {
+			dom.set_lower_bound(val);
+			ctx.int_events
+				.entry(self.0.0)
+				.and_modify(|e| *e += IntEvent::LowerBound)
+				.or_insert(IntEvent::LowerBound);
+		} else {
+			def.domain = Domain::Alias(val.into());
+			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
+		};
+		Ok(())
 	}
 }
 
-impl IntDecision {
-	/// Create a new integer variable definition with the given domain.
-	pub(crate) fn with_domain(dom: IntSet) -> Self {
-		Self {
-			domain: Domain::Domain(dom),
-			constraints: Default::default(),
+impl IntDecisionActions<Model> for Resolved<Decision<IntVal>> {
+	fn lit(&self, ctx: &mut Model, meaning: IntLitMeaning) -> View<bool> {
+		IntInspectionActions::try_lit(self, ctx, meaning).unwrap()
+	}
+
+	fn val_lit(&self, ctx: &mut Model) -> Option<View<bool>> {
+		let val = self.val(ctx)?;
+		Some(View(BoolView::IntEq(self.0, val)))
+	}
+}
+
+impl IntInspectionActions<Model> for Resolved<Decision<IntVal>> {
+	fn bounds(&self, ctx: &Model) -> (IntVal, IntVal) {
+		match &ctx.int_vars[self.idx()].domain {
+			Domain::Domain(d) => (*d.lower_bound().unwrap(), *d.upper_bound().unwrap()),
+			Domain::Alias(_) => unreachable!(),
+		}
+	}
+
+	fn domain(&self, ctx: &Model) -> IntSet {
+		match &ctx.int_vars[self.idx()].domain {
+			Domain::Domain(d) => d.clone(),
+			Domain::Alias(_) => unreachable!(),
+		}
+	}
+
+	fn in_domain(&self, ctx: &Model, val: IntVal) -> bool {
+		match &ctx.int_vars[self.idx()].domain {
+			Domain::Domain(d) => d.contains(&val),
+			Domain::Alias(_) => unreachable!(),
+		}
+	}
+
+	fn lit_meaning(
+		&self,
+		_: &Model,
+		lit: <Model as ReasoningContext>::Atom,
+	) -> Option<IntLitMeaning> {
+		match lit.0 {
+			BoolView::IntEq(idx, val) if idx == self.0 => Some(IntLitMeaning::Eq(val)),
+			BoolView::IntGreaterEq(idx, val) if idx == self.0 => {
+				Some(IntLitMeaning::GreaterEq(val))
+			}
+			BoolView::IntLess(idx, val) if idx == self.0 => Some(IntLitMeaning::Less(val)),
+			BoolView::IntNotEq(idx, val) if idx == self.0 => Some(IntLitMeaning::NotEq(val)),
+			_ => None,
+		}
+	}
+
+	fn max(&self, ctx: &Model) -> IntVal {
+		match &ctx.int_vars[self.idx()].domain {
+			Domain::Domain(d) => *d.upper_bound().unwrap(),
+			Domain::Alias(_) => unreachable!(),
+		}
+	}
+
+	fn max_lit(&self, ctx: &Model) -> <Model as ReasoningContext>::Atom {
+		match &ctx.int_vars[self.idx()].domain {
+			Domain::Domain(d) => d
+				.lower_bound()
+				.map(|&val| View(BoolView::IntLess(self.0, val + 1)))
+				.unwrap(),
+			Domain::Alias(_) => unreachable!(),
+		}
+	}
+
+	fn min(&self, ctx: &Model) -> IntVal {
+		match &ctx.int_vars[self.idx()].domain {
+			Domain::Domain(d) => *d.lower_bound().unwrap(),
+			Domain::Alias(_) => unreachable!(),
+		}
+	}
+
+	fn min_lit(&self, ctx: &Model) -> <Model as ReasoningContext>::Atom {
+		match &ctx.int_vars[self.idx()].domain {
+			Domain::Domain(d) => d
+				.lower_bound()
+				.map(|&val| View(BoolView::IntGreaterEq(self.0, val)))
+				.unwrap(),
+			Domain::Alias(_) => unreachable!(),
+		}
+	}
+
+	fn try_lit(
+		&self,
+		ctx: &Model,
+		meaning: IntLitMeaning,
+	) -> Option<<Model as ReasoningContext>::Atom> {
+		match &ctx.int_vars[self.idx()].domain {
+			Domain::Domain(_) => Some(View(match meaning {
+				IntLitMeaning::Eq(v) => BoolView::IntEq(self.0, v),
+				IntLitMeaning::NotEq(v) => BoolView::IntNotEq(self.0, v),
+				IntLitMeaning::GreaterEq(v) => BoolView::IntGreaterEq(self.0, v),
+				IntLitMeaning::Less(v) => BoolView::IntLess(self.0, v),
+			})),
+			Domain::Alias(_) => unreachable!(),
+		}
+	}
+
+	fn val(&self, ctx: &Model) -> Option<IntVal> {
+		match &ctx.int_vars[self.idx()].domain {
+			Domain::Domain(d) => {
+				let (lb, ub) = (d.lower_bound().unwrap(), d.upper_bound().unwrap());
+				if lb == ub { Some(*lb) } else { None }
+			}
+			Domain::Alias(_) => unreachable!(),
 		}
 	}
 }
-
-impl DecisionReference for IntVal {
-	type Ref = u32;
-}
-impl private::Sealed for IntVal {}

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -882,7 +882,7 @@ where
 	fn lit_bool(&mut self, lit: &Literal<S>) -> Result<View<bool>, FlatZincError> {
 		match lit {
 			Literal::Identifier(ident) => self.lookup_or_create_var(ident).map(|mv| match mv {
-				AnyView::Bool(bv) => Ok(bv.resolve_alias(&self.prb)),
+				AnyView::Bool(bv) => Ok(bv.resolve_alias(&self.prb).into_inner()),
 				AnyView::Int(_) => Err(FlatZincError::InvalidArgumentType {
 					expected: "bool",
 					found: "int".to_owned(),
@@ -899,7 +899,7 @@ where
 	fn lit_int(&mut self, lit: &Literal<S>) -> Result<View<IntVal>, FlatZincError> {
 		match lit {
 			Literal::Identifier(ident) => self.lookup_or_create_var(ident).map(|mv| match mv {
-				AnyView::Int(iv) => Ok(iv.resolve_alias(&self.prb)),
+				AnyView::Int(iv) => Ok(iv.resolve_alias(&self.prb).into_inner()),
 				AnyView::Bool(_) => Err(FlatZincError::InvalidArgumentType {
 					expected: "int",
 					found: "bool".to_owned(),

--- a/crates/huub/src/model/initilization_context.rs
+++ b/crates/huub/src/model/initilization_context.rs
@@ -8,6 +8,7 @@ use crate::{
 	},
 	model::{
 		AdvRef, Advisor, ConRef, Decision, Model,
+		resolved::Resolved,
 		view::{View, boolean::BoolView, integer::IntView},
 	},
 	solver::{
@@ -37,13 +38,11 @@ pub struct ModelInitContext<'a> {
 
 impl BoolInitActions<ModelInitContext<'_>> for Decision<bool> {
 	fn advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
-		let view: View<bool> = (*self).into();
-		view.advise_when_fixed(ctx, data);
+		self.resolve_alias(ctx.model).advise_when_fixed(ctx, data);
 	}
 
 	fn enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
-		let view: View<bool> = (*self).into();
-		view.enqueue_when_fixed(ctx);
+		self.resolve_alias(ctx.model).enqueue_when_fixed(ctx);
 	}
 }
 
@@ -55,26 +54,11 @@ impl BoolInspectionActions<ModelInitContext<'_>> for Decision<bool> {
 
 impl IntInitActions<ModelInitContext<'_>> for Decision<IntVal> {
 	fn advise_when(&self, ctx: &mut ModelInitContext<'_>, cond: IntPropCond, data: u64) {
-		ctx.model.advisors.push(Advisor {
-			con: ctx.con,
-			data,
-			negated: false,
-			bool2int: false,
-			condition: None,
-		});
-		let adv = AdvRef::new(ctx.model.advisors.len() - 1);
-		ctx.model.int_vars[self.idx()]
-			.constraints
-			.add(ActivationAction::Advise(adv), cond);
+		self.resolve_alias(ctx.model).advise_when(ctx, cond, data);
 	}
 
 	fn enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
-		if condition != IntPropCond::Fixed {
-			ctx.semantic_enqueue();
-		}
-		ctx.model.int_vars[self.idx()]
-			.constraints
-			.add(ActivationAction::Enqueue(ctx.con), condition);
+		self.resolve_alias(ctx.model).enqueue_when(ctx, condition);
 	}
 }
 
@@ -177,26 +161,34 @@ impl ReasoningContext for ModelInitContext<'_> {
 	type Conflict = <Model as ReasoningEngine>::Conflict;
 }
 
-impl BoolInitActions<ModelInitContext<'_>> for View<bool> {
+impl BoolInitActions<ModelInitContext<'_>> for Resolved<Decision<bool>> {
 	fn advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
-		let var = self.resolve_alias(ctx.model);
-		let (iv, cond, event) = match var.0 {
-			BoolView::Decision(lit) => {
-				ctx.model.advisors.push(Advisor {
-					con: ctx.con,
-					data,
-					negated: false,
-					bool2int: false,
-					condition: None,
-				});
-				let adv = AdvRef::new(ctx.model.advisors.len() - 1);
-				ctx.model.bool_vars[lit.idx()]
-					.constraints
-					.push(ActivationAction::Advise(adv).into());
-				return;
-			}
+		ctx.model.advisors.push(Advisor {
+			con: ctx.con,
+			data,
+			negated: false,
+			bool2int: false,
+			condition: None,
+		});
+		let adv = AdvRef::new(ctx.model.advisors.len() - 1);
+		ctx.model.bool_vars[self.0.idx()]
+			.constraints
+			.push(ActivationAction::Advise(adv).into());
+	}
+
+	fn enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
+		ctx.model.bool_vars[self.0.idx()]
+			.constraints
+			.push(ActivationAction::Enqueue(ctx.con).into());
+	}
+}
+
+impl BoolInitActions<ModelInitContext<'_>> for Resolved<View<bool>> {
+	fn advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
+		let (iv, cond, event) = match self.0.0 {
+			BoolView::Decision(lit) => return Resolved(lit).advise_when_fixed(ctx, data),
 			BoolView::Const(_) => {
-				// Value does not change, so no advisor will ever be called
+				// Value does not change, so no advisor will ever be called.
 				return;
 			}
 			BoolView::IntEq(iv, v) => (iv, IntLitMeaning::Eq(v), IntPropCond::Domain),
@@ -216,12 +208,10 @@ impl BoolInitActions<ModelInitContext<'_>> for View<bool> {
 			.constraints
 			.add(ActivationAction::Advise(adv), event);
 	}
+
 	fn enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
-		let var = self.resolve_alias(ctx.model);
-		match var.0 {
-			BoolView::Decision(lit) => ctx.model.bool_vars[lit.idx()]
-				.constraints
-				.push(ActivationAction::Enqueue(ctx.con).into()),
+		match self.0.0 {
+			BoolView::Decision(lit) => Resolved(lit).enqueue_when_fixed(ctx),
 			BoolView::Const(_) => ctx.semantic_enqueue(),
 			// TODO: These definitions might enqueue when the boolean is not fixed. Use advisors
 			// instead?
@@ -235,17 +225,46 @@ impl BoolInitActions<ModelInitContext<'_>> for View<bool> {
 	}
 }
 
-impl BoolInspectionActions<ModelInitContext<'_>> for View<bool> {
+impl BoolInspectionActions<ModelInitContext<'_>> for Resolved<Decision<bool>> {
+	fn val(&self, ctx: &ModelInitContext<'_>) -> Option<bool> {
+		self.0.val(ctx.model)
+	}
+}
+
+impl BoolInspectionActions<ModelInitContext<'_>> for Resolved<View<bool>> {
 	fn val(&self, ctx: &ModelInitContext<'_>) -> Option<bool> {
 		self.val(ctx.model)
 	}
 }
 
-impl IntInitActions<ModelInitContext<'_>> for View<IntVal> {
+impl IntInitActions<ModelInitContext<'_>> for Resolved<Decision<IntVal>> {
 	fn advise_when(&self, ctx: &mut ModelInitContext<'_>, cond: IntPropCond, data: u64) {
-		let var = self.resolve_alias(ctx.model);
+		ctx.model.advisors.push(Advisor {
+			con: ctx.con,
+			data,
+			negated: false,
+			bool2int: false,
+			condition: None,
+		});
+		let adv = AdvRef::new(ctx.model.advisors.len() - 1);
+		ctx.model.int_vars[self.idx()]
+			.constraints
+			.add(ActivationAction::Advise(adv), cond);
+	}
 
-		match var.0 {
+	fn enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
+		if condition != IntPropCond::Fixed {
+			ctx.semantic_enqueue();
+		}
+		ctx.model.int_vars[self.idx()]
+			.constraints
+			.add(ActivationAction::Enqueue(ctx.con), condition);
+	}
+}
+
+impl IntInitActions<ModelInitContext<'_>> for Resolved<View<IntVal>> {
+	fn advise_when(&self, ctx: &mut ModelInitContext<'_>, cond: IntPropCond, data: u64) {
+		match self.0.0 {
 			IntView::Linear(lin) => {
 				let negated = lin.scale.is_negative();
 				ctx.model.advisors.push(Advisor {
@@ -263,7 +282,7 @@ impl IntInitActions<ModelInitContext<'_>> for View<IntVal> {
 			IntView::Const(_) => ctx.semantic_enqueue(),
 			IntView::Bool(lin) => {
 				let var = lin.var.resolve_alias(ctx.model);
-				let (iv, cond, event) = match var.0 {
+				let (iv, cond, event) = match var.into_inner().0 {
 					BoolView::Decision(lit) => {
 						ctx.model.advisors.push(Advisor {
 							con: ctx.con,
@@ -305,16 +324,14 @@ impl IntInitActions<ModelInitContext<'_>> for View<IntVal> {
 	}
 
 	fn enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
-		let var = self.resolve_alias(ctx.model);
-
-		match var.0 {
+		match self.0.0 {
 			IntView::Linear(lin) => {
 				let condition = match condition {
 					IntPropCond::LowerBound if lin.scale.is_negative() => IntPropCond::UpperBound,
 					IntPropCond::UpperBound if lin.scale.is_negative() => IntPropCond::LowerBound,
 					_ => condition,
 				};
-				lin.var.enqueue_when(ctx, condition);
+				Resolved(lin.var).enqueue_when(ctx, condition);
 			}
 			IntView::Const(_) => ctx.semantic_enqueue(),
 			IntView::Bool(lin) => {
@@ -324,6 +341,115 @@ impl IntInitActions<ModelInitContext<'_>> for View<IntVal> {
 				lin.var.enqueue_when_fixed(ctx);
 			}
 		}
+	}
+}
+
+impl IntInspectionActions<ModelInitContext<'_>> for Resolved<Decision<IntVal>> {
+	fn bounds(&self, ctx: &ModelInitContext<'_>) -> (IntVal, IntVal) {
+		self.bounds(ctx.model)
+	}
+
+	fn domain(&self, ctx: &ModelInitContext<'_>) -> IntSet {
+		self.domain(ctx.model)
+	}
+
+	fn in_domain(&self, ctx: &ModelInitContext<'_>, val: IntVal) -> bool {
+		self.in_domain(ctx.model, val)
+	}
+
+	fn lit_meaning(&self, ctx: &ModelInitContext<'_>, lit: View<bool>) -> Option<IntLitMeaning> {
+		self.lit_meaning(ctx.model, lit)
+	}
+
+	fn max(&self, ctx: &ModelInitContext<'_>) -> IntVal {
+		self.max(ctx.model)
+	}
+
+	fn max_lit(&self, ctx: &ModelInitContext<'_>) -> View<bool> {
+		self.max_lit(ctx.model)
+	}
+
+	fn min(&self, ctx: &ModelInitContext<'_>) -> IntVal {
+		self.min(ctx.model)
+	}
+
+	fn min_lit(&self, ctx: &ModelInitContext<'_>) -> View<bool> {
+		self.min_lit(ctx.model)
+	}
+
+	fn try_lit(&self, ctx: &ModelInitContext<'_>, meaning: IntLitMeaning) -> Option<View<bool>> {
+		self.try_lit(ctx.model, meaning)
+	}
+
+	fn val(&self, ctx: &ModelInitContext<'_>) -> Option<IntVal> {
+		self.val(ctx.model)
+	}
+}
+
+impl IntInspectionActions<ModelInitContext<'_>> for Resolved<View<IntVal>> {
+	fn bounds(&self, ctx: &ModelInitContext<'_>) -> (IntVal, IntVal) {
+		self.bounds(ctx.model)
+	}
+
+	fn domain(&self, ctx: &ModelInitContext<'_>) -> IntSet {
+		self.domain(ctx.model)
+	}
+
+	fn in_domain(&self, ctx: &ModelInitContext<'_>, val: IntVal) -> bool {
+		self.in_domain(ctx.model, val)
+	}
+
+	fn lit_meaning(&self, ctx: &ModelInitContext<'_>, lit: View<bool>) -> Option<IntLitMeaning> {
+		self.lit_meaning(ctx.model, lit)
+	}
+
+	fn max(&self, ctx: &ModelInitContext<'_>) -> IntVal {
+		self.max(ctx.model)
+	}
+
+	fn max_lit(&self, ctx: &ModelInitContext<'_>) -> View<bool> {
+		self.max_lit(ctx.model)
+	}
+
+	fn min(&self, ctx: &ModelInitContext<'_>) -> IntVal {
+		self.min(ctx.model)
+	}
+
+	fn min_lit(&self, ctx: &ModelInitContext<'_>) -> View<bool> {
+		self.min_lit(ctx.model)
+	}
+
+	fn try_lit(&self, ctx: &ModelInitContext<'_>, meaning: IntLitMeaning) -> Option<View<bool>> {
+		self.try_lit(ctx.model, meaning)
+	}
+
+	fn val(&self, ctx: &ModelInitContext<'_>) -> Option<IntVal> {
+		self.val(ctx.model)
+	}
+}
+
+impl BoolInitActions<ModelInitContext<'_>> for View<bool> {
+	fn advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
+		self.resolve_alias(ctx.model).advise_when_fixed(ctx, data);
+	}
+	fn enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
+		self.resolve_alias(ctx.model).enqueue_when_fixed(ctx);
+	}
+}
+
+impl BoolInspectionActions<ModelInitContext<'_>> for View<bool> {
+	fn val(&self, ctx: &ModelInitContext<'_>) -> Option<bool> {
+		self.val(ctx.model)
+	}
+}
+
+impl IntInitActions<ModelInitContext<'_>> for View<IntVal> {
+	fn advise_when(&self, ctx: &mut ModelInitContext<'_>, cond: IntPropCond, data: u64) {
+		self.resolve_alias(ctx.model).advise_when(ctx, cond, data);
+	}
+
+	fn enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
+		self.resolve_alias(ctx.model).enqueue_when(ctx, condition);
 	}
 }
 

--- a/crates/huub/src/model/resolved.rs
+++ b/crates/huub/src/model/resolved.rs
@@ -1,0 +1,166 @@
+//! Resolved model handles that no longer carry aliasing ambiguity.
+use std::{num::NonZero, ops::Not};
+
+use crate::{
+	IntVal,
+	actions::IntInspectionActions,
+	model::{
+		Decision, Model, View,
+		decision::integer::Domain,
+		view::{boolean::BoolView, integer::IntView},
+	},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// Wrapper for model values whose aliases have been resolved against a model.
+///
+/// This type marks a model handle whose alias chain has already been followed
+/// against the current model state. Mutating operations should keep this
+/// wrapper updated in place, or the wrapper should simply be discarded.
+pub(crate) struct Resolved<T>(pub(crate) T);
+
+impl Decision<IntVal> {
+	/// Resolve this decision into a view that no longer references aliases.
+	pub(crate) fn resolve_alias(self, model: &Model) -> Resolved<View<IntVal>> {
+		View::from(self).resolve_alias(model)
+	}
+}
+
+impl Decision<bool> {
+	/// Resolve this decision into a view that no longer references aliases.
+	pub(crate) fn resolve_alias(self, model: &Model) -> Resolved<View<bool>> {
+		View::from(self).resolve_alias(model)
+	}
+}
+
+impl Resolved<Decision<IntVal>> {
+	/// Return the storage index of the resolved decision.
+	pub(crate) fn idx(&self) -> usize {
+		self.0.idx()
+	}
+}
+
+impl<T> Resolved<T> {
+	/// Return the wrapped resolved value.
+	pub(crate) fn into_inner(self) -> T {
+		self.0
+	}
+}
+
+impl Resolved<View<IntVal>> {
+	/// Return the underlying canonical decision when the resolved view is
+	/// backed by an integer decision variable.
+	pub(crate) fn integer_decision(&self) -> Option<Resolved<Decision<IntVal>>> {
+		match self.0.0 {
+			IntView::Linear(lin) => Some(Resolved(lin.var)),
+			IntView::Const(_) | IntView::Bool(_) => None,
+		}
+	}
+}
+
+impl<T: Not> Not for Resolved<T> {
+	type Output = Resolved<T::Output>;
+
+	fn not(self) -> Self::Output {
+		Resolved(!self.0)
+	}
+}
+
+impl View<IntVal> {
+	/// Resolve any aliasing in the IntDecision, ensuring the result is a
+	/// IntDecision that if it is a `Var` or `Linear`, then the domain is not an
+	/// alias.
+	pub(crate) fn resolve_alias(self, model: &Model) -> Resolved<Self> {
+		use IntView::*;
+
+		let mut view = self;
+		let mut scale = 1;
+		let mut offset = 0;
+		loop {
+			match view.0 {
+				Const(c) => {
+					return Resolved((c * scale + offset).into());
+				}
+				_ if scale == 0 => {
+					return Resolved(offset.into());
+				}
+				Linear(lin) => match model.int_vars[lin.var.idx()].domain {
+					Domain::Domain(_) => {
+						return Resolved(View(Linear(lin * NonZero::new(scale).unwrap() + offset)));
+					}
+					Domain::Alias(alias) => {
+						view = alias;
+						offset += scale * lin.offset;
+						scale *= lin.scale.get();
+					}
+				},
+				Bool(lin) => {
+					let var = lin.var.resolve_alias(model).into_inner();
+					if let BoolView::Const(b) = var.0 {
+						return Resolved(View(Const(
+							lin.transform_val(b as IntVal) * scale + offset,
+						)));
+					}
+					return Resolved(View(Bool(lin * NonZero::new(scale).unwrap() + offset)));
+				}
+			}
+		}
+	}
+}
+
+impl View<bool> {
+	/// Resolve any aliasing in the BoolDecision, ensuring the result is a
+	/// BoolDecision that if it is a `Lit`, then it is not an alias.
+	pub(crate) fn resolve_alias(self, model: &Model) -> Resolved<Self> {
+		use BoolView::*;
+
+		let mut result = self;
+		// If the current Lit is an alias, then resolve it.
+		while let Decision(lit) = result.0 {
+			if let Some(alias) = model.bool_vars[lit.idx()].alias {
+				debug_assert_ne!(alias, result);
+				debug_assert_ne!(alias, !result);
+				result = if lit.is_negated() { !alias } else { alias };
+			} else {
+				break;
+			}
+		}
+		// If the current Lit is a integer view, check whether it is already fixed.
+		match result.0 {
+			IntEq(iv, val) => {
+				let (lb, ub) = iv.bounds(model);
+				if val < lb || val > ub {
+					return Resolved(false.into());
+				} else if val == lb && val == ub {
+					return Resolved(true.into());
+				}
+			}
+			IntGreaterEq(iv, val) => {
+				let (lb, ub) = iv.bounds(model);
+				if lb >= val {
+					return Resolved(true.into());
+				} else if ub < val {
+					return Resolved(false.into());
+				}
+			}
+			IntLess(iv, val) => {
+				let (lb, ub) = iv.bounds(model);
+				if ub < val {
+					return Resolved(true.into());
+				} else if lb >= val {
+					return Resolved(false.into());
+				}
+			}
+			IntNotEq(iv, val) => {
+				let (lb, ub) = iv.bounds(model);
+				if val < lb || val > ub {
+					return Resolved(true.into());
+				} else if val == lb && val == ub {
+					return Resolved(false.into());
+				}
+			}
+			_ => {}
+		}
+		Resolved(result)
+	}
+}

--- a/crates/huub/src/model/view/boolean.rs
+++ b/crates/huub/src/model/view/boolean.rs
@@ -11,13 +11,14 @@ use crate::{
 	IntVal,
 	actions::{
 		BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions,
-		IntInspectionActions, IntPropagationActions, PropagationActions,
+		PropagationActions,
 	},
 	constraints::{Conflict, ReasonBuilder},
 	model::{
 		AdvRef, Advisor, ConRef, Model,
 		decision::Decision,
 		expressions::BoolFormula,
+		resolved::Resolved,
 		view::{DefaultView, View, private},
 	},
 	solver::{
@@ -49,126 +50,52 @@ pub enum BoolView {
 	IntNotEq(Decision<IntVal>, IntVal),
 }
 
-impl View<bool> {
-	/// Resolve any aliasing in the BoolDecision, ensuring the result is a
-	/// BoolDecision that if it is a `Lit`, then it is not an alias.
-	pub(crate) fn resolve_alias(self, model: &Model) -> Self {
-		use BoolView::*;
-
-		let mut result = self;
-		// If the current Lit is an alias, then resolve it.
-		while let Decision(lit) = result.0 {
-			if let Some(alias) = model.bool_vars[lit.idx()].alias {
-				debug_assert_ne!(alias, result);
-				debug_assert_ne!(alias, !result);
-				result = if lit.is_negated() { !alias } else { alias };
-			} else {
-				break;
-			}
-		}
-		// If the current Lit is a integer view, check whether it is already fixed.
-		match result.0 {
-			IntEq(iv, val) => {
-				let (lb, ub) = iv.bounds(model);
-				if val < lb || val > ub {
-					return false.into();
-				} else if val == lb && val == ub {
-					return true.into();
-				}
-			}
-			IntGreaterEq(iv, val) => {
-				let (lb, ub) = iv.bounds(model);
-				if lb >= val {
-					return true.into();
-				} else if ub < val {
-					return false.into();
-				}
-			}
-			IntLess(iv, val) => {
-				let (lb, ub) = iv.bounds(model);
-				if ub < val {
-					return true.into();
-				} else if lb >= val {
-					return false.into();
-				}
-			}
-			IntNotEq(iv, val) => {
-				let (lb, ub) = iv.bounds(model);
-				if val < lb || val > ub {
-					return true.into();
-				} else if val == lb && val == ub {
-					return false.into();
-				}
-			}
-			_ => {}
-		}
-		result
-	}
-}
-
-impl Add<IntVal> for View<bool> {
-	type Output = View<IntVal>;
-
-	fn add(self, rhs: IntVal) -> Self::Output {
-		let me: View<IntVal> = self.into();
-		me + rhs
-	}
-}
-
-impl BoolInspectionActions<Model> for View<bool> {
-	fn val(&self, ctx: &Model) -> Option<bool> {
-		use BoolView::*;
-
-		let b = self.resolve_alias(ctx);
-		match b.0 {
-			Const(b) => Some(b),
-			_ => None,
-		}
-	}
-}
-
-impl BoolPropagationActions<Model> for View<bool> {
-	fn fix(
-		&self,
+impl Resolved<View<bool>> {
+	/// Consuming variant of [`BoolPropagationActions::fix`].
+	pub(crate) fn fix(
+		self,
 		ctx: &mut Model,
 		val: bool,
 		reason: impl ReasonBuilder<Model>,
 	) -> Result<(), Conflict<View<bool>>> {
-		let lit = if val { *self } else { !*self };
-		lit.require(ctx, reason)
+		let lit = if val { self.0 } else { !self.0 };
+		Resolved(lit).require(ctx, reason)
 	}
 
-	fn require(
-		&self,
+	/// Consuming variant of [`BoolPropagationActions::require`].
+	pub(crate) fn require(
+		self,
 		ctx: &mut Model,
 		reason: impl ReasonBuilder<Model>,
 	) -> Result<(), Conflict<View<bool>>> {
 		use BoolView::*;
 
-		let var = self.resolve_alias(ctx);
-		match var.0 {
+		match self.0.0 {
 			Decision(l) => {
 				let def = &mut ctx.bool_vars[l.idx()];
 				debug_assert!(def.alias.is_none());
 				def.alias = Some(View(Const(!l.is_negated())));
 				ctx.bool_events.push(l.var());
-				Ok(())
 			}
-			Const(c) => c.require(ctx, reason),
-			IntEq(iv, val) => iv.fix(ctx, val, reason),
-			IntGreaterEq(iv, val) => iv.tighten_min(ctx, val, reason),
-			IntLess(iv, val) => iv.tighten_max(ctx, val - 1, reason),
-			IntNotEq(iv, val) => iv.remove_val(ctx, val, reason),
-		}
+			Const(c) => c.require(ctx, reason)?,
+			IntEq(iv, val) => iv.resolve_alias(ctx).fix(ctx, val, reason)?,
+			IntGreaterEq(iv, val) => iv.resolve_alias(ctx).tighten_min(ctx, val, reason)?,
+			IntLess(iv, val) => iv.resolve_alias(ctx).tighten_max(ctx, val - 1, reason)?,
+			IntNotEq(iv, val) => iv.resolve_alias(ctx).remove_val(ctx, val, reason)?,
+		};
+		Ok(())
 	}
-}
 
-impl BoolSimplificationActions<Model> for View<bool> {
-	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Conflict<View<bool>>> {
+	/// Consuming variant of [`BoolSimplificationActions::unify`].
+	pub(crate) fn unify(
+		self,
+		ctx: &mut Model,
+		other: Resolved<View<bool>>,
+	) -> Result<(), Conflict<View<bool>>> {
 		use BoolView::*;
 
-		let x = self.resolve_alias(ctx);
-		let y = other.into().resolve_alias(ctx);
+		let x = self.0;
+		let y = other.0;
 
 		match (x.0, y.0) {
 			(x, y) if x == y => Ok(()),
@@ -176,7 +103,7 @@ impl BoolSimplificationActions<Model> for View<bool> {
 				Err(ctx.declare_conflict([x, y]))
 			}
 			(Const(x), Const(y)) if x != y => Err(ctx.declare_conflict([])),
-			(x, Const(b)) | (Const(b), x) => View::<bool>(x).fix(ctx, b, []),
+			(x, Const(b)) | (Const(b), x) => Resolved(View::<bool>(x)).fix(ctx, b, []),
 			(Decision(x), y) | (y, Decision(x)) => {
 				let (x, y) = if let Decision(y) = y {
 					if x.0.var() > y.0.var() {
@@ -243,9 +170,67 @@ impl BoolSimplificationActions<Model> for View<bool> {
 	}
 }
 
+impl BoolInspectionActions<Model> for Resolved<View<bool>> {
+	fn val(&self, _ctx: &Model) -> Option<bool> {
+		use BoolView::*;
+
+		match self.0.0 {
+			Const(b) => Some(b),
+			_ => None,
+		}
+	}
+}
+
+impl Add<IntVal> for View<bool> {
+	type Output = View<IntVal>;
+
+	fn add(self, rhs: IntVal) -> Self::Output {
+		let me: View<IntVal> = self.into();
+		me + rhs
+	}
+}
+
+impl BoolInspectionActions<Model> for View<bool> {
+	fn val(&self, ctx: &Model) -> Option<bool> {
+		self.resolve_alias(ctx).val(ctx)
+	}
+}
+
+impl BoolPropagationActions<Model> for View<bool> {
+	fn fix(
+		&self,
+		ctx: &mut Model,
+		val: bool,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(ctx).fix(ctx, val, reason)
+	}
+
+	fn require(
+		&self,
+		ctx: &mut Model,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(ctx).require(ctx, reason)
+	}
+}
+
+impl BoolSimplificationActions<Model> for View<bool> {
+	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Conflict<View<bool>>> {
+		let other = other.into().resolve_alias(ctx);
+		self.resolve_alias(ctx).unify(ctx, other)
+	}
+}
+
 impl From<Decision<bool>> for View<bool> {
 	fn from(decision: Decision<bool>) -> Self {
 		View(BoolView::Decision(decision))
+	}
+}
+
+impl From<Resolved<View<bool>>> for View<bool> {
+	fn from(value: Resolved<View<bool>>) -> Self {
+		value.into_inner()
 	}
 }
 

--- a/crates/huub/src/model/view/integer.rs
+++ b/crates/huub/src/model/view/integer.rs
@@ -16,8 +16,8 @@ use crate::{
 	constraints::{Conflict, ReasonBuilder, int_linear::IntEq},
 	model::{
 		Decision, Model, View,
-		decision::integer::Domain,
 		expressions::linear::IntLinearExp,
+		resolved::Resolved,
 		view::{DefaultView, boolean::BoolView, private},
 	},
 	solver::IntLitMeaning,
@@ -42,6 +42,339 @@ impl DefaultView for IntVal {
 	type View = IntView;
 }
 impl private::Sealed for IntVal {}
+
+impl Resolved<View<IntVal>> {
+	/// Consuming variant of [`IntSimplificationActions::exclude`].
+	pub(crate) fn exclude(
+		self,
+		ctx: &mut Model,
+		values: &IntSet,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), Conflict<View<bool>>> {
+		match self.0.0 {
+			IntView::Const(v) => v.exclude(ctx, values, reason),
+			IntView::Linear(lin) => {
+				Resolved(lin.var).exclude(ctx, &lin.reverse_intset(values), reason)
+			}
+			IntView::Bool(lin) => lin.exclude(ctx, values, reason),
+		}
+	}
+
+	/// Consuming variant of [`IntPropagationActions::fix`].
+	pub(crate) fn fix(
+		self,
+		ctx: &mut Model,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), Conflict<View<bool>>> {
+		match self.0.0 {
+			IntView::Const(v) => v.fix(ctx, val, reason),
+			IntView::Linear(lin) => {
+				let Some(val) = lin.try_reverse_val(val) else {
+					return Err(ctx.declare_conflict(reason));
+				};
+				Resolved(lin.var).fix(ctx, val, reason)
+			}
+			IntView::Bool(lin) => lin.fix(ctx, val, reason),
+		}
+	}
+
+	/// Consuming variant of [`IntPropagationActions::remove_val`].
+	pub(crate) fn remove_val(
+		self,
+		ctx: &mut Model,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), Conflict<View<bool>>> {
+		match self.0.0 {
+			IntView::Const(v) => v.remove_val(ctx, val, reason),
+			IntView::Linear(lin) => {
+				let Some(val) = lin.try_reverse_val(val) else {
+					return Ok(());
+				};
+				Resolved(lin.var).remove_val(ctx, val, reason)
+			}
+			IntView::Bool(lin) => lin.remove_val(ctx, val, reason),
+		}
+	}
+
+	/// Consuming variant of [`IntSimplificationActions::restrict_domain`].
+	pub(crate) fn restrict_domain(
+		self,
+		ctx: &mut Model,
+		values: &IntSet,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), Conflict<View<bool>>> {
+		match self.0.0 {
+			IntView::Const(v) => v.restrict_domain(ctx, values, reason),
+			IntView::Linear(lin) => {
+				Resolved(lin.var).restrict_domain(ctx, &lin.reverse_intset(values), reason)
+			}
+			IntView::Bool(lin) => lin.restrict_domain(ctx, values, reason),
+		}
+	}
+
+	/// Consuming variant of [`IntPropagationActions::tighten_max`].
+	pub(crate) fn tighten_max(
+		self,
+		ctx: &mut Model,
+		ub: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), Conflict<View<bool>>> {
+		match self.0.0 {
+			IntView::Const(v) => v.tighten_max(ctx, ub, reason),
+			IntView::Linear(lin) => {
+				if lin.scale.get() >= 0 {
+					Resolved(lin.var).tighten_max(ctx, lin.reverse_val_floor(ub), reason)
+				} else {
+					Resolved(lin.var).tighten_min(ctx, lin.reverse_val_ceil(ub), reason)
+				}
+			}
+			IntView::Bool(lin) => lin.tighten_max(ctx, ub, reason),
+		}
+	}
+
+	/// Consuming variant of [`IntPropagationActions::tighten_min`].
+	pub(crate) fn tighten_min(
+		self,
+		ctx: &mut Model,
+		val: IntVal,
+		reason: impl ReasonBuilder<Model>,
+	) -> Result<(), Conflict<View<bool>>> {
+		match self.0.0 {
+			IntView::Const(v) => v.tighten_min(ctx, val, reason),
+			IntView::Linear(lin) => {
+				if lin.scale.get() >= 0 {
+					Resolved(lin.var).tighten_min(ctx, lin.reverse_val_ceil(val), reason)
+				} else {
+					Resolved(lin.var).tighten_max(ctx, lin.reverse_val_floor(val), reason)
+				}
+			}
+			IntView::Bool(lin) => lin.tighten_min(ctx, val, reason),
+		}
+	}
+
+	/// Consuming variant of [`IntSimplificationActions::unify`].
+	pub(crate) fn unify(
+		self,
+		ctx: &mut Model,
+		other: Resolved<View<IntVal>>,
+	) -> Result<(), Conflict<View<bool>>> {
+		use IntView::*;
+
+		let (idx, target) = match (self.0.0, other.0.0) {
+			(x, y) if x == y => return Ok(()),
+			(Bool(x), Bool(y)) => return x.unify(ctx, y),
+			(Const(x), Const(y)) if x != y => return Err(ctx.declare_conflict([])),
+			(Const(y), x) | (x, Const(y)) => {
+				let x = View::<IntVal>(x);
+				return x.fix(ctx, y, []);
+			}
+			(Linear(lin_x), Linear(lin_y)) => {
+				// Decide which variable to redefine based on the other.
+				let can_define_x = lin_y.scale.get() % lin_x.scale.get() == 0
+					&& (lin_y.offset - lin_x.offset) % lin_x.scale.get() == 0;
+				let can_define_y = lin_x.scale.get() % lin_y.scale.get() == 0
+					&& (lin_x.offset - lin_y.offset) % lin_y.scale.get() == 0;
+				let (lin_x, lin_y) = if can_define_x && can_define_y && lin_x.var.0 > lin_y.var.0 {
+					(lin_x, lin_y)
+				} else if can_define_y {
+					(lin_y, lin_x)
+				} else if can_define_x {
+					(lin_x, lin_y)
+				} else {
+					ctx.post_constraint(IntEq {
+						vars: [self.0, other.0],
+					});
+					return Ok(());
+				};
+
+				// Perform the transformation and add the aliasing domain to x:
+				// x_scale * x + x_scale = y_scale * y + y_offset
+				// === x = (y_scale / x_scale) * y + ((y_offset - x_offset) / x_scale)
+				let scale = NonZero::new(lin_y.scale.get() / lin_x.scale.get()).unwrap();
+				let offset = (lin_y.offset - lin_x.offset) / lin_x.scale.get();
+				let target = View(Linear(LinearView::new(scale, offset, lin_y.var)));
+				(lin_x.var, target)
+			}
+			(Linear(lin), Bool(b)) | (Bool(b), Linear(lin)) => {
+				let lb = b.transform_val(0);
+				let ub = b.transform_val(1);
+
+				let contains_lb = lin.in_domain(ctx, lb);
+				let contains_ub = lin.in_domain(ctx, ub);
+
+				match (contains_lb, contains_ub) {
+					(false, false) => {
+						return Err(ctx.declare_conflict(|ctx: &mut Model| {
+							[
+								lin.lit(ctx, IntLitMeaning::NotEq(lb)),
+								lin.lit(ctx, IntLitMeaning::NotEq(ub)),
+							]
+						}));
+					}
+					(false, true) => {
+						let Some(val) = lin.try_reverse_val(ub) else {
+							unreachable!()
+						};
+						Resolved(lin.var).fix(ctx, val, [])?;
+						return b.var.require(ctx, |ctx: &mut Model| {
+							[lin.lit(ctx, IntLitMeaning::NotEq(lb))]
+						});
+					}
+					(true, false) => {
+						let Some(val) = lin.try_reverse_val(lb) else {
+							unreachable!()
+						};
+						Resolved(lin.var).fix(ctx, val, [])?;
+						return b.var.fix(ctx, false, |ctx: &mut Model| {
+							[lin.lit(ctx, IntLitMeaning::NotEq(ub))]
+						});
+					}
+					(true, true) => {
+						let Ok(IntLitMeaning::Eq(i_lb)) =
+							lin.reverse_meaning(IntLitMeaning::Eq(lb))
+						else {
+							unreachable!()
+						};
+						let Ok(IntLitMeaning::Eq(i_ub)) =
+							lin.reverse_meaning(IntLitMeaning::Eq(ub))
+						else {
+							unreachable!()
+						};
+						let target = View(Bool(LinearBoolView::new(
+							NonZero::new(i_ub - i_lb).unwrap(),
+							i_lb,
+							b.var,
+						)));
+
+						(lin.var, target)
+					}
+				}
+			}
+		};
+
+		Resolved(idx).unify_internal(ctx, target)
+	}
+}
+
+impl IntDecisionActions<Model> for Resolved<View<IntVal>> {
+	fn lit(&self, ctx: &mut Model, meaning: IntLitMeaning) -> View<bool> {
+		IntInspectionActions::try_lit(self, ctx, meaning).unwrap()
+	}
+
+	fn val_lit(&self, ctx: &mut Model) -> Option<View<bool>> {
+		let val = self.val(ctx)?;
+		Some(IntInspectionActions::try_lit(self, ctx, IntLitMeaning::Eq(val)).unwrap())
+	}
+}
+
+impl IntInspectionActions<Model> for Resolved<View<IntVal>> {
+	fn bounds(&self, ctx: &Model) -> (IntVal, IntVal) {
+		match self.0.0 {
+			IntView::Const(v) => (v, v),
+			IntView::Linear(lin) => {
+				LinearView::new(lin.scale, lin.offset, Resolved(lin.var)).bounds(ctx)
+			}
+			IntView::Bool(lin) => lin.bounds(ctx),
+		}
+	}
+
+	fn domain(&self, ctx: &Model) -> IntSet {
+		match self.0.0 {
+			IntView::Const(c) => (c..=c).into(),
+			IntView::Linear(lin) => {
+				LinearView::new(lin.scale, lin.offset, Resolved(lin.var)).domain(ctx)
+			}
+			IntView::Bool(lin) => lin.domain(ctx),
+		}
+	}
+
+	fn in_domain(&self, ctx: &Model, val: IntVal) -> bool {
+		match self.0.0 {
+			IntView::Const(v) => v == val,
+			IntView::Linear(lin) => {
+				LinearView::new(lin.scale, lin.offset, Resolved(lin.var)).in_domain(ctx, val)
+			}
+			IntView::Bool(lin) => lin.in_domain(ctx, val),
+		}
+	}
+
+	fn lit_meaning(&self, ctx: &Model, lit: View<bool>) -> Option<IntLitMeaning> {
+		match self.0.0 {
+			IntView::Const(_) => None,
+			IntView::Linear(lin) => {
+				LinearView::new(lin.scale, lin.offset, Resolved(lin.var)).lit_meaning(ctx, lit)
+			}
+			IntView::Bool(lin) => lin.lit_meaning(ctx, lit),
+		}
+	}
+
+	fn max(&self, ctx: &Model) -> IntVal {
+		match self.0.0 {
+			IntView::Const(v) => v,
+			IntView::Linear(lin) => {
+				LinearView::new(lin.scale, lin.offset, Resolved(lin.var)).max(ctx)
+			}
+			IntView::Bool(lin) => lin.max(ctx),
+		}
+	}
+
+	fn max_lit(&self, ctx: &Model) -> View<bool> {
+		match self.0.0 {
+			IntView::Const(_) => true.into(),
+			IntView::Linear(lin) => {
+				LinearView::new(lin.scale, lin.offset, Resolved(lin.var)).max_lit(ctx)
+			}
+			IntView::Bool(lin) => lin.max_lit(ctx),
+		}
+	}
+
+	fn min(&self, ctx: &Model) -> IntVal {
+		match self.0.0 {
+			IntView::Const(v) => v,
+			IntView::Linear(lin) => {
+				LinearView::new(lin.scale, lin.offset, Resolved(lin.var)).min(ctx)
+			}
+			IntView::Bool(lin) => lin.min(ctx),
+		}
+	}
+
+	fn min_lit(&self, ctx: &Model) -> View<bool> {
+		match self.0.0 {
+			IntView::Const(_) => true.into(),
+			IntView::Linear(lin) => {
+				LinearView::new(lin.scale, lin.offset, Resolved(lin.var)).min_lit(ctx)
+			}
+			IntView::Bool(lin) => lin.min_lit(ctx),
+		}
+	}
+
+	fn try_lit(&self, ctx: &Model, meaning: IntLitMeaning) -> Option<View<bool>> {
+		match self.0.0 {
+			IntView::Const(v) => Some(match meaning {
+				IntLitMeaning::Eq(i) => (v == i).into(),
+				IntLitMeaning::NotEq(i) => (v != i).into(),
+				IntLitMeaning::GreaterEq(i) => (v >= i).into(),
+				IntLitMeaning::Less(i) => (v < i).into(),
+			}),
+			IntView::Linear(lin) => {
+				LinearView::new(lin.scale, lin.offset, Resolved(lin.var)).try_lit(ctx, meaning)
+			}
+			IntView::Bool(lin) => lin.try_lit(ctx, meaning),
+		}
+	}
+
+	fn val(&self, ctx: &Model) -> Option<IntVal> {
+		match self.0.0 {
+			IntView::Const(v) => Some(v),
+			IntView::Linear(lin) => {
+				LinearView::new(lin.scale, lin.offset, Resolved(lin.var)).val(ctx)
+			}
+			IntView::Bool(lin) => lin.val(ctx),
+		}
+	}
+}
 
 impl View<IntVal> {
 	/// Create a view that represents the addition of a constant value to the
@@ -226,44 +559,6 @@ impl View<IntVal> {
 	pub fn ne(&self, v: IntVal) -> View<bool> {
 		!self.eq(v)
 	}
-
-	/// Resolve any aliasing in the IntDecision, ensuring the result is a
-	/// IntDecision that if it is a `Var` or `Linear`, then the domain is not an
-	/// alias.
-	pub(crate) fn resolve_alias(self, model: &Model) -> Self {
-		use IntView::*;
-
-		let mut view = self;
-		let mut scale = 1;
-		let mut offset = 0;
-		loop {
-			match view.0 {
-				Const(c) => {
-					return (c * scale + offset).into();
-				}
-				_ if scale == 0 => {
-					return offset.into();
-				}
-				Linear(lin) => match model.int_vars[lin.var.idx()].domain {
-					Domain::Domain(_) => {
-						return View(Linear(lin * NonZero::new(scale).unwrap() + offset));
-					}
-					Domain::Alias(alias) => {
-						view = alias;
-						offset += scale * lin.offset;
-						scale *= lin.scale.get();
-					}
-				},
-				Bool(lin) => {
-					let var = lin.var.resolve_alias(model);
-					if let BoolView::Const(b) = var.0 {
-						return View(Const(lin.transform_val(b as IntVal) * scale + offset));
-					}
-					return View(Bool(lin * NonZero::new(scale).unwrap() + offset));
-				}
-			}
-		}
-	}
 }
 
 impl Add<IntVal> for View<IntVal> {
@@ -331,12 +626,11 @@ impl From<i64> for View<IntVal> {
 
 impl IntDecisionActions<Model> for View<IntVal> {
 	fn lit(&self, ctx: &mut Model, meaning: IntLitMeaning) -> View<bool> {
-		IntInspectionActions::try_lit(self, ctx, meaning).unwrap()
+		self.resolve_alias(ctx).lit(ctx, meaning)
 	}
 
 	fn val_lit(&self, ctx: &mut Model) -> Option<View<bool>> {
-		let val = self.val(ctx)?;
-		Some(Self::eq(self, val))
+		self.resolve_alias(ctx).val_lit(ctx)
 	}
 }
 
@@ -348,84 +642,43 @@ impl IntExplanationActions<Model> for View<IntVal> {
 
 impl IntInspectionActions<Model> for View<IntVal> {
 	fn bounds(&self, ctx: &Model) -> (IntVal, IntVal) {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => (v, v),
-			IntView::Linear(lin) => lin.bounds(ctx),
-			IntView::Bool(lin) => lin.bounds(ctx),
-		}
+		self.resolve_alias(ctx).bounds(ctx)
 	}
 
 	fn domain(&self, ctx: &Model) -> IntSet {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(c) => (c..=c).into(),
-			IntView::Linear(lin) => lin.domain(ctx),
-			IntView::Bool(lin) => lin.domain(ctx),
-		}
+		self.resolve_alias(ctx).domain(ctx)
 	}
 
 	fn in_domain(&self, ctx: &Model, val: IntVal) -> bool {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => v == val,
-			IntView::Linear(lin) => lin.in_domain(ctx, val),
-			IntView::Bool(lin) => lin.in_domain(ctx, val),
-		}
+		self.resolve_alias(ctx).in_domain(ctx, val)
 	}
 
 	fn lit_meaning(&self, ctx: &Model, lit: View<bool>) -> Option<IntLitMeaning> {
-		match self.0 {
-			IntView::Const(_) => None,
-			IntView::Linear(lin) => lin.lit_meaning(ctx, lit),
-			IntView::Bool(lin) => lin.lit_meaning(ctx, lit),
-		}
+		self.resolve_alias(ctx).lit_meaning(ctx, lit)
 	}
 
 	fn max(&self, ctx: &Model) -> IntVal {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => v,
-			IntView::Linear(lin) => lin.max(ctx),
-			IntView::Bool(lin) => lin.max(ctx),
-		}
+		self.resolve_alias(ctx).max(ctx)
 	}
 
 	fn max_lit(&self, ctx: &Model) -> View<bool> {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(_) => true.into(),
-			IntView::Linear(lin) => lin.max_lit(ctx),
-			IntView::Bool(lin) => lin.max_lit(ctx),
-		}
+		self.resolve_alias(ctx).max_lit(ctx)
 	}
 
 	fn min(&self, ctx: &Model) -> IntVal {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => v,
-			IntView::Linear(lin) => lin.min(ctx),
-			IntView::Bool(lin) => lin.min(ctx),
-		}
+		self.resolve_alias(ctx).min(ctx)
 	}
 
 	fn min_lit(&self, ctx: &Model) -> View<bool> {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(_) => true.into(),
-			IntView::Linear(lin) => lin.min_lit(ctx),
-			IntView::Bool(lin) => lin.min_lit(ctx),
-		}
+		self.resolve_alias(ctx).min_lit(ctx)
 	}
 
-	fn try_lit(&self, _: &Model, meaning: IntLitMeaning) -> Option<View<bool>> {
-		Some(match meaning {
-			IntLitMeaning::Eq(v) => self.eq(v),
-			IntLitMeaning::NotEq(v) => self.ne(v),
-			IntLitMeaning::GreaterEq(v) => self.geq(v),
-			IntLitMeaning::Less(v) => self.lt(v),
-		})
+	fn try_lit(&self, ctx: &Model, meaning: IntLitMeaning) -> Option<View<bool>> {
+		self.resolve_alias(ctx).try_lit(ctx, meaning)
 	}
 
 	fn val(&self, ctx: &Model) -> Option<IntVal> {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => Some(v),
-			IntView::Linear(lin) => lin.val(ctx),
-			IntView::Bool(lin) => lin.val(ctx),
-		}
+		self.resolve_alias(ctx).val(ctx)
 	}
 }
 
@@ -436,11 +689,7 @@ impl IntPropagationActions<Model> for View<IntVal> {
 		val: IntVal,
 		reason: impl ReasonBuilder<Model>,
 	) -> Result<(), Conflict<View<bool>>> {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => v.fix(ctx, val, reason),
-			IntView::Linear(lin) => lin.fix(ctx, val, reason),
-			IntView::Bool(lin) => lin.fix(ctx, val, reason),
-		}
+		self.resolve_alias(ctx).fix(ctx, val, reason)
 	}
 
 	fn remove_val(
@@ -449,11 +698,7 @@ impl IntPropagationActions<Model> for View<IntVal> {
 		val: IntVal,
 		reason: impl ReasonBuilder<Model>,
 	) -> Result<(), Conflict<View<bool>>> {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => v.remove_val(ctx, val, reason),
-			IntView::Linear(lin) => lin.remove_val(ctx, val, reason),
-			IntView::Bool(lin) => lin.remove_val(ctx, val, reason),
-		}
+		self.resolve_alias(ctx).remove_val(ctx, val, reason)
 	}
 
 	fn tighten_max(
@@ -462,11 +707,7 @@ impl IntPropagationActions<Model> for View<IntVal> {
 		ub: IntVal,
 		reason: impl ReasonBuilder<Model>,
 	) -> Result<(), Conflict<View<bool>>> {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => v.tighten_max(ctx, ub, reason),
-			IntView::Linear(lin) => lin.tighten_max(ctx, ub, reason),
-			IntView::Bool(lin) => lin.tighten_max(ctx, ub, reason),
-		}
+		self.resolve_alias(ctx).tighten_max(ctx, ub, reason)
 	}
 
 	fn tighten_min(
@@ -475,11 +716,7 @@ impl IntPropagationActions<Model> for View<IntVal> {
 		val: IntVal,
 		reason: impl ReasonBuilder<Model>,
 	) -> Result<(), Conflict<View<bool>>> {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => v.tighten_min(ctx, val, reason),
-			IntView::Linear(lin) => lin.tighten_min(ctx, val, reason),
-			IntView::Bool(lin) => lin.tighten_min(ctx, val, reason),
-		}
+		self.resolve_alias(ctx).tighten_min(ctx, val, reason)
 	}
 }
 
@@ -490,11 +727,7 @@ impl IntSimplificationActions<Model> for View<IntVal> {
 		values: &IntSet,
 		reason: impl ReasonBuilder<Model>,
 	) -> Result<(), Conflict<View<bool>>> {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => v.exclude(ctx, values, reason),
-			IntView::Linear(lin) => lin.exclude(ctx, values, reason),
-			IntView::Bool(lin) => lin.exclude(ctx, values, reason),
-		}
+		self.resolve_alias(ctx).exclude(ctx, values, reason)
 	}
 
 	fn restrict_domain(
@@ -503,104 +736,12 @@ impl IntSimplificationActions<Model> for View<IntVal> {
 		values: &IntSet,
 		reason: impl ReasonBuilder<Model>,
 	) -> Result<(), Conflict<View<bool>>> {
-		match self.resolve_alias(ctx).0 {
-			IntView::Const(v) => v.restrict_domain(ctx, values, reason),
-			IntView::Linear(lin) => lin.restrict_domain(ctx, values, reason),
-			IntView::Bool(lin) => lin.restrict_domain(ctx, values, reason),
-		}
+		self.resolve_alias(ctx).restrict_domain(ctx, values, reason)
 	}
 
 	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Conflict<View<bool>>> {
-		use IntView::*;
-
-		let x = self.resolve_alias(ctx);
-		let y = other.into().resolve_alias(ctx);
-
-		let (idx, target) = match (x.0, y.0) {
-			(x, y) if x == y => return Ok(()),
-			(Bool(x), Bool(y)) => return x.unify(ctx, y),
-			(Const(x), Const(y)) if x != y => return Err(ctx.declare_conflict([])),
-			(Const(y), x) | (x, Const(y)) => {
-				let x = View::<IntVal>(x);
-				return x.fix(ctx, y, []);
-			}
-			(Linear(lin_x), Linear(lin_y)) => {
-				// Decide which variable to redefine based on the other.
-				let can_define_x = lin_y.scale.get() % lin_x.scale.get() == 0
-					&& (lin_y.offset - lin_x.offset) % lin_x.scale.get() == 0;
-				let can_define_y = lin_x.scale.get() % lin_y.scale.get() == 0
-					&& (lin_x.offset - lin_y.offset) % lin_y.scale.get() == 0;
-				let (lin_x, lin_y) = if can_define_x && can_define_y && lin_x.var.0 > lin_y.var.0 {
-					(lin_x, lin_y)
-				} else if can_define_y {
-					(lin_y, lin_x)
-				} else if can_define_x {
-					(lin_x, lin_y)
-				} else {
-					ctx.post_constraint(IntEq { vars: [x, y] });
-					return Ok(());
-				};
-
-				// Perform the transformation and add the aliasing domain to x:
-				// x_scale * x + x_scale = y_scale * y + y_offset
-				// === x = (y_scale / x_scale) * y + ((y_offset - x_offset) / x_scale)
-				let scale = NonZero::new(lin_y.scale.get() / lin_x.scale.get()).unwrap();
-				let offset = (lin_y.offset - lin_x.offset) / lin_x.scale.get();
-				let target = View(Linear(LinearView::new(scale, offset, lin_y.var)));
-				(lin_x.var, target)
-			}
-			(Linear(lin), Bool(b)) | (Bool(b), Linear(lin)) => {
-				let lb = b.transform_val(0);
-				let ub = b.transform_val(1);
-
-				let contains_lb = lin.in_domain(ctx, lb);
-				let contains_ub = lin.in_domain(ctx, ub);
-
-				match (contains_lb, contains_ub) {
-					(false, false) => {
-						return Err(ctx.declare_conflict(|ctx: &mut Model| {
-							[
-								lin.lit(ctx, IntLitMeaning::NotEq(lb)),
-								lin.lit(ctx, IntLitMeaning::NotEq(ub)),
-							]
-						}));
-					}
-					(false, true) => {
-						lin.fix(ctx, ub, [])?;
-						return b.var.require(ctx, |ctx: &mut Model| {
-							[lin.lit(ctx, IntLitMeaning::NotEq(lb))]
-						});
-					}
-					(true, false) => {
-						lin.fix(ctx, lb, [])?;
-						return b.var.fix(ctx, false, |ctx: &mut Model| {
-							[lin.lit(ctx, IntLitMeaning::NotEq(ub))]
-						});
-					}
-					(true, true) => {
-						let Ok(IntLitMeaning::Eq(i_lb)) =
-							lin.reverse_meaning(IntLitMeaning::Eq(lb))
-						else {
-							unreachable!()
-						};
-						let Ok(IntLitMeaning::Eq(i_ub)) =
-							lin.reverse_meaning(IntLitMeaning::Eq(ub))
-						else {
-							unreachable!()
-						};
-						let target = View(Bool(LinearBoolView::new(
-							NonZero::new(i_ub - i_lb).unwrap(),
-							i_lb,
-							b.var,
-						)));
-
-						(lin.var, target)
-					}
-				}
-			}
-		};
-
-		idx.unify_internal(ctx, target)
+		let other = other.into().resolve_alias(ctx);
+		self.resolve_alias(ctx).unify(ctx, other)
 	}
 }
 

--- a/crates/huub/src/tests.rs
+++ b/crates/huub/src/tests.rs
@@ -161,6 +161,25 @@ fn test_duplicate_propagation() {
 	);
 }
 
+#[test]
+fn test_require_bool_view_over_aliased_int_decision() {
+	use crate::actions::IntSimplificationActions;
+
+	let mut prb = Model::default();
+	let a = prb.new_bool_decision();
+	let x = prb.new_int_decision(1..=2);
+
+	assert!(x.unify(&mut prb, a + 1).is_ok());
+	prb.proposition(Formula::Atom(x.eq(1))).post();
+
+	let vars = [ModelView::from(a), ModelView::from(x)];
+	prb.expect_solutions(
+		&vars,
+		expect![[r#"
+		false, 1"#]],
+	);
+}
+
 #[traced_test]
 #[test]
 fn test_unify_int_impossible() {

--- a/crates/huub/src/views/linear_view.rs
+++ b/crates/huub/src/views/linear_view.rs
@@ -103,12 +103,12 @@ impl<Var> LinearView<NonZero<IntVal>, IntVal, Var> {
 	}
 
 	/// Reverses the transformation of an [`IntVal`], rounding up.
-	fn reverse_val_ceil(&self, val: IntVal) -> IntVal {
+	pub(crate) fn reverse_val_ceil(&self, val: IntVal) -> IntVal {
 		div_ceil(val - self.offset, self.scale)
 	}
 
 	/// Reverses the transformation of an [`IntVal`], rounding down.
-	fn reverse_val_floor(&self, val: IntVal) -> IntVal {
+	pub(crate) fn reverse_val_floor(&self, val: IntVal) -> IntVal {
 		div_floor(val - self.offset, self.scale)
 	}
 
@@ -136,7 +136,7 @@ impl<Var> LinearView<NonZero<IntVal>, IntVal, Var> {
 	}
 
 	/// Try to reverse the transformation of an [`IntVal`] without rounding.
-	fn try_reverse_val(&self, val: IntVal) -> Option<IntVal> {
+	pub(crate) fn try_reverse_val(&self, val: IntVal) -> Option<IntVal> {
 		let val = val - self.offset;
 		if val % self.scale.get() == 0 {
 			Some(val / self.scale.get())


### PR DESCRIPTION
Introduce `Resolved<T>` to distinguish aliasable model handles from
canonical resolved decisions and views.

Move domain- and subscription-sensitive logic behind resolved handles,
update lowering to work with canonical integer decisions explicitly, and
rework propagation/simplification helpers to avoid relying on unresolved
Decision semantics.

Resolves #276