### PR TITLE
fix: preserve queued integer events on sat implied assignments

### DIFF
--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -509,7 +509,7 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 
 	/// Split the solver into an solving actions objects (limiting the
 	/// interaction with the SAT) and the dynamic engine reference.
-	fn as_parts_mut(&mut self) -> (impl SolvingActions + '_, RefMut<'_, Engine>) {
+	pub(crate) fn as_parts_mut(&mut self) -> (impl SolvingActions + '_, RefMut<'_, Engine>) {
 		struct SA<'a, O>(&'a mut O);
 		impl<O: ExternalPropagation> SolvingActions for SA<'_, O> {
 			fn is_decision(&mut self, _: RawLit) -> bool {

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -565,12 +565,13 @@ impl PropagatorExtension for Engine {
 						self.state.last_propagated = None;
 						event
 					}
-					_ => {
-						self.state
-							.propagation_queue
-							.retain(|event| event.lit != lit);
-						None
-					}
+					_ => self
+						.state
+						.propagation_queue
+						.iter()
+						.position(|event| event.lit == lit)
+						.and_then(|pos| self.state.propagation_queue.remove(pos))
+						.and_then(|event| event.event),
 				},
 				None => None,
 			};
@@ -1003,5 +1004,127 @@ impl TrailingActions for State {
 
 	fn trailed<T: Bytes>(&self, x: Trailed<T>) -> T {
 		self.trail.trailed(x)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use pindakaas::solver::propagation::Propagator as ExternalPropagator;
+	use rangelist::RangeList;
+
+	use crate::{
+		IntVal,
+		actions::{
+			BoolPropagationActions, InitActions, IntDecisionActions, IntInitActions,
+			IntPropagationActions, ReasoningEngine,
+		},
+		constraints::Propagator,
+		solver::{
+			BoolView, Decision, IntLitMeaning, Solver, View,
+			activation_list::{IntEvent, IntPropCond},
+			decision::integer::{EncodingType, IntDecision},
+			engine::Engine,
+		},
+	};
+
+	#[test]
+	/// Regression test for losing an integer notification when a queued
+	/// propagation is also implied by another propagated literal.
+	///
+	/// The propagator emits two consequences in order:
+	/// - first `req_first`, then `ge_1_second >= 1`.
+	/// - A clause also makes `req_first -> ge_1_second >= 1`.
+	///
+	/// After the engine returns `req_first` to the SAT solver, the lower-bound
+	/// literal is still queued, but its effect is already reflected in the
+	/// trailed integer state. When the SAT solver reports both assignments
+	/// together, the lower-bound advisor still has to be notified exactly once.
+	/// Before the fix, the queued event was purged and this notification was
+	/// lost.
+	fn queued_integer_event_survives_sat_assignment() {
+		use std::{cell::RefCell, rc::Rc};
+
+		#[derive(Clone, Debug)]
+		struct ProducerAndListener {
+			req_first: Decision<bool>,
+			notifications: Rc<RefCell<usize>>,
+			ge_1_second: View<IntVal>,
+			done: bool,
+		}
+
+		impl Propagator<Engine> for ProducerAndListener {
+			fn initialize(&mut self, ctx: &mut <Engine as ReasoningEngine>::InitializationCtx<'_>) {
+				ctx.enqueue_now(true);
+				self.ge_1_second
+					.advise_when(ctx, IntPropCond::LowerBound, 0);
+			}
+
+			fn advise_of_int_change(
+				&mut self,
+				_: &mut <Engine as ReasoningEngine>::NotificationCtx<'_>,
+				data: u64,
+				event: IntEvent,
+			) -> bool {
+				assert_eq!(data, 0);
+				assert_eq!(event, IntEvent::LowerBound);
+				*self.notifications.borrow_mut() += 1;
+				false
+			}
+
+			fn propagate(
+				&mut self,
+				ctx: &mut <Engine as ReasoningEngine>::PropagationCtx<'_>,
+			) -> Result<(), <Engine as ReasoningEngine>::Conflict> {
+				assert!(!self.done);
+				self.done = true;
+				self.req_first.require(ctx, [])?;
+				self.ge_1_second.tighten_min(ctx, 1, [])?;
+				Ok(())
+			}
+		}
+
+		let mut slv: Solver = Solver::default();
+		let notifications = Rc::new(RefCell::new(0));
+		let imply = slv.new_bool_decision();
+		let var = IntDecision::new_in(
+			&mut slv,
+			RangeList::from(0..=2),
+			EncodingType::Eager,
+			EncodingType::Lazy,
+		);
+		slv.add_propagator(
+			Box::new(ProducerAndListener {
+				req_first: imply,
+				notifications: Rc::clone(&notifications),
+				ge_1_second: var,
+				done: false,
+			}),
+			false,
+		);
+		let ge_view = var.lit(&mut slv, IntLitMeaning::GreaterEq(1));
+		let BoolView::Lit(ge) = ge_view.0 else {
+			unreachable!()
+		};
+		// The second consequence is also implied by the first one through SAT.
+		slv.add_clause([(!imply).into(), ge_view]).unwrap();
+
+		let (mut actions, mut engine) = slv.as_parts_mut();
+		// Running propagate once communicates only the first consequence back to
+		// SAT. The lower-bound propagation remains queued, but its bound update is
+		// already visible in the integer trail.
+		let propagated = ExternalPropagator::propagate(&mut *engine, &mut actions);
+		assert_eq!(propagated, Some(imply.0));
+		assert_eq!(engine.state.propagation_queue.len(), 1);
+		assert_eq!(engine.state.propagation_queue[0].lit, ge.0);
+
+		// SAT now reports both literals together. The queued lower-bound event must
+		// survive this path so the advisor is still notified.
+		ExternalPropagator::notify_assignments(&mut *engine, &[imply.0, ge.0]);
+		assert_eq!(*notifications.borrow(), 1);
+
+		let propagated = ExternalPropagator::propagate(&mut *engine, &mut actions);
+		assert_eq!(propagated, None);
+
+		assert_eq!(*notifications.borrow(), 1);
 	}
 }


### PR DESCRIPTION
When a propagated integer literal was later assigned indirectly through
SAT propagation, the engine removed the matching queued propagation
entry before reusing its stored integer event.
