### PR TITLE
fix: IntUnique::simplify allowed duplicate value assignments

### DIFF
--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -955,6 +955,73 @@ mod tests {
 		(start, dur, usage)
 	}
 
+	/// This test verifies that the cumulative propagator performs multiple
+	/// rounds of propagation to reach a fixpoint. In each round, the
+	/// propagator first updates the start times of tasks according to the
+	/// time-table profile. Once no further updates to start times are possible,
+	/// the propagator then tightens the usage bounds based on the current
+	/// profile. This ensures the time-table profile is the latest and the
+	/// propagation of usage bounds are correct.
+	#[test]
+	#[traced_test]
+	fn test_cumulative_propagate() {
+		let mut prb = Model::default();
+		// Task A: can start at 0, 1, or 2; duration 3. Latest start time: 2, earliest
+		// completion time: 3. Compulsory part: [0, 2] (must be scheduled in this
+		// interval for feasibility).
+		let start_time_a = prb.new_int_decision(0..=2);
+		// Task B: same as Task A (identical domain and duration).
+		let start_time_b = prb.new_int_decision(0..=2);
+		// Task C: can start at 0..=4; duration 3. Latest start time: 4, earliest
+		// completion time: 3. No compulsory part.
+		let start_time_c = prb.new_int_decision(0..=4);
+		let usages = prb.new_int_decisions(3, 1..=2);
+		prb.cumulative()
+			.start_times(vec![start_time_a, start_time_b, start_time_c])
+			.durations(vec![3, 3, 3])
+			.usages(usages.clone())
+			.capacity(2)
+			.post();
+
+		// First propagation: The compulsory parts of Task A and B ([0, 2])
+		// require that Task C cannot overlap with them due to capacity constraints.
+		// This pushes the earliest start time of Task C to 3.
+		let _ = prb.propagate(ConRef::from_raw(0));
+		let time_bounds = start_time_a.bounds(&prb);
+		assert_eq!(time_bounds, (0, 2));
+		let usage_bounds = usages[0].bounds(&prb);
+		assert_eq!(usage_bounds, (1, 2));
+
+		let time_bounds = start_time_b.bounds(&prb);
+		assert_eq!(time_bounds, (0, 2));
+		let usage_bounds = usages[1].bounds(&prb);
+		assert_eq!(usage_bounds, (1, 2));
+
+		let time_bounds = start_time_c.bounds(&prb);
+		assert_eq!(time_bounds, (3, 4));
+		let usage_bounds = usages[2].bounds(&prb);
+		assert_eq!(usage_bounds, (1, 2));
+
+		// Second propagation: With Task C's start time now at least 3, only A and B
+		// overlap in [0, 2]. The combined usage of A and B in this interval must not
+		// exceed the capacity (2), so their usage upper bounds are tightened to 1.
+		let _ = prb.propagate(ConRef::from_raw(0));
+		let time_bounds = start_time_a.bounds(&prb);
+		assert_eq!(time_bounds, (0, 2));
+		let usage_bounds = usages[0].bounds(&prb);
+		assert_eq!(usage_bounds, (1, 1));
+
+		let time_bounds = start_time_b.bounds(&prb);
+		assert_eq!(time_bounds, (0, 2));
+		let usage_bounds = usages[1].bounds(&prb);
+		assert_eq!(usage_bounds, (1, 1));
+
+		let time_bounds = start_time_c.bounds(&prb);
+		assert_eq!(time_bounds, (3, 4));
+		let usage_bounds = usages[2].bounds(&prb);
+		assert_eq!(usage_bounds, (1, 2));
+	}
+
 	#[test]
 	#[traced_test]
 	fn test_cumulative_val_sat() {
@@ -1272,72 +1339,5 @@ mod tests {
 		);
 
 		slv.assert_unsatisfiable();
-	}
-
-	/// This test verifies that the cumulative propagator performs multiple
-	/// rounds of propagation to reach a fixpoint. In each round, the
-	/// propagator first updates the start times of tasks according to the
-	/// time-table profile. Once no further updates to start times are possible,
-	/// the propagator then tightens the usage bounds based on the current
-	/// profile. This ensures the time-table profile is the latest and the
-	/// propagation of usage bounds are correct.
-	#[test]
-	#[traced_test]
-	fn test_cumulative_propagate() {
-		let mut prb = Model::default();
-		// Task A: can start at 0, 1, or 2; duration 3. Latest start time: 2, earliest
-		// completion time: 3. Compulsory part: [0, 2] (must be scheduled in this
-		// interval for feasibility).
-		let start_time_a = prb.new_int_decision(0..=2);
-		// Task B: same as Task A (identical domain and duration).
-		let start_time_b = prb.new_int_decision(0..=2);
-		// Task C: can start at 0..=4; duration 3. Latest start time: 4, earliest
-		// completion time: 3. No compulsory part.
-		let start_time_c = prb.new_int_decision(0..=4);
-		let usages = prb.new_int_decisions(3, 1..=2);
-		prb.cumulative()
-			.start_times(vec![start_time_a, start_time_b, start_time_c])
-			.durations(vec![3, 3, 3])
-			.usages(usages.clone())
-			.capacity(2)
-			.post();
-
-		// First propagation: The compulsory parts of Task A and B ([0, 2])
-		// require that Task C cannot overlap with them due to capacity constraints.
-		// This pushes the earliest start time of Task C to 3.
-		let _ = prb.propagate(ConRef::from_raw(0));
-		let time_bounds = start_time_a.bounds(&prb);
-		assert_eq!(time_bounds, (0, 2));
-		let usage_bounds = usages[0].bounds(&prb);
-		assert_eq!(usage_bounds, (1, 2));
-
-		let time_bounds = start_time_b.bounds(&prb);
-		assert_eq!(time_bounds, (0, 2));
-		let usage_bounds = usages[1].bounds(&prb);
-		assert_eq!(usage_bounds, (1, 2));
-
-		let time_bounds = start_time_c.bounds(&prb);
-		assert_eq!(time_bounds, (3, 4));
-		let usage_bounds = usages[2].bounds(&prb);
-		assert_eq!(usage_bounds, (1, 2));
-
-		// Second propagation: With Task C's start time now at least 3, only A and B
-		// overlap in [0, 2]. The combined usage of A and B in this interval must not
-		// exceed the capacity (2), so their usage upper bounds are tightened to 1.
-		let _ = prb.propagate(ConRef::from_raw(0));
-		let time_bounds = start_time_a.bounds(&prb);
-		assert_eq!(time_bounds, (0, 2));
-		let usage_bounds = usages[0].bounds(&prb);
-		assert_eq!(usage_bounds, (1, 1));
-
-		let time_bounds = start_time_b.bounds(&prb);
-		assert_eq!(time_bounds, (0, 2));
-		let usage_bounds = usages[1].bounds(&prb);
-		assert_eq!(usage_bounds, (1, 1));
-
-		let time_bounds = start_time_c.bounds(&prb);
-		assert_eq!(time_bounds, (3, 4));
-		let usage_bounds = usages[2].bounds(&prb);
-		assert_eq!(usage_bounds, (1, 2));
 	}
 }

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -466,6 +466,46 @@ mod tests {
 	};
 
 	#[test]
+	fn recompute_max_support_after_index_pruning() {
+		let mut prb = Model::default();
+		let a = prb.new_int_decision(1..=1);
+		let b = prb.new_int_decision(3..=3);
+		let c = prb.new_int_decision(4..=4);
+		let result = prb.new_int_decision(1..=4);
+		let index = prb.new_int_decision(0..=2);
+
+		prb.element(vec![a, b, c])
+			.index(index)
+			.result(result)
+			.post();
+		index.remove_val(&mut prb, 2, []).unwrap();
+		let _: (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
+
+		assert_eq!(index.domain(&prb), (0..=1).into());
+		assert_eq!(result.bounds(&prb), (1, 3));
+	}
+
+	#[test]
+	fn recompute_min_support_after_index_pruning() {
+		let mut prb = Model::default();
+		let a = prb.new_int_decision(1..=1);
+		let b = prb.new_int_decision(3..=3);
+		let c = prb.new_int_decision(4..=4);
+		let result = prb.new_int_decision(2..=4);
+		let index = prb.new_int_decision(0..=2);
+
+		prb.element(vec![a, b, c])
+			.index(index)
+			.result(result)
+			.post();
+		index.remove_val(&mut prb, 0, []).unwrap();
+		let _: (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
+
+		assert_eq!(index.domain(&prb), (1..=2).into());
+		assert_eq!(result.bounds(&prb), (3, 4));
+	}
+
+	#[test]
 	#[traced_test]
 	fn test_element_bounds_sat() {
 		let mut slv = Solver::default();
@@ -562,46 +602,6 @@ mod tests {
     0, 3, 3, 2
     0, 3, 3, 3"#]],
 		);
-	}
-
-	#[test]
-	fn recompute_min_support_after_index_pruning() {
-		let mut prb = Model::default();
-		let a = prb.new_int_decision(1..=1);
-		let b = prb.new_int_decision(3..=3);
-		let c = prb.new_int_decision(4..=4);
-		let result = prb.new_int_decision(2..=4);
-		let index = prb.new_int_decision(0..=2);
-
-		prb.element(vec![a, b, c])
-			.index(index)
-			.result(result)
-			.post();
-		index.remove_val(&mut prb, 0, []).unwrap();
-		let _: (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
-
-		assert_eq!(index.domain(&prb), (1..=2).into());
-		assert_eq!(result.bounds(&prb), (3, 4));
-	}
-
-	#[test]
-	fn recompute_max_support_after_index_pruning() {
-		let mut prb = Model::default();
-		let a = prb.new_int_decision(1..=1);
-		let b = prb.new_int_decision(3..=3);
-		let c = prb.new_int_decision(4..=4);
-		let result = prb.new_int_decision(1..=4);
-		let index = prb.new_int_decision(0..=2);
-
-		prb.element(vec![a, b, c])
-			.index(index)
-			.result(result)
-			.post();
-		index.remove_val(&mut prb, 2, []).unwrap();
-		let _: (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
-
-		assert_eq!(index.domain(&prb), (0..=1).into());
-		assert_eq!(result.bounds(&prb), (1, 3));
 	}
 
 	#[test]

--- a/crates/huub/src/constraints/int_unique.rs
+++ b/crates/huub/src/constraints/int_unique.rs
@@ -4,14 +4,11 @@
 use std::cmp;
 
 use itertools::{Either, Itertools};
-use rangelist::RangeList;
+use tracing::warn;
 
 use crate::{
 	IntVal,
-	actions::{
-		InitActions, IntDecisionActions, IntInspectionActions, IntSimplificationActions,
-		PostingActions, ReasoningEngine,
-	},
+	actions::{InitActions, IntInspectionActions, PostingActions, ReasoningEngine},
 	constraints::{
 		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
 	},
@@ -31,8 +28,10 @@ use crate::{
 /// values.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct IntUnique {
-	/// List of integer decision variables that must take different values.
-	pub(crate) prop: IntUniqueBounds<View<IntVal>>,
+	/// Instance of the [`IntUniqueBounds`] propagator.
+	pub(crate) bounds_prop: IntUniqueBounds<View<IntVal>>,
+	/// Instance of the [`IntUniqueValue`] propagator.
+	pub(crate) value_prop: IntUniqueValue<View<IntVal>>,
 	/// Whether to enable the bounds consistent propagator.
 	///
 	/// Defaults to `true`.
@@ -106,6 +105,7 @@ impl IntUnique {
 	pub fn bounds_propagation(&self) -> bool {
 		self.bounds_propagation.unwrap_or(true)
 	}
+
 	/// Returns whether a value consistent propagator will be posted when
 	/// creating a [`Solver`](crate::solver::Solver) object.
 	pub fn value_propagation(&self) -> bool {
@@ -123,54 +123,45 @@ where
 		ctx: &mut E::PropagationCtx<'_>,
 	) -> Result<SimplificationStatus, E::Conflict> {
 		self.propagate(ctx)?;
-
-		// TODO: Should this just use the value consistent propagator, or should this
-		// not be done by the bounds consistent propagator?
-		let (vals, vars): (Vec<_>, Vec<_>) =
-			self.prop.var.iter().enumerate().partition_map(|(i, &var)| {
-				if let Some(val) = var.val(ctx) {
-					Either::Left((i, val))
-				} else {
-					Either::Right(var)
-				}
-			});
-		if !vals.is_empty() {
-			let neg: RangeList<_> = vals.iter().map(|&(_, v)| v..=v).collect();
-			for var in &vars {
-				var.exclude(ctx, &neg, |ctx: &mut E::PropagationCtx<'_>| {
-					vals.iter()
-						.map(|&(i, _)| self.prop.var[i].val_lit(ctx).unwrap())
-						.collect_vec()
-				})?;
-			}
-			// Shrink variable array (and related caches)
-			let n = 2 * vars.len() + 2;
-			self.prop.lb_cache.shrink_to(n);
-			self.prop.ub_cache.shrink_to(n);
-			self.prop.min_sorted = (0..vars.len()).collect();
-			self.prop.max_sorted = (0..vars.len()).collect();
-			self.prop.bounds.shrink_to(n);
-			self.prop.predecessor.shrink_to(n);
-			self.prop.diff.shrink_to(n);
-			self.prop.hall_interval.shrink_to(n);
-			self.prop.bucket.shrink_to(n);
-			self.prop.var = vars;
-		}
-
-		if self.prop.var.iter().all(|v| v.val(ctx).is_some()) {
-			return Ok(SimplificationStatus::Subsumed);
-		}
 		Ok(SimplificationStatus::NoFixpoint)
 	}
 
 	fn to_solver(&self, slv: &mut LoweringContext<'_>) -> Result<(), LoweringError> {
-		let vars: Vec<_> = self.prop.var.iter().map(|v| slv.solver_view(*v)).collect();
-		// propagation should have removed any fixed values
-		debug_assert!(vars.iter().all(|v| v.val(slv).is_none()));
-		if self.value_propagation() {
+		let (_vals, vars): (Vec<_>, Vec<_>) = self.bounds_prop.var.iter().partition_map(|&var| {
+			let var = slv.solver_view(var);
+			if let Some(val) = var.val(slv) {
+				Either::Left(val)
+			} else {
+				Either::Right(var)
+			}
+		});
+		// Propagation should have detected any duplicate fixed values and removed them
+		// from the domains of other decision variables.
+		debug_assert!(_vals.iter().unique().collect_vec().len() == _vals.len());
+		debug_assert!(
+			_vals
+				.iter()
+				.all(|&val| vars.iter().all(|var| !var.in_domain(slv, val)))
+		);
+
+		// If the number of non-fixed decision variables is less than or equal
+		// to 1, there is no need to post any propagators.
+		if vars.len() <= 1 {
+			return Ok(());
+		}
+
+		let value_propagation = self.value_propagation();
+		if value_propagation {
 			IntUniqueValue::post(slv, vars.clone());
 		}
-		if self.bounds_propagation() {
+		let mut bounds_propagation = self.bounds_propagation();
+		if !value_propagation && !bounds_propagation {
+			warn!(
+				"all propagation algorithms are disabled for `int_unique` constraint, override with bounds propagation to ensure consistency"
+			);
+			bounds_propagation = true;
+		}
+		if bounds_propagation {
 			IntUniqueBounds::post(slv, vars);
 		}
 		Ok(())
@@ -182,12 +173,29 @@ where
 	E: ReasoningEngine,
 	View<IntVal>: IntSolverActions<E>,
 {
+	fn advise_of_backtrack(&mut self, ctx: &mut E::NotificationCtx<'_>) {
+		self.value_prop.advise_of_backtrack(ctx);
+	}
+
+	fn advise_of_int_change(
+		&mut self,
+		ctx: &mut E::NotificationCtx<'_>,
+		data: u64,
+		event: IntEvent,
+	) -> bool {
+		self.value_prop.advise_of_int_change(ctx, data, event)
+	}
+
 	fn initialize(&mut self, ctx: &mut E::InitializationCtx<'_>) {
-		self.prop.initialize(ctx);
+		self.value_prop.initialize(ctx);
+		self.bounds_prop.initialize(ctx);
 	}
 
 	fn propagate(&mut self, ctx: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
-		self.prop.propagate(ctx)
+		if !self.value_prop.action_list.is_empty() {
+			self.value_prop.propagate(ctx)?;
+		}
+		self.bounds_prop.propagate(ctx)
 	}
 }
 
@@ -494,6 +502,14 @@ where
 }
 
 impl<I> IntUniqueValue<I> {
+	/// Create a new [`IntUniqueValue`] propagator.
+	pub(crate) fn new(vars: Vec<I>) -> Self {
+		Self {
+			vars,
+			action_list: Vec::new(),
+		}
+	}
+
 	/// Create a new [`IntUniqueBounds`] propagator and post it in the
 	/// solver.
 	pub fn post<E>(solver: &mut E, vars: Vec<I>)
@@ -501,10 +517,7 @@ impl<I> IntUniqueValue<I> {
 		E: PostingActions + ?Sized,
 		I: IntSolverActions<Engine>,
 	{
-		solver.add_propagator(Box::new(Self {
-			vars: vars.clone(),
-			action_list: Vec::new(),
-		}));
+		solver.add_propagator(Box::new(Self::new(vars)));
 	}
 }
 
@@ -534,7 +547,13 @@ where
 		// Let the propagator be advised when each specific decision is fixed to a
 		// value, with the index of the decision.
 		for (i, v) in self.vars.iter().enumerate() {
-			v.advise_when(ctx, IntPropCond::Fixed, i as u64);
+			if self.vars[i].val(ctx).is_some() {
+				// If the variable is already fixed, then add it to the action list immediately.
+				self.action_list.push(i);
+				ctx.enqueue_now(true);
+			} else {
+				v.advise_when(ctx, IntPropCond::Fixed, i as u64);
+			}
 		}
 		// Advise the propagator of backtracking to clear the list of fixed decision
 		// (indices).
@@ -576,7 +595,7 @@ mod tests {
 	use tracing_test::traced_test;
 
 	use crate::{
-		IntVal,
+		IntVal, Model,
 		constraints::{
 			int_linear::IntLinearLessEqBounds,
 			int_unique::{IntUniqueBounds, IntUniqueValue},
@@ -784,6 +803,24 @@ mod tests {
 		IntUniqueValue::post(&mut slv, vec![a, b, c]);
 
 		slv.assert_unsatisfiable();
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_gapped_domain_regression() {
+		let mut prb = Model::default();
+		let prev: Vec<_> = [
+			RangeList::from_iter([15..=15, 20..=20]),
+			RangeList::from(20..=20),
+			RangeList::from_iter([15..=15, 20..=20]),
+		]
+		.into_iter()
+		.map(|domain| prb.new_int_decision(domain))
+		.collect();
+
+		prb.unique(prev.iter().copied()).post();
+
+		prb.assert_unsatisfiable();
 	}
 
 	fn test_sudoku(grid: &[&str], expected: Status) {

--- a/crates/huub/src/constraints/int_value_precede.rs
+++ b/crates/huub/src/constraints/int_value_precede.rs
@@ -981,56 +981,6 @@ mod tests {
 
 	#[test]
 	#[traced_test]
-	fn test_seq_precede_chain_single_var() {
-		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			RangeList::from_iter([-1..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-
-		IntSeqPrecedeChainBounds::post(&mut slv, vec![x0]);
-		slv.expect_solutions(
-			&[x0],
-			expect![[r#"
-			-1
-			0
-			1"#]],
-		);
-	}
-
-	#[test]
-	#[traced_test]
-	fn test_seq_precede_chain_simple() {
-		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			RangeList::from_iter([0..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			RangeList::from_iter([0..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-
-		IntSeqPrecedeChainBounds::post(&mut slv, vec![x0, x1]);
-		slv.expect_solutions(
-			&[x0, x1],
-			expect![[r#"
-    		0, 0
-    		0, 1
-    		1, 0
-    		1, 1
-    		1, 2"#]],
-		);
-	}
-
-	#[test]
-	#[traced_test]
 	fn test_seq_precede_chain_paper() {
 		let mut slv = Solver::default();
 		let x1 = IntDecision::new_in(
@@ -1097,6 +1047,56 @@ mod tests {
 
 	#[test]
 	#[traced_test]
+	fn test_seq_precede_chain_simple() {
+		let mut slv = Solver::default();
+		let x0 = IntDecision::new_in(
+			&mut slv,
+			RangeList::from_iter([0..=3]),
+			EncodingType::Eager,
+			EncodingType::Eager,
+		);
+		let x1 = IntDecision::new_in(
+			&mut slv,
+			RangeList::from_iter([0..=3]),
+			EncodingType::Eager,
+			EncodingType::Eager,
+		);
+
+		IntSeqPrecedeChainBounds::post(&mut slv, vec![x0, x1]);
+		slv.expect_solutions(
+			&[x0, x1],
+			expect![[r#"
+    		0, 0
+    		0, 1
+    		1, 0
+    		1, 1
+    		1, 2"#]],
+		);
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_seq_precede_chain_single_var() {
+		let mut slv = Solver::default();
+		let x0 = IntDecision::new_in(
+			&mut slv,
+			RangeList::from_iter([-1..=3]),
+			EncodingType::Eager,
+			EncodingType::Eager,
+		);
+
+		IntSeqPrecedeChainBounds::post(&mut slv, vec![x0]);
+		slv.expect_solutions(
+			&[x0],
+			expect![[r#"
+			-1
+			0
+			1"#]],
+		);
+	}
+
+	#[test]
+	#[traced_test]
 	fn test_seq_precede_chain_unrestricted() {
 		let mut slv = Solver::default();
 		let x1 = IntDecision::new_in(
@@ -1126,6 +1126,87 @@ mod tests {
 
 		IntSeqPrecedeChainBounds::post(&mut slv, vec![x1, x2, x3, x4]);
 		slv.assert_all_solutions(&[x1, x2, x3, x4], valid_sequence_precede);
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_val_precede_chain_all_enforced() {
+		let mut slv = Solver::default();
+		let x0 = IntDecision::new_in(
+			&mut slv,
+			RangeList::from_iter([1..=3]),
+			EncodingType::Eager,
+			EncodingType::Eager,
+		);
+		let x1 = IntDecision::new_in(
+			&mut slv,
+			RangeList::from_iter([1..=3]),
+			EncodingType::Eager,
+			EncodingType::Eager,
+		);
+
+		IntValuePrecedeChainValue::post(&mut slv, vec![3, 2, 1], vec![x0, x1]);
+		slv.expect_solutions(
+			&[x0, x1],
+			expect![[r#"
+    		3, 2
+    		3, 3"#]],
+		);
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_val_precede_chain_simple() {
+		let mut slv = Solver::default();
+		let x0 = IntDecision::new_in(
+			&mut slv,
+			RangeList::from_iter([0..=3]),
+			EncodingType::Eager,
+			EncodingType::Eager,
+		);
+		let x1 = IntDecision::new_in(
+			&mut slv,
+			RangeList::from_iter([0..=3]),
+			EncodingType::Eager,
+			EncodingType::Eager,
+		);
+
+		IntValuePrecedeChainValue::post(&mut slv, vec![1, 3], vec![x0, x1]);
+		slv.expect_solutions(
+			&[x0, x1],
+			expect![[r#"
+    		0, 0
+    		0, 1
+    		0, 2
+    		1, 0
+    		1, 1
+    		1, 2
+    		1, 3
+    		2, 0
+    		2, 1
+    		2, 2"#]],
+		);
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_val_precede_chain_single_var() {
+		let mut slv = Solver::default();
+		let x0 = IntDecision::new_in(
+			&mut slv,
+			RangeList::from_iter([0..=3]),
+			EncodingType::Eager,
+			EncodingType::Eager,
+		);
+
+		IntValuePrecedeChainValue::post(&mut slv, vec![2, 1], vec![x0]);
+		slv.expect_solutions(
+			&[x0],
+			expect![[r#"
+    		0
+    		2
+    		3"#]],
+		);
 	}
 
 	#[test]
@@ -1195,87 +1276,6 @@ mod tests {
 		slv.assert_all_solutions(
 			&[x0, x1, x2, x3, x4, x5, x6, x7, x8],
 			valid_value_precede(vec![2, -2, 1, -1]),
-		);
-	}
-
-	#[test]
-	#[traced_test]
-	fn test_val_precede_chain_single_var() {
-		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			RangeList::from_iter([0..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-
-		IntValuePrecedeChainValue::post(&mut slv, vec![2, 1], vec![x0]);
-		slv.expect_solutions(
-			&[x0],
-			expect![[r#"
-    		0
-    		2
-    		3"#]],
-		);
-	}
-
-	#[test]
-	#[traced_test]
-	fn test_val_precede_chain_simple() {
-		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			RangeList::from_iter([0..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			RangeList::from_iter([0..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-
-		IntValuePrecedeChainValue::post(&mut slv, vec![1, 3], vec![x0, x1]);
-		slv.expect_solutions(
-			&[x0, x1],
-			expect![[r#"
-    		0, 0
-    		0, 1
-    		0, 2
-    		1, 0
-    		1, 1
-    		1, 2
-    		1, 3
-    		2, 0
-    		2, 1
-    		2, 2"#]],
-		);
-	}
-
-	#[test]
-	#[traced_test]
-	fn test_val_precede_chain_all_enforced() {
-		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			RangeList::from_iter([1..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			RangeList::from_iter([1..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-
-		IntValuePrecedeChainValue::post(&mut slv, vec![3, 2, 1], vec![x0, x1]);
-		slv.expect_solutions(
-			&[x0, x1],
-			expect![[r#"
-    		3, 2
-    		3, 3"#]],
 		);
 	}
 

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -230,65 +230,6 @@ impl Model {
 			.collect()
 	}
 
-	/// Post a constraint to the model.
-	///
-	/// The constraint is added to the model. It will be enforced during
-	/// simplification and in any subsequent solving method.
-	pub fn post_constraint<C: Constraint<Self>>(&mut self, mut constraint: C) {
-		let con = ConRef::new(self.constraints.len());
-		let mut ctx = ModelInitContext::new(self, con);
-		constraint.initialize(&mut ctx);
-		let priority = ctx.priority;
-		let enqueue = ctx.enqueue();
-		self.constraints.push(Some(Box::new(constraint)));
-		let r = ConRef::new(self.constraints.len() - 1);
-		debug_assert_eq!(r, con);
-		self.propagator_queue.info.push(PropagatorInfo {
-			enqueued: false,
-			priority,
-		});
-		debug_assert_eq!(r.index(), self.propagator_queue.info.len() - 1);
-		if enqueue {
-			self.propagator_queue.enqueue_propagator(con.raw());
-		}
-	}
-
-	/// Propagate the constraint at index `con`, updating the domains of the
-	/// variables and rewriting the constraint if necessary.
-	pub(crate) fn propagate(&mut self, con: ConRef) -> Result<(), LoweringError> {
-		let Some(mut con_obj) = self.constraints[con.index()].take() else {
-			return Ok(());
-		};
-		self.cur_prop = Some(con);
-		let mut status = con_obj.simplify(self);
-		self.cur_prop = None;
-
-		// Resolve lazy explanation if it is required.
-		if let Err(Conflict {
-			subject,
-			reason: Reason::Lazy(r),
-		}) = status
-		{
-			debug_assert_eq!(ConRef::new(r.propagator as usize), con);
-			let conj = con_obj.explain(self, subject.unwrap_or(false.into()), r.data);
-			status = Err(Conflict {
-				subject,
-				reason: Reason::Eager(conj.into_boxed_slice()),
-			});
-		};
-
-		match status? {
-			SimplificationStatus::Subsumed => {
-				// Constraint is known to be satisfied, no need to place back.
-			}
-			SimplificationStatus::NoFixpoint => {
-				self.constraints[con.index()] = Some(con_obj);
-			}
-		}
-		self.notify_advisors();
-		Ok(())
-	}
-
 	/// Notify all advisors of changes.
 	pub(crate) fn notify_advisors(&mut self) {
 		// Notify propagators about all events that occurred
@@ -389,6 +330,65 @@ impl Model {
 			}
 		}
 		self.bool_events = bool_events;
+	}
+
+	/// Post a constraint to the model.
+	///
+	/// The constraint is added to the model. It will be enforced during
+	/// simplification and in any subsequent solving method.
+	pub fn post_constraint<C: Constraint<Self>>(&mut self, mut constraint: C) {
+		let con = ConRef::new(self.constraints.len());
+		let mut ctx = ModelInitContext::new(self, con);
+		constraint.initialize(&mut ctx);
+		let priority = ctx.priority;
+		let enqueue = ctx.enqueue();
+		self.constraints.push(Some(Box::new(constraint)));
+		let r = ConRef::new(self.constraints.len() - 1);
+		debug_assert_eq!(r, con);
+		self.propagator_queue.info.push(PropagatorInfo {
+			enqueued: false,
+			priority,
+		});
+		debug_assert_eq!(r.index(), self.propagator_queue.info.len() - 1);
+		if enqueue {
+			self.propagator_queue.enqueue_propagator(con.raw());
+		}
+	}
+
+	/// Propagate the constraint at index `con`, updating the domains of the
+	/// variables and rewriting the constraint if necessary.
+	pub(crate) fn propagate(&mut self, con: ConRef) -> Result<(), LoweringError> {
+		let Some(mut con_obj) = self.constraints[con.index()].take() else {
+			return Ok(());
+		};
+		self.cur_prop = Some(con);
+		let mut status = con_obj.simplify(self);
+		self.cur_prop = None;
+
+		// Resolve lazy explanation if it is required.
+		if let Err(Conflict {
+			subject,
+			reason: Reason::Lazy(r),
+		}) = status
+		{
+			debug_assert_eq!(ConRef::new(r.propagator as usize), con);
+			let conj = con_obj.explain(self, subject.unwrap_or(false.into()), r.data);
+			status = Err(Conflict {
+				subject,
+				reason: Reason::Eager(conj.into_boxed_slice()),
+			});
+		};
+
+		match status? {
+			SimplificationStatus::Subsumed => {
+				// Constraint is known to be satisfied, no need to place back.
+			}
+			SimplificationStatus::NoFixpoint => {
+				self.constraints[con.index()] = Some(con_obj);
+			}
+		}
+		self.notify_advisors();
+		Ok(())
 	}
 
 	/// Process the model to create a [`Solver`] instance that can be used to
@@ -623,6 +623,98 @@ mod tests {
 		int_check: Trailed<IntVal>,
 	}
 
+	#[test]
+	#[traced_test]
+	fn test_inverted_bool() {
+		let mut prb = Model::default();
+		let b = prb.new_bool_decision();
+		let i1 = prb.new_int_decision(-1..=0);
+		i1.unify(&mut prb, !b - 1).expect("unify failed");
+
+		let (mut slv, map): (Solver, _) = prb
+			.to_solver(&InitConfig::default())
+			.expect("to_solver failed");
+		let b_slv = map.get_any(&mut slv, AnyView::from(b));
+		let i1_slv = map.get_any(&mut slv, AnyView::from(i1));
+		slv.expect_solutions(
+			&[b_slv, i1_slv],
+			expect![[r#"
+    			false, 0
+    			true, -1"#]],
+		);
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_model_advisor_bool_call() {
+		let mut prb = Model::default();
+		let i = prb.new_int_decision(0..=3);
+		let b = i.geq(2);
+		let bool_check = prb.new_trailed(0);
+		let int_check = prb.new_trailed(0);
+		let t = TestModel {
+			b,
+			i,
+			bool_check,
+			int_check,
+		};
+		prb.post_constraint(t);
+		i.tighten_min(&mut prb, 2, []).expect("tighten_min failed");
+		let (_, _): (Solver, _) = prb
+			.to_solver(&InitConfig::default())
+			.expect("to_solver failed");
+		assert_eq!(prb.trailed(bool_check), 1);
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_model_advisor_bool_no_call() {
+		let mut prb = Model::default();
+		let i = prb.new_int_decision(0..=3);
+		let b = i.geq(2);
+		let bool_check = prb.new_trailed(0);
+		let int_check = prb.new_trailed(0);
+		let t = TestModel {
+			b,
+			i,
+			bool_check,
+			int_check,
+		};
+		prb.post_constraint(t);
+		i.tighten_min(&mut prb, 1, []).expect("tighten_min failed");
+		let (_, _): (Solver, _) = prb
+			.to_solver(&InitConfig::default())
+			.expect("to_solver failed");
+		assert_eq!(prb.trailed(bool_check), 0);
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_model_advisor_int_call() {
+		let mut prb = Model::default();
+		let i = prb.new_int_decision(0..=3);
+		let b = prb.new_bool_decision();
+		let bool_check = prb.new_trailed(0);
+		let int_check = prb.new_trailed(0);
+		let t = TestModel {
+			b,
+			i,
+			bool_check,
+			int_check,
+		};
+		prb.post_constraint(t);
+		i.tighten_min(&mut prb, 1, []).expect("tighten_min failed");
+		i.tighten_max(&mut prb, 2, []).expect("tighten_max failed");
+		let (mut slv, map): (Solver, _) = prb
+			.to_solver(&InitConfig::default())
+			.expect("to_solver failed");
+		assert_eq!(prb.trailed(int_check), 1);
+		let i_slv = map.get(&mut slv, i);
+		let (min, max) = i_slv.bounds(&slv);
+		assert_eq!(min, 1);
+		assert_eq!(max, 2);
+	}
+
 	impl<E> Constraint<E> for TestModel
 	where
 		E: ReasoningEngine,
@@ -675,97 +767,5 @@ mod tests {
 		fn propagate(&mut self, _context: &mut E::PropagationCtx<'_>) -> Result<(), E::Conflict> {
 			Ok(())
 		}
-	}
-
-	#[test]
-	#[traced_test]
-	fn test_model_advisor_bool_no_call() {
-		let mut prb = Model::default();
-		let i = prb.new_int_decision(0..=3);
-		let b = i.geq(2);
-		let bool_check = prb.new_trailed(0);
-		let int_check = prb.new_trailed(0);
-		let t = TestModel {
-			b,
-			i,
-			bool_check,
-			int_check,
-		};
-		prb.post_constraint(t);
-		i.tighten_min(&mut prb, 1, []).expect("tighten_min failed");
-		let (_, _): (Solver, _) = prb
-			.to_solver(&InitConfig::default())
-			.expect("to_solver failed");
-		assert_eq!(prb.trailed(bool_check), 0);
-	}
-
-	#[test]
-	#[traced_test]
-	fn test_model_advisor_bool_call() {
-		let mut prb = Model::default();
-		let i = prb.new_int_decision(0..=3);
-		let b = i.geq(2);
-		let bool_check = prb.new_trailed(0);
-		let int_check = prb.new_trailed(0);
-		let t = TestModel {
-			b,
-			i,
-			bool_check,
-			int_check,
-		};
-		prb.post_constraint(t);
-		i.tighten_min(&mut prb, 2, []).expect("tighten_min failed");
-		let (_, _): (Solver, _) = prb
-			.to_solver(&InitConfig::default())
-			.expect("to_solver failed");
-		assert_eq!(prb.trailed(bool_check), 1);
-	}
-
-	#[test]
-	#[traced_test]
-	fn test_model_advisor_int_call() {
-		let mut prb = Model::default();
-		let i = prb.new_int_decision(0..=3);
-		let b = prb.new_bool_decision();
-		let bool_check = prb.new_trailed(0);
-		let int_check = prb.new_trailed(0);
-		let t = TestModel {
-			b,
-			i,
-			bool_check,
-			int_check,
-		};
-		prb.post_constraint(t);
-		i.tighten_min(&mut prb, 1, []).expect("tighten_min failed");
-		i.tighten_max(&mut prb, 2, []).expect("tighten_max failed");
-		let (mut slv, map): (Solver, _) = prb
-			.to_solver(&InitConfig::default())
-			.expect("to_solver failed");
-		assert_eq!(prb.trailed(int_check), 1);
-		let i_slv = map.get(&mut slv, i);
-		let (min, max) = i_slv.bounds(&slv);
-		assert_eq!(min, 1);
-		assert_eq!(max, 2);
-	}
-
-	#[test]
-	#[traced_test]
-	fn test_inverted_bool() {
-		let mut prb = Model::default();
-		let b = prb.new_bool_decision();
-		let i1 = prb.new_int_decision(-1..=0);
-		i1.unify(&mut prb, !b - 1).expect("unify failed");
-
-		let (mut slv, map): (Solver, _) = prb
-			.to_solver(&InitConfig::default())
-			.expect("to_solver failed");
-		let b_slv = map.get_any(&mut slv, AnyView::from(b));
-		let i1_slv = map.get_any(&mut slv, AnyView::from(i1));
-		slv.expect_solutions(
-			&[b_slv, i1_slv],
-			expect![[r#"
-    			false, 0
-    			true, -1"#]],
-		);
 	}
 }

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -449,13 +449,13 @@ impl Model {
 					int_eager_direct.insert(var);
 				}
 			} else if let Some(c) = c.downcast_ref::<IntUnique>() {
-				for v in &c.prop.var {
+				for v in &c.bounds_prop.var {
 					let v = v.resolve_alias(self);
 					if let Some(var) = v.integer_decision() {
 						let Domain::Domain(dom) = &self.int_vars[var.idx()].domain else {
 							unreachable!()
 						};
-						if dom.card() <= Some(c.prop.var.len() * 100 / 80) {
+						if dom.card() <= Some(c.bounds_prop.var.len() * 100 / 80) {
 							int_eager_direct.insert(var);
 						}
 					}

--- a/crates/huub/src/model/expressions.rs
+++ b/crates/huub/src/model/expressions.rs
@@ -32,7 +32,7 @@ use crate::{
 		int_pow::IntPowBounds,
 		int_set_contains::IntSetContainsReif,
 		int_table::IntTable,
-		int_unique::{IntUnique, IntUniqueBounds},
+		int_unique::{IntUnique, IntUniqueBounds, IntUniqueValue},
 		int_value_precede::{IntSeqPrecedeChainBounds, IntValuePrecedeChainValue},
 	},
 	helpers::overflow::{OverflowImpossible, OverflowPossible},
@@ -381,8 +381,10 @@ impl Model {
 		bounds_propagation: Option<bool>,
 		value_propagation: Option<bool>,
 	) {
+		let vars: Vec<_> = vars.into_iter().map_into().collect();
 		self.post_constraint(IntUnique {
-			prop: IntUniqueBounds::new(vars.into_iter().map_into().collect()),
+			bounds_prop: IntUniqueBounds::new(vars.clone()),
+			value_prop: IntUniqueValue::new(vars),
 			bounds_propagation,
 			value_propagation,
 		});

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -116,17 +116,6 @@ pub struct SearchStatistics {
 	pub(crate) user_decisions: u64,
 }
 
-/// The main solver object that is used to interact with the LCG solver.
-#[derive(Debug)]
-pub struct Solver<Sat = Cadical> {
-	/// The SAT solver that has been connected to [`Self::engine`] to perform
-	/// external propagation.
-	pub(crate) sat: Sat,
-	/// A reference to the [`Engine`] instance that is connected to
-	/// [`Self::sat`].
-	pub(crate) engine: Rc<RefCell<Engine>>,
-}
-
 /// The overarching search strategy used by the solver.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum SearchStrategy {
@@ -146,13 +135,15 @@ pub enum SearchStrategy {
 	Interleaved(SwitchTrigger),
 }
 
-/// Trigger for switching between search strategies.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum SwitchTrigger {
-	/// Switch after the given number of conflicts have been encountered.
-	Conflicts(u64),
-	/// Switch after the given number of restarts have been encountered.
-	Restarts(u64),
+/// The main solver object that is used to interact with the LCG solver.
+#[derive(Debug)]
+pub struct Solver<Sat = Cadical> {
+	/// The SAT solver that has been connected to [`Self::engine`] to perform
+	/// external propagation.
+	pub(crate) sat: Sat,
+	/// A reference to the [`Engine`] instance that is connected to
+	/// [`Self::sat`].
+	pub(crate) engine: Rc<RefCell<Engine>>,
 }
 
 /// Result of a solving attempt
@@ -166,6 +157,15 @@ pub enum Status {
 	Complete,
 	/// The solver was interrupted before a result could be reached.
 	Unknown,
+}
+
+/// Trigger for switching between search strategies.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SwitchTrigger {
+	/// Switch after the given number of conflicts have been encountered.
+	Conflicts(u64),
+	/// Switch after the given number of restarts have been encountered.
+	Restarts(u64),
 }
 
 /// Helper function that calls [`tracing::debug!`] on learned clauses.


### PR DESCRIPTION
When given domains with gaps, the bounds consistent propagator does not
guarantee that the resulting values it sets do not contain duplicate
values. It would instead rely on another pass to eliminate these values.
However, we were removing all fixed values under the assumption that a
conflict was already raised if required.

This fix removes the shrinking of the decision variable vector during
model simplification (which is the minimal fix), but also enables the
use of the value consistent propagator during model-level propagation,
simplifying some of the code.
