### PR TITLE
Negation issue on creation of solver lits

### DIFF
--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -635,7 +635,7 @@ impl LoweringMapBuilder {
 					None => slv.new_bool_decision().into(),
 				};
 				self.bool_map[idx] = Some(view);
-				view
+				if lit.is_negated() { !view } else { view }
 			}
 			Const(b) => b.into(),
 			IntEq(idx, val) => {

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -493,15 +493,15 @@ impl Model {
 			int_map: vec![None; self.int_vars.len()],
 		};
 
-		// Ensure the creation of all integer variables.
-		for (idx, _) in self.int_vars.iter().enumerate() {
-			map_builder.get_or_create_int(self, &mut slv, Decision(idx as u32));
-		}
-
 		// Ensure the creation of all Boolean variables.
 		for var in 1..=self.bool_vars.len() as u32 {
 			let raw = RawLit::from_raw(NonZeroI32::new(var as i32).unwrap());
 			map_builder.get_or_create_bool(self, &mut slv, Decision(raw).into());
+		}
+
+		// Ensure the creation of all integer variables.
+		for (idx, _) in self.int_vars.iter().enumerate() {
+			map_builder.get_or_create_int(self, &mut slv, Decision(idx as u32));
 		}
 
 		// Finalize the reformulation map (all variables must be created by now)

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -594,19 +594,21 @@ impl TrailingActions for Model {
 
 #[cfg(test)]
 mod tests {
+	use expect_test::expect;
 	use tracing_test::traced_test;
 
 	use crate::{
 		IntVal,
 		actions::{
 			BoolInitActions, BoolInspectionActions, ConstructionActions, IntInitActions,
-			IntInspectionActions, IntPropagationActions, ReasoningEngine, Trailed, TrailingActions,
+			IntInspectionActions, IntPropagationActions, IntSimplificationActions, ReasoningEngine,
+			Trailed, TrailingActions,
 		},
 		constraints::{
 			BoolModelActions, Constraint, IntModelActions, Propagator, SimplificationStatus,
 		},
 		lower::{InitConfig, LoweringContext, LoweringError},
-		model::{Model, View},
+		model::{Model, View, deserialize::AnyView},
 		solver::{
 			Solver,
 			activation_list::{IntEvent, IntPropCond},
@@ -744,5 +746,26 @@ mod tests {
 		let (min, max) = i_slv.bounds(&slv);
 		assert_eq!(min, 1);
 		assert_eq!(max, 2);
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_inverted_bool() {
+		let mut prb = Model::default();
+		let b = prb.new_bool_decision();
+		let i1 = prb.new_int_decision(-1..=0);
+		i1.unify(&mut prb, !b - 1).expect("unify failed");
+
+		let (mut slv, map): (Solver, _) = prb
+			.to_solver(&InitConfig::default())
+			.expect("to_solver failed");
+		let b_slv = map.get_any(&mut slv, AnyView::from(b));
+		let i1_slv = map.get_any(&mut slv, AnyView::from(i1));
+		slv.expect_solutions(
+			&[b_slv, i1_slv],
+			expect![[r#"
+    			false, 0
+    			true, -1"#]],
+		);
 	}
 }

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -493,15 +493,15 @@ impl Model {
 			int_map: vec![None; self.int_vars.len()],
 		};
 
+		// Ensure the creation of all integer variables.
+		for (idx, _) in self.int_vars.iter().enumerate() {
+			map_builder.get_or_create_int(self, &mut slv, Decision(idx as u32));
+		}
+
 		// Ensure the creation of all Boolean variables.
 		for var in 1..=self.bool_vars.len() as u32 {
 			let raw = RawLit::from_raw(NonZeroI32::new(var as i32).unwrap());
 			map_builder.get_or_create_bool(self, &mut slv, Decision(raw).into());
-		}
-
-		// Ensure the creation of all integer variables.
-		for (idx, _) in self.int_vars.iter().enumerate() {
-			map_builder.get_or_create_int(self, &mut slv, Decision(idx as u32));
 		}
 
 		// Finalize the reformulation map (all variables must be created by now)


### PR DESCRIPTION
I found an issue with an incorrect "optimal" solution for 2017/routing-flexible/routing_GCM_0005.mzn.

I found that the issue was caused by the following pattern: A model `LinearBoolView` of a negated lit `-l` would be mapped to a new solver lit `a` (`a` is equal to the negation of `l`). Then a boolean in the model would look up the mapping of lit `l`, but assume that the positive literal is mapped to `a`. Now different views assume that `a` points to `-l` or `l`.

I added a test case and tried to fix the issue by swapping the mapping of boolean and integer variables. In my understanding, the booleans are always directly mapped positive to positive. Then the later views correctly look up the solver lit and do the transformations. This fix works correctly with the test case and the affected benchmark instance, but please review if this correctly fixes the issue.