### PR TITLE
feat: add target-based tracing controls

### DIFF
--- a/crates/huub-cli/src/lib.rs
+++ b/crates/huub-cli/src/lib.rs
@@ -89,6 +89,8 @@ pub struct Cli<Stdout, Stderr> {
 	time_limit: Option<Duration>,
 	/// Level of verbosity
 	verbose: u8,
+	/// Tracing targets enabled at the selected verbosity level.
+	trace_targets: Vec<String>,
 
 	// --- Initialization configuration ---
 	/// Cardinatility cutoff for eager order literals
@@ -202,6 +204,7 @@ where
 		let int_reverse_map: Arc<Mutex<Vec<InternedStr>>> = Arc::default();
 		let subscriber = trace::create_subscriber(
 			self.verbose,
+			&self.trace_targets,
 			self.stderr.clone(),
 			self.ansi_color,
 			Arc::clone(&lit_reverse_map),
@@ -378,7 +381,8 @@ where
 			Some(goal) => {
 				if self.all_solutions {
 					warn!(
-						"--all-solutions is ignored when optimizing, use --intermediate-solutions or --all-optimal instead"
+						target: "solver",
+						"ignore --all-solutions when optimizing; use --intermediate-solutions or --all-optimal instead"
 					);
 				}
 				let mut no_good_vals = vec![
@@ -417,7 +421,7 @@ where
 					if let Err(err) = ctrlc::set_handler(move || {
 						interrupted.store(true, Ordering::SeqCst);
 					}) {
-						warn!("unable to set Ctrl-C handler: {}", err);
+						warn!(target: "solver", error = %err, "unable to set ctrl-c handler");
 					}
 
 					let mut last_sol = String::new();
@@ -549,6 +553,7 @@ where
 			statistics: self.statistics,
 			time_limit: self.time_limit,
 			verbose: self.verbose,
+			trace_targets: self.trace_targets,
 			int_eager_limit: self.int_eager_limit,
 			reason_eager: self.reason_eager,
 			restart: self.restart,
@@ -580,6 +585,7 @@ where
 			statistics: self.statistics,
 			time_limit: self.time_limit,
 			verbose: self.verbose,
+			trace_targets: self.trace_targets,
 			int_eager_limit: self.int_eager_limit,
 			reason_eager: self.reason_eager,
 			restart: self.restart,
@@ -607,6 +613,18 @@ impl TryFrom<Arguments> for Cli<io::Stdout, fn() -> io::Stderr> {
 		let mut verbose = 0;
 		while args.contains(["-v", "--verbose"]) {
 			verbose += 1;
+		}
+		let mut trace_targets = vec!["solver".to_owned(), "flatzinc".to_owned()];
+		let add_targets: Vec<String> = args
+			.values_from_str("--trace-target")
+			.map_err(|e| e.to_string())?;
+		trace_targets.extend(add_targets);
+		let rm_targets: Vec<String> = args
+			.values_from_str("--no-trace-target")
+			.map_err(|e| e.to_string())?;
+
+		for target in rm_targets {
+			trace_targets.retain(|value| value != &target);
 		}
 
 		let parse_bool_arg = |s: &str| match s {
@@ -675,6 +693,7 @@ impl TryFrom<Arguments> for Cli<io::Stdout, fn() -> io::Stderr> {
 				.map_err(|e| e.to_string())?,
 
 			verbose,
+			trace_targets,
 			path: args
 				.free_from_os_str(|s| -> Result<PathBuf, &'static str> { Ok(s.into()) })
 				.map_err(|e| e.to_string())?,

--- a/crates/huub-cli/src/main.rs
+++ b/crates/huub-cli/src/main.rs
@@ -74,6 +74,12 @@ FLAGS
 
                       === BEHAVIOUR OPTIONS ===
   --log-file <FILE>               Output log messages from the solver to a file, instead of stderr.
+  --trace-target <target>         Enable the given tracing target at the selected verbosity level.
+                                  Can be repeated. Targets are available for core components such as
+                                  `brancher` and for individual constraints such as `disjunctive` and
+                                  `mul`. The `solver` and `flatzinc` targets are enabled by default.
+  --no-trace-target <target>      Disable the given tracing target at the selected verbosity level.
+                                  Can be repeated.
 
 DESCRIPTION
   Create a Huub Solver instance tailored to a given FlatZinc JSON input file and solve the problem.

--- a/crates/huub-cli/src/main.rs
+++ b/crates/huub-cli/src/main.rs
@@ -134,7 +134,8 @@ fn main() -> ExitCode {
 				move || {
 					fs::OpenOptions::new()
 						.create(true)
-						.append(true)
+						.write(true)
+						.truncate(true)
 						.open(&log_file)
 						.expect("Failed to open log file")
 				},

--- a/crates/huub-cli/src/trace.rs
+++ b/crates/huub-cli/src/trace.rs
@@ -12,10 +12,12 @@ use rustc_hash::FxHashMap;
 use tracing::{
 	Event, Level, Subscriber,
 	field::{Field, Visit},
+	level_filters::LevelFilter,
 };
 use tracing_subscriber::{
 	Layer,
 	field::{MakeVisitor, RecordFields, VisitOutput},
+	filter::Targets,
 	fmt::{
 		FormatFields, MakeWriter,
 		format::{DefaultFields, Writer},
@@ -103,6 +105,7 @@ struct RegisterLazyLits {
 /// using the name mapping provided by `lit_reverse_map` and `int_reverse_map`.
 pub(crate) fn create_subscriber<W>(
 	verbose: u8,
+	trace_targets: &[String],
 	make_writer: W,
 	ansi: bool,
 	lit_reverse_map: Arc<Mutex<FxHashMap<LitInt, LitName>>>,
@@ -111,25 +114,35 @@ pub(crate) fn create_subscriber<W>(
 where
 	W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
 {
+	let selected_level = match verbose {
+		0 => Level::INFO,
+		1 => Level::DEBUG,
+		_ => Level::TRACE, // 2 or more
+	};
+	let mut filter = Targets::new();
+	for target in trace_targets {
+		filter = filter.with_target(target.as_str(), selected_level);
+	}
+
 	// Builder for the formatting subscriber
-	let builder = tracing_subscriber::fmt()
-		.with_max_level(match verbose {
-			0 => Level::INFO,
-			1 => Level::DEBUG,
-			_ => Level::TRACE, // 2 or more
-		})
+	let fmt_layer = tracing_subscriber::fmt::layer()
 		.with_writer(make_writer)
 		.with_ansi(ansi)
 		.with_timer(uptime())
-		.map_fmt_fields(|fmt| {
-			FmtLitFields::new(fmt, Arc::clone(&lit_reverse_map), int_reverse_map)
-		});
+		.map_fmt_fields(|fmt| FmtLitFields::new(fmt, Arc::clone(&lit_reverse_map), int_reverse_map))
+		.with_filter(filter);
 
-	// Create final subscriber and add the layer that will register new lazily
-	// created literals
-	builder
-		.finish()
-		.with(RegisterLazyLits::new(lit_reverse_map))
+	tracing_subscriber::registry()
+		.with(
+			RegisterLazyLits::new(lit_reverse_map).with_filter(Targets::new().with_target(
+				"literal",
+				match verbose {
+					0 => LevelFilter::OFF,
+					_ => Level::TRACE.into(),
+				},
+			)),
+		)
+		.with(fmt_layer)
 }
 
 impl FmtLitFields {
@@ -417,9 +430,9 @@ impl RegisterLazyLits {
 }
 
 impl<S: Subscriber> Layer<S> for RegisterLazyLits {
-	fn event_enabled(&self, event: &Event<'_>, _: Context<'_, S>) -> bool {
+	fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
 		let mut rec = RecordLazyLits::default();
 		event.record(&mut rec);
-		!rec.finish(&self.lit_reverse_map)
+		let _ = rec.finish(&self.lit_reverse_map);
 	}
 }

--- a/crates/huub/src/constraints.rs
+++ b/crates/huub/src/constraints.rs
@@ -372,7 +372,8 @@ impl Conflict<solver::Decision<bool>> {
 				},
 				None => {
 					warn!(
-						"Empty conflict detected. This suggests additional reasoning might be possible during Model simplification."
+						target: "solver",
+						"empty conflict detected; additional model simplification reasoning may be possible"
 					);
 					Self {
 						subject: None,

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -108,6 +108,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 
 		if !events.is_empty() {
 			trace!(
+				target: "cumulative",
 				events =? events,
 				"events for compulsory parts from tasks"
 			);
@@ -125,6 +126,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 				}
 				if cur_height > capacity_lb {
 					trace!(
+						target: "cumulative",
 						timepoint = t,
 						capacity_lb, cur_height, "push capacity lower bound"
 					);
@@ -147,6 +149,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 
 		if !self.bounds.is_empty() {
 			trace!(
+				target: "cumulative",
 				bounds = ?self.bounds,
 				heights = ?self.heights,
 				capacity_ub =? self.capacity.max(ctx),
@@ -214,6 +217,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 		}
 
 		trace!(
+			target: "cumulative",
 			time_point,
 			relevant_tasks = ?minimal_relevant_tasks.iter().map(|&i| (
 				i,
@@ -268,10 +272,11 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 	{
 		move |ctx: &mut Ctx| {
 			trace!(
+				target: "cumulative",
 				task_no,
 				timepoint =? time_point,
 				usage_limit,
-				"Explain task usage limit"
+				"explain task usage limit"
 			);
 			let capacity_ub = self.capacity.max(ctx);
 			let to_cover = capacity_ub - usage_limit;
@@ -279,6 +284,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 				self.collect_compulsory_tasks(ctx, to_cover, time_point, Some(task_no));
 
 			trace!(
+				target: "cumulative",
 				time_point,
 				relevant_tasks = ?relevant_tasks.iter().map(|&i| (
 					i,
@@ -287,7 +293,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 					self.earliest_completion_time(ctx, i),
 				)).collect_vec(),
 				capacity_ub,
-				"Explain task usage limit"
+				"explain task usage limit"
 			);
 
 			let cap_lit = self.capacity.max_lit(ctx);
@@ -333,6 +339,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 			let relevant_tasks = self.collect_compulsory_tasks(ctx, to_cover, time_point, None);
 
 			trace!(
+				target: "cumulative",
 				time_point,
 				relevant_tasks = ?relevant_tasks.iter().map(|&i| (
 					i,
@@ -340,7 +347,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 					self.earliest_completion_time(ctx, i),
 					&self.durations[i]
 				)).collect_vec(),
-				"Explain resource overload"
+				"explain resource overload"
 			);
 
 			let cap_lit = self.capacity.max_lit(ctx);
@@ -389,6 +396,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 				self.collect_compulsory_tasks(ctx, to_cover, time_point, Some(task_no));
 
 			trace!(
+				target: "cumulative",
 				time_point,
 				relevant_tasks = ?relevant_tasks.iter().map(|&i| (
 					i,
@@ -397,7 +405,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 					self.earliest_completion_time(ctx, i),
 				)).collect_vec(),
 				rule =? propagation_rule,
-				"Explain task sweeping"
+				"explain task sweeping"
 			);
 
 			// Construct the reason for the propagation
@@ -504,12 +512,13 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 			let max_usage = self.heights[max_period];
 			let limit = self.capacity.max(ctx) - max_usage + usage_lb;
 			trace!(
+				target: "cumulative",
 				task,
-				compulosary_part =? (lst, ect),
+				compulsory_part =? (lst, ect),
 				max_period,
 				max_usage,
 				limit,
-				"Limit task usage"
+				"limit task usage"
 			);
 			self.usages[task].tighten_max(
 				ctx,
@@ -616,7 +625,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 
 		// Find the partition point where b < lst + dur
 		let last = self.bounds.partition_point(|&b| b < lst + dur_lb);
-		trace!(task, dur_lb, est, lst, usage_lb, "Task sweep backward");
+		trace!(target: "cumulative", task, dur_lb, est, lst, usage_lb, "task sweep backward");
 		let mut updated_lct = self.latest_completion_time(ctx, task);
 		let max_capacity = self.capacity.max(ctx);
 		for i in (1..last).rev() {
@@ -653,6 +662,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 					.skip(1)
 					.collect_vec();
 				trace!(
+					target: "cumulative",
 					updated_lct,
 					b_start,
 					remainder,
@@ -721,7 +731,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 
 		// Find the partition point where est > b
 		let first = self.bounds.partition_point(|&b| b < est);
-		trace!(task, dur_lb, est, lst, usage_lb, "Task sweep forward");
+		trace!(target: "cumulative", task, dur_lb, est, lst, usage_lb, "task sweep forward");
 		let mut updated_est = est;
 		let max_capacity = self.capacity.max(ctx);
 		for i in first..self.bounds.len() - 1 {
@@ -756,6 +766,7 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 					.skip(1)
 					.collect_vec();
 				trace!(
+					target: "cumulative",
 					updated_est,
 					b_end,
 					remainder,
@@ -854,7 +865,12 @@ where
 		self.capacity.enqueue_when(ctx, IntPropCond::UpperBound);
 	}
 
-	#[tracing::instrument(name = "cumulative_timetable", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "cumulative_time_table",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		// Build the time-table profile and check resource overload
 		match self.build_profile_and_check_overload(ctx) {

--- a/crates/huub/src/constraints/disjunctive.rs
+++ b/crates/huub/src/constraints/disjunctive.rs
@@ -322,6 +322,7 @@ impl<I> DisjunctivePropagator<I> {
 			.map(|i| self.earliest_start_time(ctx, i))
 			.collect_vec();
 		trace!(
+			target: "disjunctive",
 			task_no,
 			left_cut_set =? (0..self.start_times.len())
 				.filter(|&j| {
@@ -399,6 +400,7 @@ impl<I> DisjunctivePropagator<I> {
 			.collect_vec();
 
 		trace!(
+			target: "disjunctive",
 			task_no,
 			window =? (earliest_start, updated_lct_i),
 			nlset = ? nlset.iter().map(|&j| (j, self.durations[j], self.earliest_start_time(ctx,j, ), self.latest_start_time( ctx,j,))).collect_vec(),
@@ -443,6 +445,7 @@ impl<I> DisjunctivePropagator<I> {
 			let mut e_tasks = Vec::new();
 
 			trace!(
+				target: "disjunctive",
 				window =? (earliest_start, time_bound),
 				"explain resource overload"
 			);
@@ -497,6 +500,7 @@ impl<I> DisjunctivePropagator<I> {
 			.collect_vec();
 
 		trace!(
+			target: "disjunctive",
 			task_no,
 			window =? (earliest_start, latest_start),
 			precedence_set = ?precedence_set,
@@ -674,6 +678,7 @@ impl<I> DisjunctivePropagator<I> {
 					self.durations[front_task],
 				);
 				trace!(
+					target: "disjunctive",
 					successor = ect_task,
 					predecessor = front_task,
 					"precedence detected",
@@ -691,6 +696,7 @@ impl<I> DisjunctivePropagator<I> {
 				binding_tasks[ect_task] = Some(self.ot_tree.binding_task(tasks_in_tree_ect, 0));
 				updated_est[ect_task] = updated_est[ect_task].max(tasks_in_tree_ect);
 				trace!(
+					target: "disjunctive",
 					ect_task,
 					updated_est = updated_est[ect_task],
 					tasks_in_tree =? (0..lst_front_idx)
@@ -735,7 +741,7 @@ impl<I> DisjunctivePropagator<I> {
 				}
 			}
 		}
-		trace!(propagated, "detectable precedence propagation completed");
+		trace!(target: "disjunctive", propagated, "detectable precedence propagation completed");
 		Ok(propagated)
 	}
 
@@ -836,6 +842,7 @@ impl<I> DisjunctivePropagator<I> {
 						ect_gray_in_tree - 1,
 					);
 					trace!(
+						target: "disjunctive",
 						ect_in_tree,
 						task = blocked_task,
 						window =? (lb, ect_gray_in_tree - 1),
@@ -858,7 +865,7 @@ impl<I> DisjunctivePropagator<I> {
 			}
 			self.ot_tree.annotate_gray_task(lct_task);
 		}
-		trace!(propagated, "edge finding propagation completed");
+		trace!(target: "disjunctive", propagated, "edge finding propagation completed");
 		Ok(propagated)
 	}
 
@@ -951,6 +958,7 @@ impl<I> DisjunctivePropagator<I> {
 					latest_start_times[self.tasks_sorted_by_latest_start[lst_front_idx - 1]];
 				updated_lct[lct_task] = updated_lct[lct_task].min(front_lst);
 				trace!(
+					target: "disjunctive",
 					lct_task=? (lct_task, lct),
 					updated_lct = updated_lct[lct_task],
 					lst_front_idx,
@@ -985,6 +993,7 @@ impl<I> DisjunctivePropagator<I> {
 			{
 				let lb = self.earliest_start_time(ctx, binding_task);
 				trace!(
+					target: "disjunctive",
 					task = i,
 					window =? (lb, updated_lct[i]),
 					"not last propagation"
@@ -1001,7 +1010,7 @@ impl<I> DisjunctivePropagator<I> {
 				propagated = true;
 			}
 		}
-		trace!(propagated, "not last propagation completed");
+		trace!(target: "disjunctive", propagated, "not last propagation completed");
 		Ok(propagated)
 	}
 
@@ -1055,8 +1064,9 @@ impl<I> DisjunctivePropagator<I> {
 				let earliest_start = self.start_times[binding_task].min(ctx);
 				let expl = self.explain_overload_checking(lct_i + 1);
 				trace!(
+					target: "disjunctive",
 					time_window =? (earliest_start, lct_i),
-					"Resource overload"
+					"resource overload"
 				);
 				self.start_times[*i].tighten_min(ctx, ect - self.durations[*i], expl)?;
 			}
@@ -1070,7 +1080,7 @@ impl<I> DisjunctivePropagator<I> {
 			0 => DisjunctivePropagationRule::EdgeFinding,
 			1 => DisjunctivePropagationRule::NotLast,
 			2 => DisjunctivePropagationRule::Precedence,
-			_ => unreachable!("Invalid propagation rule in data"),
+			_ => unreachable!("invalid propagation rule in data"),
 		}
 	}
 
@@ -1086,7 +1096,12 @@ where
 	I: IntSolverActions<E>,
 {
 	/// Explain the propagation of the disjunctive propagator.
-	#[tracing::instrument(name = "disjunctive_strict", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "disjunctive",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn explain(
 		&mut self,
 		ctx: &mut E::ExplanationCtx<'_>,
@@ -1120,7 +1135,12 @@ where
 	}
 
 	/// Propagate the disjunctive propagator.
-	#[tracing::instrument(name = "disjunctive_strict", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "disjunctive",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		// Sort the tasks by earliest start time and initialize the Omega-Theta tree
 		// according to the property of the Omega-Theta tree.

--- a/crates/huub/src/constraints/int_abs.rs
+++ b/crates/huub/src/constraints/int_abs.rs
@@ -104,7 +104,12 @@ where
 		self.abs.enqueue_when(ctx, IntPropCond::Bounds);
 	}
 
-	#[tracing::instrument(name = "int_abs", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_abs_bounds",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		let (lb, ub) = self.origin.bounds(ctx);
 

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -196,7 +196,12 @@ where
 		}
 	}
 
-	#[tracing::instrument(name = "array_int_element", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_array_element_bounds",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		// ensure bounds of result and self.vars[self.index] are consistent when
 		// self.index is fixed only trigger when self.index is fixed and (1) y is

--- a/crates/huub/src/constraints/int_array_minimum.rs
+++ b/crates/huub/src/constraints/int_array_minimum.rs
@@ -89,7 +89,12 @@ where
 		self.min.enqueue_when(ctx, IntPropCond::LowerBound);
 	}
 
-	#[tracing::instrument(name = "array_int_minimum", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_array_minimum_bounds",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		// set y to be less than or equal to the minimum of upper bounds of x_i
 		let (min_ub, min_ub_var) = self

--- a/crates/huub/src/constraints/int_div.rs
+++ b/crates/huub/src/constraints/int_div.rs
@@ -272,7 +272,12 @@ where
 		self.result.enqueue_when(ctx, IntPropCond::Bounds);
 	}
 
-	#[tracing::instrument(name = "int_div", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_div_bounds",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		let (denom_lb, denom_ub) = self.denominator.bounds(ctx);
 		if denom_lb < 0 && denom_ub > 0 {

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -716,6 +716,12 @@ where
 	IV: IntSolverActions<E>,
 	E::Atom: BoolSolverActions<E>,
 {
+	#[tracing::instrument(
+		name = "int_linear_less_eq_bounds",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn explain(
 		&mut self,
 		ctx: &mut E::ExplanationCtx<'_>,
@@ -748,7 +754,12 @@ where
 	}
 
 	// propagation rule: x[i] <= rhs - sum_{j != i} x[j].lower_bound
-	#[tracing::instrument(name = "int_lin_le", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_linear_less_eq_bounds",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		// If the reified variable is false, skip propagation
 		let r_val = self.reification.val(ctx);
@@ -1023,7 +1034,12 @@ where
 			.advise_when_fixed(ctx, self.terms.len() as u64);
 	}
 
-	#[tracing::instrument(name = "int_lin_ne", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_linear_not_eq_value",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		let r_fixed = match self.reification.val(ctx) {
 			Some(false) => return Ok(()),

--- a/crates/huub/src/constraints/int_mul.rs
+++ b/crates/huub/src/constraints/int_mul.rs
@@ -145,7 +145,12 @@ where
 		self.product.enqueue_when(ctx, IntPropCond::Bounds);
 	}
 
-	#[tracing::instrument(name = "int_times", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_mul_bounds",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		let (f1_lb, f1_ub) = self.factor1.bounds(ctx);
 		let f1_lb_lit = self.factor1.min_lit(ctx);

--- a/crates/huub/src/constraints/int_no_overlap.rs
+++ b/crates/huub/src/constraints/int_no_overlap.rs
@@ -652,7 +652,12 @@ where
 		}
 	}
 
-	#[tracing::instrument(name = "int_no_overlap", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_no_overlap_sweep",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		// Cache the current bounds of all variables.
 		for o in 0..self.num_objects() {

--- a/crates/huub/src/constraints/int_pow.rs
+++ b/crates/huub/src/constraints/int_pow.rs
@@ -476,7 +476,12 @@ where
 		self.result.enqueue_when(ctx, IntPropCond::Bounds);
 	}
 
-	#[tracing::instrument(name = "int_pow", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_pow_bounds",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		self.propagate_result(ctx)?;
 		self.propagate_base(ctx)?;

--- a/crates/huub/src/constraints/int_unique.rs
+++ b/crates/huub/src/constraints/int_unique.rs
@@ -479,7 +479,12 @@ where
 		}
 	}
 
-	#[tracing::instrument(name = "int_unique_bounds", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_unique_bounds",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		self.sort(ctx);
 		self.filter_lower(ctx)?;
@@ -536,7 +541,12 @@ where
 		ctx.advise_on_backtrack();
 	}
 
-	#[tracing::instrument(name = "int_unique_value", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_unique_value",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		debug_assert!(!self.action_list.is_empty() && self.action_list.iter().all_unique());
 		// We walk through all fixed decisions (indices).

--- a/crates/huub/src/constraints/int_value_precede.rs
+++ b/crates/huub/src/constraints/int_value_precede.rs
@@ -379,7 +379,12 @@ where
 		}
 	}
 
-	#[tracing::instrument(name = "seq_precede_chain", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_seq_precede_chain_bounds",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		if !self.initialized {
 			return self.initial_propagation(ctx);
@@ -891,7 +896,12 @@ where
 		}
 	}
 
-	#[tracing::instrument(name = "value_precede_chain", level = "trace", skip(self, ctx))]
+	#[tracing::instrument(
+		name = "int_value_precede_chain_value",
+		target = "solver",
+		level = "trace",
+		skip(self, ctx)
+	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 		if !self.initialized {
 			return self.initial_propagation(ctx);

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -419,7 +419,10 @@ impl Model {
 			// user search heuristics are provided
 			r.set_option("restart", config.restart() as i32);
 		} else {
-			warn!("unknown solver: vivification and restart options are ignored");
+			warn!(
+				target: "solver",
+				"ignore vivification and restart options for unknown solver"
+			);
 		}
 
 		while let Some(con) = self.propagator_queue.pop() {

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -274,7 +274,11 @@ where
 								warm_start.extend(w);
 								branchings.extend(b);
 							}
-							_ => warn!("unsupported search annotation: {}", ann),
+							_ => warn!(
+								target: "flatzinc",
+								annotation = ?ann,
+								"unsupported search annotation"
+							),
 						}
 					}
 					Ok((warm_start, branchings))
@@ -347,7 +351,11 @@ where
 				}
 			}
 			other => {
-				warn!("ignoring unsupported search annotation: {}", other);
+				warn!(
+					target: "flatzinc",
+					annotation = ?other,
+					"ignore unsupported search annotation"
+				);
 				Ok((Vec::new(), Vec::new()))
 			}
 		}
@@ -372,7 +380,12 @@ where
 					// "outdomain_median" => Ok(ValueSelection::OutdomainMedian),
 					// "outdomain_random" => Ok(ValueSelection::OutdomainRandom),
 					_ => {
-						warn!("unsupported value selection `{}', using `indomain_min'", s);
+						warn!(
+							target: "flatzinc",
+							selection = %s,
+							fallback = "indomain_min",
+							"unsupported value selection"
+						);
 						Ok(ValueSelection::IndomainMin)
 					}
 				}
@@ -402,8 +415,10 @@ where
 					"smallest" => Ok(VariableSelection::Smallest),
 					_ => {
 						warn!(
-							"unsupported variable selection `{}', using `input_order'",
-							s
+							target: "flatzinc",
+							selection = %s,
+							fallback = "input_order",
+							"unsupported variable selection"
 						);
 						Ok(VariableSelection::InputOrder)
 					}
@@ -610,7 +625,11 @@ where
 					warm_start.extend(w);
 					branchings.extend(b);
 				}
-				_ => warn!("ignoring unsupported search annotation: {}", ann),
+				_ => warn!(
+					target: "flatzinc",
+					annotation = ?ann,
+					"ignore unsupported search annotation"
+				),
 			}
 		}
 		branchings.insert(0, Branching::WarmStart(warm_start));
@@ -907,10 +926,11 @@ where
 							Some(_) => unreachable!(),
 							None => {
 								warn!(
-									"decision variable `{}' was unbounded, assuming domain {}..{}",
-									ident,
-									FULL_INT_DOMAIN.start(),
-									FULL_INT_DOMAIN.end()
+									target: "flatzinc",
+									variable = %ident,
+									min = FULL_INT_DOMAIN.start(),
+									max = FULL_INT_DOMAIN.end(),
+									"assume full integer domain for unbounded decision variable"
 								);
 								self.prb.new_int_decision(FULL_INT_DOMAIN).into()
 							}
@@ -1907,8 +1927,10 @@ where
 			for (i, used) in ann_used.iter().enumerate() {
 				if !used {
 					warn!(
-						"ignored unsupported annotation `{}' on constraint type `{}`",
-						c.ann[i], c.id
+						target: "flatzinc",
+						annotation = ?c.ann[i],
+						constraint = %c.id,
+						"ignore unsupported constraint annotation"
 					);
 				}
 			}
@@ -2106,10 +2128,11 @@ where
 								})
 								.unwrap();
 							warn!(
-								"decision variable `{}' was unbounded, assuming domain {}..{}",
-								id,
-								FULL_INT_DOMAIN.start(),
-								FULL_INT_DOMAIN.end()
+								target: "flatzinc",
+								variable = %id,
+								min = FULL_INT_DOMAIN.start(),
+								max = FULL_INT_DOMAIN.end(),
+								"assume full integer domain for unbounded decision variable"
 							);
 							self.prb.new_int_decision(FULL_INT_DOMAIN).into()
 						}

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -169,7 +169,11 @@ pub enum Status {
 ///
 /// This function is used as part of the callback given to the SAT solver.
 fn trace_learned_clause(clause: &mut dyn Iterator<Item = RawLit>) {
-	debug!(clause = ?clause.map(i32::from).collect::<Vec<i32>>(), "learn clause");
+	debug!(
+		target: "solver",
+		clause = ?clause.map(i32::from).collect::<Vec<i32>>(),
+		"learn clause"
+	);
 }
 
 impl<A: FailedAssumptions> AssumptionChecker for A {
@@ -400,7 +404,18 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 				}
 			})
 			.collect_vec();
-		debug!(clause = ?clause.iter().filter_map(|&x| if let BoolView::Lit(x) = x.0 { Some(i32::from(x.0)) } else { None }).collect::<Vec<i32>>(), "add solution nogood");
+		debug!(
+			target: "solver",
+			clause = ?clause
+				.iter()
+				.filter_map(|&x| if let BoolView::Lit(x) = x.0 {
+					Some(i32::from(x.0))
+				} else {
+					None
+				})
+				.collect::<Vec<i32>>(),
+			"add solution nogood"
+		);
 		self.add_clause(clause)
 	}
 
@@ -533,13 +548,20 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 			Goal::Minimize(objective) => (objective.min(&self), objective),
 			Goal::Maximize(objective) => (objective.max(&self), objective),
 		};
-		debug!(obj_bound, "start branch and bound");
+		debug!(target: "solver", obj_bound, "start branch and bound");
 		loop {
 			let status = self.solve(|sol| {
 				obj_curr = Some(IntValuation::val(&objective, sol));
 				on_sol(sol);
 			});
-			debug!(?status, ?obj_curr, obj_bound, ?goal, "SAT solve result");
+			debug!(
+				target: "solver",
+				?status,
+				?obj_curr,
+				obj_bound,
+				goal = %if goal == Goal::Minimize(objective) { "Minimize" } else { "Maximize" },
+				"sat solve result"
+			);
 			match status {
 				Satisfied => {
 					if obj_curr == Some(obj_bound) {
@@ -557,6 +579,7 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 							}
 						};
 						debug!(
+							target: "solver",
 							lit = i32::from({
 								let BoolView::Lit(l) = bound_lit.unwrap().0 else {
 									unreachable!()

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -3,7 +3,8 @@
 /// Macro to output a trace message when a new literal is registered.
 macro_rules! trace_new_lit {
 	($iv:expr, $def:expr, $lit:expr) => {
-		tracing::debug!(
+		tracing::trace!(
+			target: "literal",
 			lit = i32::from($lit),
 			int_var = $iv.ident(),
 			is_eq = matches!($def.meaning, IntLitMeaning::Eq(_)),
@@ -14,7 +15,6 @@ macro_rules! trace_new_lit {
 			},
 			"register new literal"
 		);
-		tracing::trace!(lit = i32::from($lit), "lazy literal")
 	};
 }
 
@@ -227,6 +227,7 @@ impl Engine {
 				// Ensure that the same literal is not negated in the reason
 				if seen.contains(&!l) {
 					tracing::error!(
+						target: "solver",
 						clause = ?clause.iter().map(|&l| i32::from(l)).collect::<Vec<_>>(),
 						lit_explained = i32::from(lit),
 						lit_pos = i32::from(!l),
@@ -248,6 +249,7 @@ impl Engine {
 				let val = Decision::<bool>(!l).val(&self.state.trail);
 				if !val.unwrap_or(false) {
 					tracing::error!(
+						target: "solver",
 						clause = ?clause.iter().map(|&l| i32::from(l)).collect::<Vec<_>>(),
 						lit_explained = i32::from(lit),
 						lit_invalid = i32::from(!l),
@@ -333,7 +335,11 @@ impl PropagatorExtension for Engine {
 	) -> Option<(Clause<RawLit>, ClausePersistence)> {
 		if !self.state.clauses.is_empty() {
 			let clause = self.state.clauses.pop_front(); // Known to be `Some`
-			trace!(clause = ?clause.as_ref().unwrap().iter().map(|&x| i32::from(x)).collect::<Vec<i32>>(), "add external clause");
+			trace!(
+				target: "solver",
+				clause = ?clause.as_ref().unwrap().iter().map(|&x| i32::from(x)).collect::<Vec<i32>>(),
+				"add external clause"
+			);
 			clause.map(|c| (c, ClausePersistence::Irreduntant))
 		} else if !self.state.propagation_queue.is_empty() {
 			None // Require that the solver first applies the remaining propagation
@@ -343,7 +349,11 @@ impl PropagatorExtension for Engine {
 				conflict
 					.reason
 					.explain(&mut self.propagators, ctx.state, conflict.subject);
-			debug!(clause = ?clause.iter().map(|&x| i32::from(x)).collect::<Vec<i32>>(), "add conflict clause");
+			debug!(
+				target: "solver",
+				clause = ?clause.iter().map(|&x| i32::from(x)).collect::<Vec<i32>>(),
+				"add conflict clause"
+			);
 			Some((clause, ClausePersistence::Forgettable))
 		} else {
 			None
@@ -370,11 +380,15 @@ impl PropagatorExtension for Engine {
 			vec![propagated_lit]
 		};
 
-		debug!(clause = ?clause.iter().map(|&x| i32::from(x)).collect::<Vec<i32>>(), "add reason clause");
+		debug!(
+			target: "solver",
+			clause = ?clause.iter().map(|&x| i32::from(x)).collect::<Vec<i32>>(),
+			"add reason clause"
+		);
 		clause
 	}
 
-	#[tracing::instrument(level = "debug", skip(self, slv, _sol))]
+	#[tracing::instrument(target = "solver", level = "debug", skip(self, slv, _sol))]
 	fn check_solution(
 		&mut self,
 		slv: &mut dyn SolvingActions,
@@ -478,7 +492,7 @@ impl PropagatorExtension for Engine {
 		self.state.conflict = conflict;
 
 		let accept = self.state.conflict.is_none();
-		debug!(accept, "check model");
+		debug!(target: "solver", accept, "check model");
 		accept
 	}
 
@@ -505,7 +519,7 @@ impl PropagatorExtension for Engine {
 							"brancher yielded an already fixed literal"
 						);
 						// The current brancher has selected a literal, return it as our decision
-						debug!(lit = i32::from(lit.0), "decide");
+						debug!(target: "solver", lit = i32::from(lit.0), "decide");
 						self.state.statistics.user_decisions += 1;
 						return SearchDecision::Assign(lit.0);
 					}
@@ -531,7 +545,11 @@ impl PropagatorExtension for Engine {
 	}
 
 	fn notify_assignments(&mut self, lits: &[RawLit]) {
-		debug!(lits = ?lits.iter().map(|&x| i32::from(x)).collect::<Vec<i32>>(), "assignments");
+		debug!(
+			target: "solver",
+			lits = ?lits.iter().map(|&x| i32::from(x)).collect::<Vec<i32>>(),
+			"assignments"
+		);
 
 		self.state.trail.reset_to_trail_head();
 
@@ -601,7 +619,13 @@ impl PropagatorExtension for Engine {
 						// Although we do not expect this to happen, it seems that CaDiCaL
 						// chronological backtracking might send notifications before
 						// additional propagation.
-						trace!(lit = i32::from(lit), lb, ub, "invalid eq notification");
+						trace!(
+							target: "solver",
+							lit = i32::from(lit),
+							lb,
+							ub,
+							"invalid eq notification"
+						);
 						None
 					}
 					IntLitMeaning::Eq(val) => {
@@ -625,7 +649,7 @@ impl PropagatorExtension for Engine {
 					IntLitMeaning::NotEq(_) => Some(IntEvent::Domain),
 					IntLitMeaning::GreaterEq(new_lb) if new_lb <= lb => None,
 					IntLitMeaning::GreaterEq(new_lb) => {
-						trace!(lit = i32::from(lit), lb = new_lb, "new lb");
+						trace!(target: "solver", lit = i32::from(lit), lb = new_lb, "new lb");
 						self.state.int_vars[iv.idx()]
 							.notify_lower_bound(&mut self.state.trail, new_lb);
 						Some(if new_lb == ub {
@@ -637,7 +661,12 @@ impl PropagatorExtension for Engine {
 					IntLitMeaning::Less(i) => {
 						let new_ub = i - 1;
 						if new_ub < ub {
-							trace!(lit = i32::from(lit), ub = new_ub, "new ub");
+							trace!(
+								target: "solver",
+								lit = i32::from(lit),
+								ub = new_ub,
+								"new ub"
+							);
 							self.state.int_vars[iv.idx()]
 								.notify_upper_bound(&mut self.state.trail, new_ub);
 							Some(if new_ub == lb {
@@ -682,7 +711,7 @@ impl PropagatorExtension for Engine {
 	}
 
 	fn notify_backtrack(&mut self, new_level: usize, restart: bool) {
-		debug!(new_level, restart, "backtrack");
+		debug!(target: "solver", new_level, restart, "backtrack");
 		self.notify_backtrack::<false>(new_level, restart);
 	}
 
@@ -697,7 +726,7 @@ impl PropagatorExtension for Engine {
 		// might have introduced a new literal, which would in turn add its defining
 		// clauses to `self.state.clauses`.
 
-		trace!("new decision level");
+		trace!(target: "solver", "new decision level");
 		self.state.notify_new_decision_level();
 
 		// Update peak decision level
@@ -707,7 +736,12 @@ impl PropagatorExtension for Engine {
 		}
 	}
 
-	#[tracing::instrument(level = "debug", skip(self, slv), fields(level = self.state.decision_level()))]
+	#[tracing::instrument(
+		target = "solver",
+		level = "debug",
+		skip(self, slv),
+		fields(level = self.state.decision_level())
+	)]
 	fn propagate(&mut self, slv: &mut dyn SolvingActions) -> Option<RawLit> {
 		debug_assert!(self.state.last_propagated.is_none());
 		// Check whether there are previous clauses to be communicated
@@ -741,7 +775,7 @@ impl PropagatorExtension for Engine {
 		if let Some(LitPropagation { lit, reason, event }) =
 			self.state.propagation_queue.pop_front()
 		{
-			debug!(lit = i32::from(lit), "propagate");
+			debug!(target: "solver", lit = i32::from(lit), "propagate");
 			debug_assert!(self.state.trail.sat_value(lit).is_some());
 			self.state.register_reason(lit, reason);
 			#[cfg(debug_assertions)]
@@ -870,9 +904,10 @@ impl State {
 			self.vsids = true;
 			self.config.vsids_after_conflict = None; // Only switch once
 			debug!(
+				target: "solver",
 				vsids = self.vsids,
 				conflicts = self.statistics.conflicts,
-				"enable vsids after N conflicts"
+				"enable vsids after conflict threshold"
 			);
 		}
 
@@ -882,13 +917,15 @@ impl State {
 			if self.config.toggle_vsids && !self.config.vsids_only {
 				self.vsids = !self.vsids;
 				debug!(
+					target: "solver",
 					vsids = self.vsids,
 					restart = self.statistics.restarts,
-					"toggling vsids"
+					"toggle vsids on restart"
 				);
 			} else if self.config.vsids_after_restart {
 				self.vsids = true;
 				debug!(
+					target: "solver",
 					vsids = self.vsids,
 					restart = self.statistics.restarts,
 					"enable vsids after restart"

--- a/crates/huub/src/solver/solving_context.rs
+++ b/crates/huub/src/solver/solving_context.rs
@@ -354,6 +354,7 @@ impl<'a> SolvingContext<'a> {
 	) {
 		let reason = Reason::from_view(reason.build_reason(self));
 		trace!(
+			target: "solver",
 			lit = i32::from(lit.0),
 			reason = ?ReasonTracePrint(&reason),
 			prop = self.current_prop.index(),
@@ -382,6 +383,7 @@ impl<'a> SolvingContext<'a> {
 			self.current_prop = PropRef::INVALID;
 			if let Err(conflict) = res {
 				trace!(
+					target: "solver",
 					lit = conflict
 						.subject
 						.map(|s| i32::from(s.0))

--- a/crates/huub/src/solver/trail.rs
+++ b/crates/huub/src/solver/trail.rs
@@ -103,6 +103,7 @@ impl Trail {
 					let e: Option<TrailEvent> = self.undo::<true>();
 					debug_assert_eq!(e, Some(TrailEvent::SatAssignment(var)));
 					trace!(
+						target: "solver",
 						len = self.pos,
 						lit = i32::from(lit),
 						"redo to when literal was set"
@@ -111,6 +112,7 @@ impl Trail {
 				}
 			}
 			trace!(
+				target: "solver",
 				len = self.pos,
 				lit = i32::from(lit),
 				"trail reset for unknown literal"
@@ -120,6 +122,7 @@ impl Trail {
 		while let Some(event) = self.undo::<true>() {
 			if matches!(event, TrailEvent::SatAssignment(r) if r == var) {
 				trace!(
+					target: "solver",
 					len = self.pos,
 					lit = i32::from(lit),
 					"undo to when literal was set"

--- a/share/minizinc/solvers/huub.msc
+++ b/share/minizinc/solvers/huub.msc
@@ -15,6 +15,8 @@
     ["--probing","Whether to enable the failed literal probing","bool:false:true","false"],
     ["--reason-eager", "Whether to add explanation clauses for all literals propagated on the level of a conflict","bool:false:true","false"],
     ["--restart","Whether to enable restarts during search","bool:false:true","false"],
+    ["--trace-target", "Enable a tracing target at the selected verbosity level", "string", "solver"],
+    ["--no-trace-target", "Disable a tracing target at the selected verbosity level", "string", ""],
     ["--subsumption","Whether to enable the global forward subsumption","bool:false:true","false"],
     ["--toggle-vsids", "Alternate between the activity-based search heuristic and the user-specific search heuristic after every restart.", "bool", "false"],
     ["--variable-elimination","Whether to enable the bounded variable elimination ","bool:false:true","false"],


### PR DESCRIPTION
This PR restructures tracing in Huub around explicit `tracing` targets and adds CLI controls for selecting which trace streams are enabled.

The main goal is to separate solver-wide tracing from component-specific tracing. Core solver activity now uses the `solver` target, FlatZinc/model conversion warnings use `flatzinc`, and component-level events use more specific targets such as `cumulative`, `disjunctive`, `linear`, `mul`, `unique`, and others. This makes it possible to inspect a specific part of the system without turning on every trace emitted by the solver.

The CLI keeps the existing `-v` / `-vv` behavior for the default experience, but the enabled trace streams are now explicit. By default, verbosity only enables the `solver` and `flatzinc` targets. Two new flags, `--trace-target` and `--no-trace-target`, allow users to add or remove targets at runtime. That makes it possible to focus on a specific propagator or brancher, or to suppress the standard solver stream entirely when debugging a particular component.

The tracing output was also cleaned up to be more uniform. Event messages were normalized toward a lower-case style, and dynamic information is now carried in structured fields where possible rather than embedded directly in the message text. In addition, the `#[tracing::instrument]` spans were renamed to follow the snake_case form of their enclosing type names, which makes the span hierarchy more predictable and easier to correlate with the implementation.