### PR TITLE
fix: integer event determination in SolvingContext::propgate_int

### DIFF
--- a/crates/huub/src/solver/decision/integer.rs
+++ b/crates/huub/src/solver/decision/integer.rs
@@ -1020,8 +1020,7 @@ impl IntDecision {
 		iv.into()
 	}
 
-	/// Notify that a new lower bound has been propagated for the variable,
-	/// returning the previous lower bound.
+	/// Notify that a new lower bound has been propagated for the variable.
 	///
 	/// # Warning
 	///
@@ -1060,8 +1059,7 @@ impl IntDecision {
 		}
 	}
 
-	/// Notify that a new upper bound has been propagated for the variable,
-	/// returning the previous upper bound.
+	/// Notify that a new upper bound has been propagated for the variable.
 	///
 	/// # Warning
 	///

--- a/crates/huub/src/solver/solving_context.rs
+++ b/crates/huub/src/solver/solving_context.rs
@@ -318,7 +318,9 @@ impl<'a> SolvingContext<'a> {
 		let event = match lit_req {
 			IntLitMeaning::Eq(_) => IntEvent::Fixed,
 			IntLitMeaning::NotEq(_) => IntEvent::Domain,
+			IntLitMeaning::GreaterEq(i) if i == ub => IntEvent::Fixed,
 			IntLitMeaning::GreaterEq(_) => IntEvent::LowerBound,
+			IntLitMeaning::Less(i) if i == lb + 1 => IntEvent::Fixed,
 			IntLitMeaning::Less(_) => IntEvent::UpperBound,
 		};
 		self.propagate_lit(lit, reason, Some((iv, event)));


### PR DESCRIPTION
This ensures that the right `IntEvent` is created and used for
queue management and advisor activation when a variable becomes
fixed by `tighten_min` or `tighten_max`.
