### PR TITLE
feat: replace solver methods with builder-pattern solve() API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["sat", "lcg", "flatzinc", "minizinc", "optimization"]
 
 [workspace.dependencies]
 anstream = "1.0.0"
-bon = "3.9.1"
+bon = { version = "3.9.1", features = ["experimental-generics-setters"] }
 clap = { version = "4.6.1", features = ["derive"] }
 clap_complete = "4.6.3"
 ctrlc = "3.5.2"

--- a/crates/huub-cli/src/lib.rs
+++ b/crates/huub-cli/src/lib.rs
@@ -37,12 +37,14 @@ use std::{
 
 use flatzinc_serde::{FlatZinc, Literal, NamedRef, Variable, helpers::ArcKey};
 use huub::{
-	actions::IntDecisionActions,
 	lower::LoweringError,
-	model::deserialize::flatzinc::{FlatZincError, FznIdent},
+	model::deserialize::{
+		Goal,
+		flatzinc::{FlatZincError, FznIdent},
+	},
 	solver::{
-		AnyView, Goal, IntLitMeaning, SearchStrategy, Solution, Solver, Status, SwitchTrigger,
-		TerminationSignal, Value,
+		AnyView, SearchStrategy, Solution, Solver, Status, SwitchTrigger, TerminationSignal,
+		Valuation,
 	},
 };
 use mimalloc::MiMalloc;
@@ -120,7 +122,7 @@ impl<'a> Cli<'a> {
 			)
 		})?;
 
-		let (mut slv, meta) = match Solver::from_fzn(&fzn, &self.init_config()) {
+		let (mut slv, meta): (Solver, _) = match Solver::from_fzn(&fzn, &self.init_config()) {
 			Err(FlatZincError::ReformulationError(
 				LoweringError::Simplification(_) | LoweringError::Lowering(_),
 			)) => {
@@ -261,7 +263,7 @@ impl<'a> Cli<'a> {
 					.collect(),
 			})
 			.collect();
-		let (res, stats) = match meta.goal {
+		let res = match meta.goal {
 			Some(goal) => {
 				if self.all_solutions {
 					warn!(
@@ -269,76 +271,11 @@ impl<'a> Cli<'a> {
 						"ignore --all-solutions when optimizing; use --intermediate-solutions or --all-optimal instead"
 					);
 				}
-				let mut no_good_vals = vec![
-					Value::Bool(false);
-					if self.all_optimal {
-						output_vars.len()
-					} else {
-						0
-					}
-				];
-				let all_opt_slv = if self.all_optimal {
-					Some(slv.clone())
-				} else {
-					None
-				};
-				let (status, stats, obj_val) = if self.intermediate_solutions {
-					slv.branch_and_bound(goal, |sol| {
-						output!(
-							self.stdout,
-							"{}",
-							SolutionWrap {
-								sol,
-								fzn: &fzn,
-								var_map: &meta.names
-							}
-						);
-						if self.all_optimal {
-							for (i, var) in output_vars.iter().enumerate() {
-								no_good_vals[i] = var.val(sol);
-							}
-						}
-					})
-				} else {
-					if let Err(err) = ctrlc::set_handler(move || {
-						interrupted.store(true, Ordering::SeqCst);
-					}) {
-						warn!(target: "solver", error = %err, "unable to set ctrl-c handler");
-					}
-
-					let mut last_sol = String::new();
-					let res = slv.branch_and_bound(goal, |sol| {
-						last_sol = SolutionWrap {
-							sol,
-							fzn: &fzn,
-							var_map: &meta.names,
-						}
-						.to_string();
-						if self.all_optimal {
-							for (i, var) in output_vars.iter().enumerate() {
-								no_good_vals[i] = var.val(sol);
-							}
-						}
-					});
-					output!(self.stdout, "{}", last_sol);
-					res
-				};
-				if status == Status::Complete && self.all_optimal {
-					let mut slv = all_opt_slv.unwrap();
-					let Some(obj_val) = obj_val else {
-						unreachable!()
-					};
-					match goal {
-						Goal::Minimize(obj) | Goal::Maximize(obj) => {
-							let obj_lit = obj.lit(&mut slv, IntLitMeaning::Eq(obj_val));
-							slv.add_clause([obj_lit]).unwrap();
-						}
-						_ => panic!("unknown optimization goal"),
-					}
-					if slv.add_no_good(&output_vars, &no_good_vals).is_err() {
-						(Status::Complete, stats)
-					} else {
-						let (res, stats_all) = slv.all_solutions(&output_vars, |sol| {
+				if self.intermediate_solutions {
+					let solve = slv
+						.solve()
+						.bind_using_clauses(true)
+						.on_solution(|sol| {
 							output!(
 								self.stdout,
 								"{}",
@@ -348,26 +285,72 @@ impl<'a> Cli<'a> {
 									var_map: &meta.names
 								}
 							);
-						});
-						(res, stats + stats_all)
+						})
+						.maybe_all_solutions(self.all_optimal.then(|| output_vars.clone()));
+					match goal {
+						Goal::Minimize(obj) => solve.minimize(obj),
+						Goal::Maximize(obj) => solve.maximize(obj),
+						_ => panic!("unknown optimization goal"),
 					}
+					.0
 				} else {
-					(status, stats)
+					if let Err(err) = ctrlc::set_handler(move || {
+						interrupted.store(true, Ordering::SeqCst);
+					}) {
+						warn!(target: "solver", error = %err, "unable to set ctrl-c handler");
+					}
+
+					let obj_dcn = match goal {
+						Goal::Minimize(obj) => obj,
+						Goal::Maximize(obj) => obj,
+						_ => panic!("unknown optimization goal"),
+					};
+					let mut last_obj = None;
+					let mut last_sol = String::new();
+					let solve = slv
+						.solve()
+						.bind_using_clauses(!self.all_optimal)
+						.on_solution(|sol| {
+							if last_obj == Some(obj_dcn.val(sol)) {
+								if !last_sol.is_empty() {
+									output!(self.stdout, "{}", last_sol);
+									last_sol = String::new();
+								}
+								output!(
+									self.stdout,
+									"{}",
+									SolutionWrap {
+										sol,
+										fzn: &fzn,
+										var_map: &meta.names
+									}
+								);
+							} else {
+								last_sol = SolutionWrap {
+									sol,
+									fzn: &fzn,
+									var_map: &meta.names,
+								}
+								.to_string();
+								last_obj = Some(obj_dcn.val(sol));
+							}
+						})
+						.maybe_all_solutions(self.all_optimal.then(|| output_vars.clone()));
+					let (status, _obj) = match goal {
+						Goal::Minimize(obj) => solve.minimize(obj),
+						Goal::Maximize(obj) => solve.maximize(obj),
+						_ => panic!("unknown optimization goal"),
+					};
+					if !last_sol.is_empty() {
+						output!(self.stdout, "{}", last_sol);
+					}
+					status
 				}
 			}
-			None if self.all_solutions => slv.all_solutions(&output_vars, |sol| {
-				output!(
-					self.stdout,
-					"{}",
-					SolutionWrap {
-						sol,
-						fzn: &fzn,
-						var_map: &meta.names
-					}
-				);
-			}),
-			None => {
-				let res = slv.solve(|sol| {
+			None => slv
+				.solve()
+				.bind_using_clauses(true)
+				.on_solution(|sol| {
 					output!(
 						self.stdout,
 						"{}",
@@ -377,11 +360,12 @@ impl<'a> Cli<'a> {
 							var_map: &meta.names
 						}
 					);
-				});
-				(res, slv.solver_statistics())
-			}
+				})
+				.maybe_all_solutions(self.all_solutions.then(|| output_vars.clone()))
+				.satisfy(),
 		};
 		if self.statistics {
+			let stats = slv.solver_statistics();
 			print_statistics_block(
 				&mut self.stdout,
 				"complete",

--- a/crates/huub/examples/jobshop/main.rs
+++ b/crates/huub/examples/jobshop/main.rs
@@ -32,7 +32,7 @@ use std::{
 use clap::{ArgAction, Parser, ValueEnum, builder::BoolishValueParser};
 use huub::{
 	lower::InitConfig,
-	solver::{Goal, IntValuation, SearchStrategy, Solver, SwitchTrigger, TerminationSignal},
+	solver::{SearchStrategy, Solver, SwitchTrigger, TerminationSignal, Valuation},
 };
 
 use crate::{
@@ -210,15 +210,19 @@ fn main() {
 	}
 
 	// ANCHOR: solve_with_branch_and_bound
-	let (status, stats, _) = slv.branch_and_bound(Goal::Minimize(obj), |sol| {
-		solution.save_assignment(sol);
-		last_obj = Some(IntValuation::val(&obj, sol));
-		if options.verbose {
-			println!("Found new solution with objective: {}", last_obj.unwrap());
-			println!("{solution}");
-			println!("-------------------------");
-		}
-	});
+	let (status, _) = slv
+		.solve()
+		.on_solution(|sol| {
+			solution.save_assignment(sol);
+			last_obj = Some(Valuation::val(&obj, sol));
+			if options.verbose {
+				println!("Found new solution with objective: {}", last_obj.unwrap());
+				println!("{solution}");
+				println!("-------------------------");
+			}
+		})
+		.minimize(obj);
+	let stats = slv.solver_statistics();
 	// ANCHOR_END: solve_with_branch_and_bound
 
 	if !options.verbose {

--- a/crates/huub/examples/jobshop/model.rs
+++ b/crates/huub/examples/jobshop/model.rs
@@ -10,7 +10,7 @@ use clap::ValueEnum;
 use huub::{
 	lower::LoweringMap,
 	model::{self, Model, expressions::IntLinearExp},
-	solver::{self, IntValuation, Solver},
+	solver::{self, Solver, Valuation},
 };
 
 #[derive(Debug, Default)]
@@ -268,7 +268,7 @@ impl Solution {
 		for ops in &self.machine_schedule {
 			let mut machine_profile = Vec::new();
 			for (job_idx, op_idx, start_view) in ops {
-				machine_profile.push((*job_idx, *op_idx, IntValuation::val(start_view, value)));
+				machine_profile.push((*job_idx, *op_idx, Valuation::val(start_view, value)));
 			}
 			machine_profile.sort_by_key(|&(_, _, start)| start);
 			start_time.push(machine_profile);
@@ -296,7 +296,7 @@ impl fmt::Display for Solution {
 mod tests {
 	use huub::{
 		lower::InitConfig,
-		solver::{Goal, IntValuation, Solver},
+		solver::{Solver, Valuation},
 	};
 
 	use crate::model::{Instance, JobShopModel, ObjectiveType};
@@ -349,9 +349,11 @@ mod tests {
 		let (mut slv, map): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
 		let obj = map.get(&mut slv, objective);
 		let mut best = None;
-		slv.branch_and_bound(Goal::Minimize(obj), |sol| {
-			best = Some(IntValuation::val(&obj, sol));
-		});
+		slv.solve()
+			.on_solution(|sol| {
+				best = Some(Valuation::val(&obj, sol));
+			})
+			.minimize(obj);
 		best.expect("failed to find a solution")
 	}
 }

--- a/crates/huub/examples/send-more-money/main.rs
+++ b/crates/huub/examples/send-more-money/main.rs
@@ -28,7 +28,7 @@ use std::{fmt::Write, sync::Mutex};
 use huub::{
 	lower::InitConfig,
 	model::Model,
-	solver::{IntValuation, Solver},
+	solver::{Solver, Valuation},
 };
 
 #[cfg(test)]
@@ -85,15 +85,17 @@ pub fn main() {
 
 	// ANCHOR: solve_and_print
 	// Solve and print the first solution
-	solver.solve(|sol| {
-		let [s, e, n, d, m, o, r, y] = [s, e, n, d, m, o, r, y].map(|v| v.val(sol));
+	let _status = solver
+		.solve()
+		.on_solution(|sol| {
+			let [s, e, n, d, m, o, r, y] = [s, e, n, d, m, o, r, y].map(|v| v.val(sol));
 
-		let send = 1000 * s + 100 * e + 10 * n + d;
-		let more = 1000 * m + 100 * o + 10 * r + e;
-		let money = 10000 * m + 1000 * o + 100 * n + 10 * e + y;
+			let send = 1000 * s + 100 * e + 10 * n + d;
+			let more = 1000 * m + 100 * o + 10 * r + e;
+			let money = 10000 * m + 1000 * o + 100 * n + 10 * e + y;
 
-		println!(
-			"Solution found!
+			println!(
+				"Solution found!
 
      S={s}, E={e}, N={n}, D={d}
  +   M={m}, O={o}, R={r}, E={e}
@@ -101,8 +103,9 @@ pub fn main() {
 M={m}, O={o}, N={n}, E={e}, Y={y}
 
 {send} + {more} = {money}"
-		);
-	});
+			);
+		})
+		.satisfy();
 	// ANCHOR_END: solve_and_print
 }
 

--- a/crates/huub/src/constraints/int_unique.rs
+++ b/crates/huub/src/constraints/int_unique.rs
@@ -598,7 +598,7 @@ mod tests {
 		},
 		model::Model,
 		solver::{
-			IntValuation, Solver, Status,
+			Solver, Status, Valuation,
 			decision::integer::{EncodingType, IntDecision},
 		},
 	};
@@ -875,34 +875,36 @@ mod tests {
 			}
 		}
 		assert_eq!(
-			slv.solve(|sol| {
-				(0..9).for_each(|r| {
-					let row = all_vars[r].iter().map(|&v| v.val(sol)).collect_vec();
-					assert!(
-						row.iter().all_unique(),
-						"Values in row {r} are not all different: {row:?}",
-					);
-				});
-				(0..9).for_each(|c| {
-					let col = all_vars.iter().map(|row| row[c].val(sol)).collect_vec();
-					assert!(
-						col.iter().all_unique(),
-						"Values in column {c} are not all different: {col:?}",
-					);
-				});
-				(0..3).for_each(|i| {
-					(0..3).for_each(|j| {
-						let block = (0..3)
-							.flat_map(|x| (0..3).map(move |y| (x, y)))
-							.map(|(x, y)| all_vars[3 * i + x][3 * j + y].val(sol))
-							.collect_vec();
+			slv.solve()
+				.on_solution(|sol| {
+					(0..9).for_each(|r| {
+						let row = all_vars[r].iter().map(|&v| v.val(sol)).collect_vec();
 						assert!(
-							block.iter().all_unique(),
-							"Values in block ({i}, {j}) are not all different: {block:?}",
+							row.iter().all_unique(),
+							"Values in row {r} are not all different: {row:?}",
 						);
 					});
-				});
-			}),
+					(0..9).for_each(|c| {
+						let col = all_vars.iter().map(|row| row[c].val(sol)).collect_vec();
+						assert!(
+							col.iter().all_unique(),
+							"Values in column {c} are not all different: {col:?}",
+						);
+					});
+					(0..3).for_each(|i| {
+						(0..3).for_each(|j| {
+							let block = (0..3)
+								.flat_map(|x| (0..3).map(move |y| (x, y)))
+								.map(|(x, y)| all_vars[3 * i + x][3 * j + y].val(sol))
+								.collect_vec();
+							assert!(
+								block.iter().all_unique(),
+								"Values in block ({i}, {j}) are not all different: {block:?}",
+							);
+						});
+					});
+				})
+				.satisfy(),
 			expected
 		);
 	}

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -25,9 +25,9 @@
 //!
 //! ```
 //! # use huub::{
-//! #     lower::InitConfig,
-//! #     model::Model,
-//! #     solver::{IntValuation, Solver, Status},
+//! # 	lower::InitConfig,
+//! # 	model::Model,
+//! # 	solver::{Solver, Status, Valuation},
 //! # };
 //! let mut model = Model::default();
 //! let x = model.new_int_decision(0..=5);
@@ -41,9 +41,12 @@
 //! let y = map.get(&mut solver, y);
 //!
 //! let mut solution = None;
-//! let status = solver.solve(|sol| {
-//!     solution = Some((x.val(sol), y.val(sol)));
-//! });
+//! let status = solver
+//! 	.solve()
+//! 	.on_solution(|sol| {
+//! 		solution = Some((x.val(sol), y.val(sol)));
+//! 	})
+//! 	.satisfy();
 //!
 //! assert_eq!(status, Status::Satisfied);
 //! let (x, y) = solution.unwrap();
@@ -51,6 +54,12 @@
 //! assert_ne!(x, y);
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
+
+#![expect(
+	clippy::tabs_in_doc_comments,
+	reason = "doctest examples use tab-indented code to match rustfmt output",
+	// Tracking Issue: https://github.com/rust-lang/rust-clippy/issues/12425
+)]
 
 pub mod actions;
 pub mod constraints;

--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -506,18 +506,22 @@ impl LoweringMap {
 	///
 	/// ```
 	/// # use huub::{
-	/// #     lower::InitConfig,
-	/// #     model::Model,
-	/// #     solver::{IntValuation, Solver, Status},
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
 	/// # let mut model = Model::default();
 	/// let model_x = model.new_int_decision(1..=3);
 	/// let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
 	///
 	/// let solver_x = map.get(&mut solver, model_x);
-	/// solver.solve(|solution| {
-	///     assert!((1..=3).contains(&solver_x.val(solution)));
-	/// });
+	/// let status = solver
+	/// 	.solve()
+	/// 	.on_solution(|solution| {
+	/// 		assert!((1..=3).contains(&solver_x.val(solution)));
+	/// 	})
+	/// 	.satisfy();
+	/// assert_eq!(status, Status::Satisfied);
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
 	/// ```
 	pub fn get<Ctx, T>(&self, ctx: &mut Ctx, view: model::View<T>) -> solver::View<T>

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -98,9 +98,9 @@ pub(crate) struct ConRef(u32);
 ///
 /// ```
 /// # use huub::{
-/// #     lower::InitConfig,
-/// #     model::Model,
-/// #     solver::{IntValuation, Solver, Status},
+/// # 	lower::InitConfig,
+/// # 	model::Model,
+/// # 	solver::{Solver, Status, Valuation},
 /// # };
 /// let mut model = Model::default();
 /// let x = model.new_int_decision(1..=3);
@@ -112,9 +112,12 @@ pub(crate) struct ConRef(u32);
 /// # let x = map.get(&mut solver, x);
 /// # let y = map.get(&mut solver, y);
 /// # let mut pair = None;
-/// # let status = solver.solve(|solution| {
-/// #     pair = Some((x.val(solution), y.val(solution)));
-/// # });
+/// # let status = solver
+/// # 	.solve()
+/// # 	.on_solution(|solution| {
+/// # 		pair = Some((x.val(solution), y.val(solution)));
+/// # 	})
+/// # 	.satisfy();
 /// # assert_eq!(status, Status::Satisfied);
 /// # let (x, y) = pair.unwrap();
 /// # assert_eq!(x + y, 4);
@@ -451,18 +454,22 @@ impl Model {
 	///
 	/// ```
 	/// # use huub::{
-	/// #     lower::InitConfig,
-	/// #     model::Model,
-	/// #     solver::{IntValuation, Solver},
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
 	/// # let mut model = Model::default();
 	/// # let x = model.new_int_decision(1..=3);
 	/// let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
 	/// let x = map.get(&mut solver, x);
 	///
-	/// solver.solve(|solution| {
-	///     assert!((1..=3).contains(&x.val(solution)));
-	/// });
+	/// let status = solver
+	/// 	.solve()
+	/// 	.on_solution(|solution| {
+	/// 		assert!((1..=3).contains(&x.val(solution)));
+	/// 	})
+	/// 	.satisfy();
+	/// assert_eq!(status, Status::Satisfied);
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
 	/// ```
 	pub fn to_solver<Sat>(
@@ -702,8 +709,8 @@ mod tests {
 		slv.expect_solutions(
 			&[b_slv, i1_slv],
 			expect![[r#"
-    			false, 0
-    			true, -1"#]],
+			false, 0
+			true, -1"#]],
 		);
 	}
 

--- a/crates/huub/src/model/deserialize.rs
+++ b/crates/huub/src/model/deserialize.rs
@@ -49,6 +49,16 @@ pub enum Branching {
 	WarmStart(Vec<View<bool>>),
 }
 
+/// Type of an optimization goal found during model or solver deserialization.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Goal<V> {
+	/// Search for a solution that minimizes the given objective.
+	Minimize(V),
+	/// Search for a solution that maximizes the given objective.
+	Maximize(V),
+}
+
 impl From<View<IntVal>> for AnyView {
 	fn from(value: View<IntVal>) -> Self {
 		Self::Int(value)

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -31,12 +31,12 @@ use crate::{
 	lower::{InitConfig, LoweringError},
 	model::{
 		Model,
-		deserialize::{AnyView, Branching},
+		deserialize::{AnyView, Branching, Goal},
 		expressions::{BoolFormula, linear::IntLinearExp},
 		view::{View, boolean::BoolView},
 	},
 	solver::{
-		self, Goal, Solver,
+		self, Solver,
 		branchers::{ValueSelection, VariableSelection},
 	},
 };

--- a/crates/huub/src/model/expressions.rs
+++ b/crates/huub/src/model/expressions.rs
@@ -187,9 +187,9 @@ impl Model {
 	///
 	/// ```
 	/// # use huub::{
-	/// #     lower::InitConfig,
-	/// #     model::Model,
-	/// #     solver::{IntValuation, Solver, Status},
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
 	/// # let mut model = Model::default();
 	/// let x = model.new_int_decision(0..=10);
@@ -199,9 +199,12 @@ impl Model {
 	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
 	/// # let x = map.get(&mut solver, x);
 	/// # let y = map.get(&mut solver, y);
-	/// # let status = solver.solve(|solution| {
-	/// #     assert_eq!(x.val(solution) * 2 + y.val(solution), 7);
-	/// # });
+	/// # let status = solver
+	/// # 	.solve()
+	/// # 	.on_solution(|solution| {
+	/// # 		assert_eq!(x.val(solution) * 2 + y.val(solution), 7);
+	/// # 	})
+	/// # 	.satisfy();
 	/// # assert_eq!(status, Status::Satisfied);
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
 	/// ```
@@ -437,22 +440,30 @@ impl Model {
 	///
 	/// ```
 	/// # use huub::{
-	/// #     lower::InitConfig,
-	/// #     model::Model,
-	/// #     solver::{IntValuation, Solver, Status},
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
 	/// # let mut model = Model::default();
 	/// let x = model.new_int_decisions(3, 1..=3);
 	/// # let x_clone = x.clone();
 	/// model.unique(x).post();
 	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
-	/// # let &[x, y, z] = x_clone.into_iter().map(|var| map.get(&mut solver, var)).collect::<Vec<_>>().as_slice() else {
+	/// # let &[x, y, z] = x_clone
+	/// # 	.into_iter()
+	/// # 	.map(|var| map.get(&mut solver, var))
+	/// # 	.collect::<Vec<_>>()
+	/// # 	.as_slice()
+	/// # else {
 	/// # 	unreachable!()
 	/// # };
-	/// # let status = solver.solve(|solution| {
-	/// #     let values = [x.val(solution), y.val(solution), z.val(solution)];
-	/// #     assert_eq!(values.iter().sum::<i64>(), 6);
-	/// # });
+	/// # let status = solver
+	/// # 	.solve()
+	/// # 	.on_solution(|solution| {
+	/// # 		let values = [x.val(solution), y.val(solution), z.val(solution)];
+	/// # 		assert_eq!(values.iter().sum::<i64>(), 6);
+	/// # 	})
+	/// # 	.satisfy();
 	/// # assert_eq!(status, Status::Satisfied);
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
 	/// ```
@@ -737,9 +748,9 @@ impl<'a, S: model_linear_builder::State> ModelLinearBuilder<'a, S> {
 	///
 	/// ```
 	/// # use huub::{
-	/// #     lower::InitConfig,
-	/// #     model::Model,
-	/// #     solver::{BoolValuation, IntValuation, Solver, Status},
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
 	/// # let mut model = Model::default();
 	/// let x = model.new_int_decision(0..=5);
@@ -751,10 +762,13 @@ impl<'a, S: model_linear_builder::State> ModelLinearBuilder<'a, S> {
 	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
 	/// # let x = map.get(&mut solver, x);
 	/// # let at_least_three = map.get(&mut solver, at_least_three);
-	/// # let status = solver.solve(|solution| {
-	/// #     assert!(at_least_three.val(solution));
-	/// #     assert!(x.val(solution) >= 3);
-	/// # });
+	/// # let status = solver
+	/// # 	.solve()
+	/// # 	.on_solution(|solution| {
+	/// # 		assert!(at_least_three.val(solution));
+	/// # 		assert!(x.val(solution) >= 3);
+	/// # 	})
+	/// # 	.satisfy();
 	/// # assert_eq!(status, Status::Satisfied);
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
 	/// ```

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -22,6 +22,7 @@ use std::{
 	rc::Rc,
 };
 
+use bon::Builder;
 use itertools::Itertools;
 pub use pindakaas::solver::cadical::Cadical;
 use pindakaas::{
@@ -32,11 +33,11 @@ use pindakaas::{
 		propagation::{ExternalPropagation, SolvingActions},
 	},
 };
-use tracing::debug;
+use tracing::{debug, warn};
 
 pub use crate::solver::{
 	decision::{Decision, DecisionReference},
-	solution::{AnyView, BoolValuation, IntValuation, Solution, Value},
+	solution::{AnyView, Solution, Valuation, Value},
 	view::{DefaultView, View, boolean::BoolView, integer::IntView},
 };
 use crate::{
@@ -69,14 +70,13 @@ pub trait AssumptionChecker {
 	fn fail(&self, bv: View<bool>) -> bool;
 }
 
-/// Type of the optimization objective.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum Goal<V> {
-	/// Search for a solution that minimizes the given objective.
-	Minimize(V),
-	/// Search for a solution that maximizes the given objective.
-	Maximize(V),
+/// Helper method for collecting solution values.
+#[derive(Debug, Eq, PartialEq)]
+pub struct CollectSolutionsIn<'a, View: Valuation> {
+	/// Decision variables to track.
+	vars: Vec<View>,
+	/// Mutable reference to storage for collected solutions.
+	store: &'a mut Vec<Vec<View::Val>>,
 }
 
 /// Statistics related to the initialization of the solver.
@@ -126,6 +126,131 @@ pub enum SearchStrategy {
 	/// search strategies, switching between them each time the trigger
 	/// condition is met.
 	Interleaved(SwitchTrigger),
+}
+
+/// Callback invoked each time a solution is found.
+///
+/// Implement this trait or use a closure to react to discovered solutions.
+/// The callback receives a [`Solution`] reference for querying decision
+/// variable values.
+pub trait SolutionCallback {
+	/// Handle a newly found solution.
+	///
+	/// This method receives a reference to the current solution. Use the
+	/// [`Valuation`] trait to extract decision variable values.
+	fn on_solution(&mut self, sol: Solution<'_>);
+}
+
+/// Internal struct representing complete solve arguments.
+///
+/// Users interact with this through the public [`SolveArgs`] builder type
+/// returned by [`Solver::solve`].
+#[derive(Builder)]
+#[builder(
+	builder_type(
+		name = SolveArgs,
+		vis = "pub",
+		doc {
+			/// Builder to configure and execute a solve operation.
+			///
+			/// Obtained by calling [`Solver::solve()`]. The builder uses type-state
+			/// parameters to enforce that each option is set at most once and that
+			/// terminal methods are only callable on a fully configured instance.
+			///
+			/// # Terminal methods
+			///
+			/// Call one of the following to execute the solve and consume the builder:
+			///
+			/// - **[`.satisfy()`][SolveArgs::satisfy]**: search for any satisfying
+			///   assignment.
+			/// - **[`.minimize(obj)`][SolveArgs::minimize]**: find the assignment
+			///   minimizing `obj` via branch-and-bound.
+			/// - **[`.maximize(obj)`][SolveArgs::maximize]**: find the assignment
+			///   maximizing `obj` via branch-and-bound.
+		}
+	),
+  generics(setters(name = "with_{}", vis = "")),
+  start_fn(vis = "", name = builder_internal),
+  finish_fn(vis = "", name = finalize_internal),
+)]
+struct SolveArgsComplete<'a, Sat, S, F>
+where
+	S: SolutionCallback,
+	F: FnOnce(&dyn AssumptionChecker),
+{
+	/// Reference to the solver being used for the search.
+	/// This field is set directly by [`Solver::solve`].
+	#[builder(setters(name = solver_internal, vis = ""))]
+	solver: &'a mut Solver<Sat>,
+	/// Boolean assumptions to pass to the underlying SAT solver.
+	///
+	/// Assumptions are used to restrict the SAT solver to consider the search
+	/// space where all assumptions are satisfied. Assumptions are temporary:
+	/// they are only used for the current solve call.
+	#[builder(default = Vec::new(), with = FromIterator::from_iter)]
+	assuming: Vec<View<bool>>,
+	/// Optional callback invoked each time a solution is found.
+	///
+	/// The callback receives a reference to the current solution context,
+	/// allowing inspection of decision variable values via the [`Valuation`]
+	/// trait.
+	///
+	/// Behavior:
+	/// - For satisfiability checks (`.satisfy()`): called at most once.
+	/// - For optimization (`.minimize()`, `.maximize()`): called for each
+	///   improving solution.
+	/// - For all-solutions enumeration: called for each distinct solution
+	///   found.
+	/// - If not set, solutions are accepted silently.
+	#[builder(setters(name = on_solution_internal, vis = ""))]
+	on_solution: Option<S>,
+	/// Optional callback invoked when the SAT solver reports unsatisfiability.
+	///
+	/// The callback receives an [`AssumptionChecker`], which allows analyzing
+	/// which assumptions (if any) contributed to the conflict. This is useful
+	/// for debugging infeasible problems or implementing iterative relaxation
+	/// strategies.
+	#[builder(setters(name = on_failure_internal, vis = ""))]
+	on_failure: Option<F>,
+	/// Optional list of decision variable views for exhaustive solution
+	/// enumeration.
+	///
+	/// When set in combination with `.minimize()` or `.maximize()`, the solver
+	/// will continue to search for all other solutions with the same optimal
+	/// objective value after the first optimum is found.
+	///
+	/// Behavior:
+	/// - If unset, then standard search is performed, stopping at the first
+	///   solution or once optimality is proven.
+	/// - If set with `.satisfy()`: enumerate all feasible solutions
+	/// - If set with `.minimize()`/`.maximize()`: find all optimal solutions
+	///
+	///
+	/// # Warning
+	///
+	/// No-good clauses are added internally to prevent re-visiting
+	/// solutions. This tightens the search space permanently and cannot be
+	/// undone.
+	#[builder(setters(name = all_solutions_internal, vis = ""))]
+	all_solutions: Option<Vec<AnyView>>,
+	/// Controls whether to use clauses to communicate objective bounds to the
+	/// SAT solver during optimization.
+	///
+	/// Two strategies are supported:
+	///
+	/// - **False (default)**: Objective bounds are passed as assumptions to the
+	///   SAT solver. Assumptions are released after each solve attempt. This is
+	///   useful when exploring multiple scenarios or performing incremental
+	///   solving.
+	///
+	/// - **True**: Objective bounds are added as permanent clauses to the
+	///   solver. **warning**: this tightens the search space permanently and
+	///   cannot be undone. Use this when performing standalone optimization
+	///   where the solver instance is not needed later.
+	///
+	/// Note: This setting is ignored if `all_solutions` is set, in which case
+	/// assumptions are always used to ensure no-good clauses work correctly.
+	bind_using_clauses: Option<bool>,
 }
 
 /// The main solver object that is used to interact with the LCG solver.
@@ -212,6 +337,24 @@ impl<A: FailedAssumptions> AssumptionChecker for A {
 	}
 }
 
+/// Implementation of solution collection callback.
+impl<'a, View: Valuation> SolutionCallback for CollectSolutionsIn<'a, View> {
+	fn on_solution(&mut self, sol: Solution<'_>) {
+		self.store
+			.push(self.vars.iter().map(|v| Valuation::val(v, sol)).collect());
+	}
+}
+
+/// Blanket implementation for closures and function pointers.
+impl<F> SolutionCallback for F
+where
+	F: for<'a> FnMut(Solution<'a>),
+{
+	fn on_solution(&mut self, sol: Solution<'_>) {
+		self(sol);
+	}
+}
+
 impl IntLitMeaning {
 	/// Returns the clauses that can be used to define the given literal
 	/// according to the meaning `self`.
@@ -269,6 +412,412 @@ impl AssumptionChecker for NoAssumptions {
 	}
 }
 
+impl<'a, Sat, S, F, State: solve_args::State> SolveArgs<'a, Sat, S, F, State>
+where
+	S: SolutionCallback,
+	F: FnOnce(&dyn AssumptionChecker),
+{
+	/// Enable exhaustive solution enumeration for selected decision variable
+	/// views.
+	///
+	/// When set, the solver will continue searching after finding the requested
+	/// solution, collecting all distinct solutions for the given views. In case
+	/// of:
+	/// - **Satisfiability checks**: It finds all feasible solutions
+	/// - **Optimization**: If finds all solutions with the same optimal
+	///   objective value
+	pub fn all_solutions<T: Into<AnyView>>(
+		self,
+		views: impl IntoIterator<Item = T>,
+	) -> SolveArgs<'a, Sat, S, F, solve_args::SetAllSolutions<State>>
+	where
+		State::AllSolutions: solve_args::IsUnset,
+	{
+		self.maybe_all_solutions(Some(views))
+	}
+
+	/// Collect solution values into a vector for later inspection.
+	///
+	/// Convenience method that creates a [`SolutionCallback`] implementation
+	/// to automatically gather variable values from each solution found.
+	/// Solutions are stored in row-major order (one solution per row).
+	///
+	/// # Arguments
+	///
+	/// - `vars`: List of decision variable views to track
+	/// - `store`: Mutable vector where solutions will be appended
+	///
+	/// # Important
+	///
+	/// This method only sets up the callback to collect solutions. To actually
+	/// enumerate all solutions, you must also call `.all_solutions(vars)` with
+	/// the same (or related) variables, or the search will terminate after
+	/// finding the first solution.
+	///
+	/// # Examples
+	///
+	/// Collect all satisfying assignments:
+	/// ```
+	/// # use huub::{lower::InitConfig, model::Model, solver::{Solver, Status}};
+	/// # let mut model = Model::default();
+	/// # let x = model.new_int_decision(1..=3);
+	/// # let y = model.new_int_decision(1..=3);
+	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let x = map.get(&mut solver, x);
+	/// # let y = map.get(&mut solver, y);
+	/// let mut solutions = Vec::new();
+	/// let status = solver
+	/// 	.solve()
+	/// 	.all_solutions([x, y])
+	/// 	.collect_solutions_in(vec![x, y], &mut solutions)
+	/// 	.satisfy();
+	/// assert_eq!(status, Status::Complete);
+	/// // solutions now contains all feasible (x, y) pairs
+	/// # Ok::<(), Box<dyn std::error::Error>>(())
+	/// ```
+	pub fn collect_solutions_in<'b, View: Valuation>(
+		self,
+		vars: Vec<View>,
+		store: &'b mut Vec<Vec<View::Val>>,
+	) -> SolveArgs<'a, Sat, CollectSolutionsIn<'b, View>, F, solve_args::SetOnSolution<State>>
+	where
+		State::OnSolution: solve_args::IsUnset,
+	{
+		// Note: Unfortunately due to Rust's type system limitations, we cannot
+		// automatically convert the View variables to AnyView here for the
+		// all_solutions field. The caller must explicitly use
+		// .all_solutions() if they need it.
+		self.with_s::<CollectSolutionsIn<'b, View>>()
+			.on_solution_internal(CollectSolutionsIn { vars, store })
+	}
+
+	/// Find a solution that maximizes the given objective expression.
+	pub fn maximize(self, objective: impl Into<View<IntVal>>) -> (Status, Option<IntVal>)
+	where
+		Sat: ExternalPropagation + Assumptions,
+		State::Solver: solve_args::IsSet,
+	{
+		let objective = objective.into();
+		let (status, opt) = self.minimize(-objective);
+		(status, opt.map(|v| -v))
+	}
+
+	/// Enable exhaustive solution enumeration for selected decision variable
+	/// views.
+	///
+	/// When set, the solver will continue searching after finding the requested
+	/// solution, collecting all distinct solutions for the given views. In case
+	/// of:
+	/// - **Satisfiability checks**: It finds all feasible solutions
+	/// - **Optimization**: If finds all solutions with the same optimal
+	///   objective value
+	pub fn maybe_all_solutions<T: Into<AnyView>>(
+		self,
+		views: Option<impl IntoIterator<Item = T>>,
+	) -> SolveArgs<'a, Sat, S, F, solve_args::SetAllSolutions<State>>
+	where
+		State::AllSolutions: solve_args::IsUnset,
+	{
+		self.maybe_all_solutions_internal(views.map(|v| v.into_iter().map(|v| v.into()).collect()))
+	}
+
+	/// Find a solution that minimizes the given objective expression.
+	/// Implements branch-and-bound search, iteratively improving the solution
+	/// until proven optimal.
+	pub fn minimize(self, objective: impl Into<View<IntVal>>) -> (Status, Option<IntVal>)
+	where
+		Sat: ExternalPropagation + Assumptions,
+		State::Solver: solve_args::IsSet,
+	{
+		use Status::*;
+
+		// Process arguments
+		let SolveArgsComplete {
+			solver,
+			assuming,
+			mut on_solution,
+			on_failure,
+			all_solutions,
+			bind_using_clauses,
+		} = self.finalize_internal();
+		let mut bind_using_clauses = bind_using_clauses.unwrap_or(false);
+		if bind_using_clauses && all_solutions.is_some() {
+			warn!("bind_using_clauses option ignored because all_solutions is enabled");
+			bind_using_clauses = false;
+		}
+
+		// Process assumptions
+		let Ok(mut assumptions): Result<Vec<RawLit>, _> = assuming
+			.into_iter()
+			.filter_map(|bv| match bv.0 {
+				BoolView::Lit(lit) => Some(Ok(lit.0)),
+				BoolView::Const(true) => None,
+				BoolView::Const(false) => Some(Err(())),
+			})
+			.collect()
+		else {
+			if let Some(on_failure) = on_failure {
+				on_failure(&NoAssumptions);
+			}
+			return (Unsatisfiable, None);
+		};
+
+		// Start branch and bound loop
+		let objective = objective.into();
+		let mut obj_curr = None;
+		let obj_bound = objective.min(solver);
+		let mut obj_assump = None;
+		let mut vals: Vec<Value> = vec![
+			Value::Int(0);
+			if let Some(all_solutions) = &all_solutions {
+				all_solutions.len()
+			} else {
+				0
+			}
+		];
+
+		debug!(target: "solver", obj_bound, "start branch and bound");
+		let (status, obj) = loop {
+			let result = solver
+				.sat
+				.solve_assuming(assumptions.iter().cloned().chain(obj_assump));
+			match result {
+				SatSolveResult::Satisfied(ref sol) => {
+					let sol = Solution {
+						sat: sol,
+						state: &solver.engine.borrow().state,
+					};
+					obj_curr = Some(Valuation::val(&objective, sol));
+					if let Some(callback) = &mut on_solution {
+						callback.on_solution(sol);
+					}
+					if let Some(vars) = &all_solutions {
+						for (i, v) in vars.iter().enumerate() {
+							vals[i] = Valuation::val(v, sol);
+						}
+					}
+					debug!(
+						target: "solver",
+						?obj_curr,
+						obj_bound,
+						"sat solve result"
+					);
+				}
+				// Latest SAT solve was unsatisfiable:
+				// - If no previous solution was found, then the problem doesn't have any feasible
+				//   solutions.
+				// - If a previous solution was found, then the current bound is the best solution
+				//   under the current constraints and assumptions.
+				SatSolveResult::Unsatisfiable(fail) => {
+					break if obj_curr.is_none() {
+						if let Some(on_failure) = on_failure {
+							on_failure(&fail);
+						}
+						(Unsatisfiable, None)
+					} else {
+						(Complete, obj_curr)
+					};
+				}
+				// Latest SAT solve returned unknown: this indicates that the
+				// solver reached a search limit.
+				// We return `Satisfied` if we found at least one solution,
+				// and `Unknown` if we didn't find any solutions yet.
+				SatSolveResult::Unknown => {
+					break if obj_curr.is_none() {
+						(Unknown, None)
+					} else {
+						(Satisfied, obj_curr)
+					};
+				}
+			}
+			drop(result);
+
+			if obj_curr == Some(obj_bound) {
+				break (Complete, obj_curr);
+			} else {
+				let bound_lit = objective.lit(solver, IntLitMeaning::Less(obj_curr.unwrap()));
+				debug!(
+					target: "solver",
+					clause = bind_using_clauses,
+					lit = i32::from({
+						let BoolView::Lit(l) = bound_lit.0 else {
+							unreachable!()
+						};
+						l.0
+					}),
+					"add objective bound"
+				);
+				if bind_using_clauses {
+					solver.add_clause([bound_lit]).unwrap();
+				} else {
+					let BoolView::Lit(l) = bound_lit.0 else {
+						unreachable!()
+					};
+					obj_assump = Some(l.0);
+				}
+			}
+		};
+		if all_solutions.is_none() || status != Complete {
+			return (status, obj);
+		}
+
+		// Continue to look for all other solutions with the same objective value.
+		// Solutions already visited are added as (permanent) no-good clauses.
+		let vars = all_solutions.unwrap();
+		let BoolView::Lit(opt_lit) = objective
+			.lit(solver, IntLitMeaning::Eq(obj_curr.unwrap()))
+			.0
+		else {
+			unreachable!()
+		};
+		assumptions.push(opt_lit.0);
+		loop {
+			solver.add_no_good(&vars, &vals).unwrap();
+
+			let result = solver.sat.solve_assuming(assumptions.clone());
+			match result {
+				SatSolveResult::Satisfied(ref sol) => {
+					let sol = Solution {
+						sat: sol,
+						state: &solver.engine.borrow().state,
+					};
+					obj_curr = Some(Valuation::val(&objective, sol));
+					if let Some(callback) = &mut on_solution {
+						callback.on_solution(sol);
+					}
+					for (i, v) in vars.iter().enumerate() {
+						vals[i] = Valuation::val(v, sol);
+					}
+					debug!(
+						target: "solver",
+						?obj_curr,
+						obj_bound,
+						"sat solve result"
+					);
+				}
+				SatSolveResult::Unsatisfiable(_) => break (Complete, obj_curr),
+				SatSolveResult::Unknown => break (Satisfied, obj_curr),
+			}
+		}
+	}
+
+	/// Register a failure callback for assumption analysis.
+	///
+	/// The callback is invoked when the SAT solver reports unsatisfiability.
+	/// It receives an [`AssumptionChecker`] object that can determine which
+	/// assumptions contributed to the conflict.
+	pub fn on_failure<NewF>(
+		self,
+		on_failure: NewF,
+	) -> SolveArgs<'a, Sat, S, NewF, solve_args::SetOnFailure<State>>
+	where
+		State::OnFailure: solve_args::IsUnset,
+		NewF: FnOnce(&dyn AssumptionChecker),
+	{
+		self.with_f::<NewF>().on_failure_internal(on_failure)
+	}
+
+	/// Register a solution callback.
+	///
+	/// The callback is invoked each time a solution is found:
+	/// - For satisfiability checks: called at most once
+	/// - For optimization: called each time a better solution is found
+	/// - For all-solutions: called for each distinct solution
+	pub fn on_solution<NewS>(
+		self,
+		on_solution: NewS,
+	) -> SolveArgs<'a, Sat, NewS, F, solve_args::SetOnSolution<State>>
+	where
+		State::OnSolution: solve_args::IsUnset,
+		NewS: for<'b> FnMut(Solution<'b>),
+	{
+		self.with_s::<NewS>().on_solution_internal(on_solution)
+	}
+
+	/// Execute a satisfiability check.
+	///
+	/// Searches for any assignment satisfying all constraints and assumptions.
+	/// The search generally terminates as soon as a solution is found (or when
+	/// we determine no solution is possible). However, if `all_solutions` is
+	/// set, the search will continue to enumerate all feasible solutions.
+	pub fn satisfy(self) -> Status
+	where
+		Sat: ExternalPropagation + Assumptions,
+		State: solve_args::IsComplete,
+	{
+		let SolveArgsComplete {
+			solver,
+			assuming,
+			mut on_solution,
+			on_failure,
+			all_solutions,
+			..
+		} = self.finalize_internal();
+
+		// Process assumptions
+		let Ok(assumptions): Result<Vec<RawLit>, _> = assuming
+			.into_iter()
+			.filter_map(|bv| match bv.0 {
+				BoolView::Lit(lit) => Some(Ok(lit.0)),
+				BoolView::Const(true) => None,
+				BoolView::Const(false) => Some(Err(())),
+			})
+			.collect()
+		else {
+			if let Some(on_failure) = on_failure {
+				on_failure(&NoAssumptions);
+			}
+			return Status::Unsatisfiable;
+		};
+
+		let mut has_solution = false;
+		loop {
+			let result = solver.sat.solve_assuming(assumptions.clone());
+			let vals: Vec<_> = match result {
+				SatSolveResult::Satisfied(ref sol) => {
+					let sol = Solution {
+						sat: sol,
+						state: &solver.engine.borrow().state,
+					};
+					has_solution = true;
+					if let Some(callback) = &mut on_solution {
+						callback.on_solution(sol);
+					}
+					if let Some(vars) = &all_solutions {
+						vars.iter().map(|v| v.val(sol)).collect()
+					} else {
+						break Status::Satisfied;
+					}
+				}
+				SatSolveResult::Unsatisfiable(fail) => {
+					if let Some(on_failure) = on_failure {
+						on_failure(&fail);
+					}
+					break if has_solution {
+						Status::Complete
+					} else {
+						Status::Unsatisfiable
+					};
+				}
+				SatSolveResult::Unknown => {
+					break if has_solution {
+						Status::Satisfied
+					} else {
+						Status::Unknown
+					};
+				}
+			};
+			drop(result);
+
+			debug_assert!(all_solutions.is_some());
+			let vars = all_solutions.as_ref().unwrap();
+			if solver.add_no_good(vars, &vals).is_err() {
+				break Status::Complete;
+			}
+		}
+	}
+}
+
 impl<Sat: ClauseDatabase> Solver<Sat> {
 	/// Add a clause to the solver
 	pub fn add_clause<Iter>(
@@ -292,6 +841,118 @@ impl<Sat: ClauseDatabase> Solver<Sat> {
 }
 
 impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
+	/// Solve the problem given the current state.
+	///
+	/// This is the main entry point for all solving operations. It returns a
+	/// fluent builder API that allows configuring solve options and callbacks
+	/// before execution.
+	///
+	/// # Examples
+	///
+	/// Simple satisfiability solving:
+	/// ```
+	/// # use huub::{
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Status},
+	/// # };
+	/// # let mut model = Model::default();
+	/// # let (mut solver, _): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// let status = solver.solve().satisfy();
+	/// assert_eq!(status, Status::Satisfied);
+	/// # Ok::<(), Box<dyn std::error::Error>>(())
+	/// ```
+	///
+	/// Satisfiability with callback to inspect solution:
+	/// ```
+	/// # use huub::{
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Status, Valuation},
+	/// # };
+	/// # let mut model = Model::default();
+	/// # let x = model.new_int_decision(1..=4);
+	/// # model.linear(x).ne(2).post();
+	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let x = map.get(&mut solver, x);
+	/// let mut value = None;
+	/// let status = solver
+	/// 	.solve()
+	/// 	.on_solution(|solution| {
+	/// 		value = Some(x.val(solution));
+	/// 	})
+	/// 	.satisfy();
+	/// assert_eq!(status, Status::Satisfied);
+	/// assert_ne!(value, Some(2));
+	/// # Ok::<(), Box<dyn std::error::Error>>(())
+	/// ```
+	///
+	/// Optimization with callbacks:
+	/// ```
+	/// # use huub::{
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Status, Valuation},
+	/// # };
+	/// # let mut model = Model::default();
+	/// # let x = model.new_int_decision(1..=4);
+	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let x = map.get(&mut solver, x);
+	/// let (status, optimum) = solver.solve().on_solution(|_| {}).minimize(x);
+	/// assert_eq!(status, Status::Complete);
+	/// assert_eq!(optimum, Some(1));
+	/// # Ok::<(), Box<dyn std::error::Error>>(())
+	/// ```
+	///
+	/// With assumptions for incremental solving:
+	/// ```
+	/// # use huub::{
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Status},
+	/// # };
+	/// # let mut model = Model::default();
+	/// # let b = model.new_bool_decision();
+	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let b = map.get(&mut solver, b);
+	/// let status = solver.solve().assuming([b]).on_failure(|_| {}).satisfy();
+	/// assert_eq!(status, Status::Satisfied);
+	/// # Ok::<(), Box<dyn std::error::Error>>(())
+	/// ```
+	///
+	/// Enumerating all solutions:
+	/// ```
+	/// # use huub::{
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Status, Valuation},
+	/// # };
+	/// # let mut model = Model::default();
+	/// # let x = model.new_int_decision(1..=3);
+	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let x = map.get(&mut solver, x);
+	/// let mut count = 0;
+	/// let status = solver
+	/// 	.solve()
+	/// 	.all_solutions([x])
+	/// 	.on_solution(|_| count += 1)
+	/// 	.satisfy();
+	/// assert_eq!(status, Status::Complete);
+	/// assert_eq!(count, 3);
+	/// # Ok::<(), Box<dyn std::error::Error>>(())
+	/// ```
+	pub fn solve<'a>(
+		&'a mut self,
+	) -> SolveArgs<
+		'a,
+		Sat,
+		for<'b> fn(Solution<'b>),
+		for<'b> fn(&'b dyn AssumptionChecker),
+		solve_args::SetSolver,
+	> {
+		SolveArgsComplete::builder_internal().solver_internal(self)
+	}
+
 	/// Try to find a solution to the problem for which the [`Solver`] was
 	/// initialized, using the given Boolean assumptions.
 	pub fn solve_assuming(
@@ -414,58 +1075,6 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 		}
 	}
 
-	/// Find all solutions with respect to a list of given variables.
-	/// The given closure will be called for each solution found.
-	///
-	/// WARNING: This method will add additional clauses into the solver to
-	/// prevent the same solution from being generated twice. This will make
-	/// repeated use of the Solver object impossible. Note that you can clone
-	/// the Solver object before calling this method to work around this
-	/// limitation.
-	pub fn all_solutions(
-		mut self,
-		vars: &[AnyView],
-		mut on_sol: impl FnMut(Solution<'_>),
-	) -> (Status, SolverStatistics) {
-		use Status::*;
-
-		let ret = |x: Self, status: Status| (status, x.solver_statistics());
-
-		let mut num_sol = 0;
-		loop {
-			let mut vals = Vec::with_capacity(vars.len());
-			let status = self.solve(|sol| {
-				num_sol += 1;
-				for v in vars {
-					vals.push(v.val(sol));
-				}
-				on_sol(sol);
-			});
-			match status {
-				Satisfied => {
-					if self.add_no_good(vars, &vals).is_err() {
-						return ret(self, Complete);
-					}
-				}
-				Unsatisfiable => {
-					if num_sol == 0 {
-						return ret(self, Unsatisfiable);
-					} else {
-						return ret(self, Complete);
-					}
-				}
-				Unknown => {
-					if num_sol == 0 {
-						return ret(self, Unknown);
-					} else {
-						return ret(self, Satisfied);
-					}
-				}
-				_ => unreachable!(),
-			}
-		}
-	}
-
 	/// Split the solver into a solving actions object that limits interaction
 	/// with the SAT solver, and the dynamic engine reference.
 	pub(crate) fn as_parts_mut(&mut self) -> (impl SolvingActions + '_, RefMut<'_, Engine>) {
@@ -488,131 +1097,6 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 		(SA(&mut self.sat), self.engine.borrow_mut())
 	}
 
-	/// Find an optimal solution with respect to the given objective and goal.
-	///
-	/// Note that this method repeatedly adds objective-bound clauses. It takes
-	/// ownership of the solver, so these clauses do not affect any cloned
-	/// solver that existed before the call.
-	///
-	/// ```
-	/// # use huub::{
-	/// #     lower::InitConfig,
-	/// #     model::Model,
-	/// #     solver::{Goal, IntValuation, Solver, Status},
-	/// # };
-	/// # let mut model = Model::default();
-	/// # let x = model.new_int_decision(0..=10);
-	/// # model.linear(x).ge(3).post();
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
-	/// # let x = map.get(&mut solver, x);
-	/// let mut best = None;
-	/// let (status, _, optimum) = solver.branch_and_bound(Goal::Minimize(x), |solution| {
-	///     best = Some(x.val(solution));
-	/// });
-	///
-	/// assert_eq!(status, Status::Complete);
-	/// assert_eq!(optimum, Some(3));
-	/// # Ok::<(), Box<dyn std::error::Error>>(())
-	/// ```
-	pub fn branch_and_bound(
-		mut self,
-		goal: Goal<View<IntVal>>,
-		mut on_sol: impl FnMut(Solution<'_>),
-	) -> (Status, SolverStatistics, Option<IntVal>) {
-		use Status::*;
-		let ret =
-			|x: Self, status: Status, obj: Option<IntVal>| (status, x.solver_statistics(), obj);
-
-		let mut obj_curr = None;
-		let (obj_bound, objective) = match goal {
-			Goal::Minimize(objective) => (objective.min(&self), objective),
-			Goal::Maximize(objective) => (objective.max(&self), objective),
-		};
-		debug!(target: "solver", obj_bound, "start branch and bound");
-		loop {
-			let status = self.solve(|sol| {
-				obj_curr = Some(IntValuation::val(&objective, sol));
-				on_sol(sol);
-			});
-			debug!(
-				target: "solver",
-				?status,
-				?obj_curr,
-				obj_bound,
-				goal = %if goal == Goal::Minimize(objective) { "Minimize" } else { "Maximize" },
-				"sat solve result"
-			);
-			match status {
-				Satisfied => {
-					if obj_curr == Some(obj_bound) {
-						return ret(self, Complete, obj_curr);
-					} else {
-						let bound_lit = match goal {
-							Goal::Minimize(_) => Some(
-								objective.lit(&mut self, IntLitMeaning::Less(obj_curr.unwrap())),
-							),
-							Goal::Maximize(_) => {
-								Some(objective.lit(
-									&mut self,
-									IntLitMeaning::GreaterEq(obj_curr.unwrap() + 1),
-								))
-							}
-						};
-						debug!(
-							target: "solver",
-							lit = i32::from({
-								let BoolView::Lit(l) = bound_lit.unwrap().0 else {
-									unreachable!()
-								};
-								l.0
-							}),
-							"add objective bound"
-						);
-						self.add_clause([bound_lit.unwrap()]).unwrap();
-					}
-				}
-				Unsatisfiable => {
-					return if obj_curr.is_none() {
-						ret(self, Unsatisfiable, None)
-					} else {
-						ret(self, Complete, obj_curr)
-					};
-				}
-				Unknown => {
-					return if obj_curr.is_none() {
-						ret(self, Unknown, None)
-					} else {
-						ret(self, Satisfied, obj_curr)
-					};
-				}
-				Complete => unreachable!(),
-			}
-		}
-	}
-
-	/// Wrapper function for `all_solutions` that collects all solutions and
-	/// returns them in a vector of solution values.
-	///
-	/// WARNING: This method will add additional clauses into the solver to
-	/// prevent the same solution from being generated twice. This will make
-	/// repeated use of the Solver object impossible. Note that you can clone
-	/// the Solver object before calling this method to work around this
-	/// limitation.
-	pub fn collect_all_solutions(
-		self,
-		vars: &[AnyView],
-	) -> (Status, SolverStatistics, Vec<Vec<Value>>) {
-		let mut solutions = Vec::new();
-		let (status, stats) = self.all_solutions(vars, |sol| {
-			let mut sol_vec = Vec::with_capacity(vars.len());
-			for v in vars {
-				sol_vec.push(v.val(sol));
-			}
-			solutions.push(sol_vec);
-		});
-		(status, stats, solutions)
-	}
-
 	/// Access the initialization statistics of the [`Solver`] object.
 	pub fn init_statistics(&self) -> InitStatistics {
 		InitStatistics {
@@ -633,48 +1117,6 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 	/// Set the overarching search strategy to use during solving.
 	pub fn set_search_strategy(&mut self, strategy: SearchStrategy) {
 		self.engine.borrow_mut().state.set_search_strategy(strategy);
-	}
-
-	/// Try to find a solution to the problem for which the [`Solver`] was
-	/// initialized.
-	///
-	/// The callback is called at most once, when the solver finds a satisfying
-	/// assignment.
-	///
-	/// ```
-	/// # use huub::{
-	/// #     lower::InitConfig,
-	/// #     model::Model,
-	/// #     solver::{IntValuation, Solver, Status},
-	/// # };
-	/// # let mut model = Model::default();
-	/// # let x = model.new_int_decision(1..=4);
-	/// # model.linear(x).ne(2).post();
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
-	/// # let x = map.get(&mut solver, x);
-	/// let mut value = None;
-	/// let status = solver.solve(|solution| {
-	///     value = Some(x.val(solution));
-	/// });
-	///
-	/// assert_eq!(status, Status::Satisfied);
-	/// assert_ne!(value, Some(2));
-	/// # Ok::<(), Box<dyn std::error::Error>>(())
-	/// ```
-	pub fn solve(&mut self, mut on_sol: impl FnMut(Solution<'_>)) -> Status {
-		let result = self.sat.solve();
-		match result {
-			SatSolveResult::Satisfied(value) => {
-				let sol = Solution {
-					sat: &value,
-					state: &self.engine.borrow().state,
-				};
-				on_sol(sol);
-				Status::Satisfied
-			}
-			SatSolveResult::Unsatisfiable(_) => Status::Unsatisfiable,
-			SatSolveResult::Unknown => Status::Unknown,
-		}
 	}
 
 	/// Access the solver statistics for the search process up to this point.

--- a/crates/huub/src/solver/branchers.rs
+++ b/crates/huub/src/solver/branchers.rs
@@ -211,12 +211,12 @@ impl IntBrancher {
 	///
 	/// ```
 	/// # use huub::{
-	/// #     lower::InitConfig,
-	/// #     model::Model,
-	/// #     solver::{
-	/// #         branchers::{IntBrancher, ValueSelection, VariableSelection},
-	/// #         IntValuation, Solver, Status,
-	/// #     },
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{
+	/// # 		Solver, Status, Valuation,
+	/// # 		branchers::{IntBrancher, ValueSelection, VariableSelection},
+	/// # 	},
 	/// # };
 	/// # let mut model = Model::default();
 	/// # let x = model.new_int_decision(1..=3);
@@ -226,15 +226,18 @@ impl IntBrancher {
 	/// # let x = map.get(&mut solver, x);
 	/// # let y = map.get(&mut solver, y);
 	/// IntBrancher::new_in(
-	///     &mut solver,
-	///     vec![x, y],
-	///     VariableSelection::FirstFail,
-	///     ValueSelection::IndomainMin,
+	/// 	&mut solver,
+	/// 	vec![x, y],
+	/// 	VariableSelection::FirstFail,
+	/// 	ValueSelection::IndomainMin,
 	/// );
 	///
-	/// # let status = solver.solve(|solution| {
-	/// #     assert_eq!(x.val(solution) + y.val(solution), 4);
-	/// # });
+	/// # let status = solver
+	/// # 	.solve()
+	/// # 	.on_solution(|solution| {
+	/// # 		assert_eq!(x.val(solution) + y.val(solution), 4);
+	/// # 	})
+	/// # 	.satisfy();
 	/// # assert_eq!(status, Status::Satisfied);
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
 	/// ```
@@ -351,10 +354,10 @@ impl WarmStartBrancher {
 	///
 	/// ```
 	/// # use huub::{
-	/// #     actions::IntDecisionActions,
-	/// #     lower::InitConfig,
-	/// #     model::Model,
-	/// #     solver::{branchers::WarmStartBrancher, IntLitMeaning, IntValuation, Solver, Status},
+	/// # 	actions::IntDecisionActions,
+	/// # 	lower::InitConfig,
+	/// # 	model::Model,
+	/// # 	solver::{IntLitMeaning, Solver, Status, Valuation, branchers::WarmStartBrancher},
 	/// # };
 	/// # let mut model = Model::default();
 	/// # let x = model.new_int_decision(1..=3);
@@ -364,9 +367,12 @@ impl WarmStartBrancher {
 	/// WarmStartBrancher::new_in(&mut solver, vec![prefer_two]);
 	///
 	/// # let mut value = None;
-	/// # let status = solver.solve(|solution| {
-	/// #     value = Some(x.val(solution));
-	/// # });
+	/// # let status = solver
+	/// # 	.solve()
+	/// # 	.on_solution(|solution| {
+	/// # 		value = Some(x.val(solution));
+	/// # 	})
+	/// # 	.satisfy();
 	/// # assert_eq!(status, Status::Satisfied);
 	/// # assert_eq!(value, Some(2));
 	/// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/crates/huub/src/solver/solution.rs
+++ b/crates/huub/src/solver/solution.rs
@@ -3,7 +3,7 @@
 
 use std::fmt::{self, Debug, Display, Formatter};
 
-use pindakaas::Valuation;
+use pindakaas::Valuation as RawValuation;
 
 use crate::{
 	IntVal,
@@ -28,18 +28,6 @@ pub enum AnyView {
 	Int(View<IntVal>),
 }
 
-/// Trait for extracting a Boolean value from a solution.
-pub trait BoolValuation {
-	/// Return the Boolean value for this view in the given solution.
-	fn val(&self, sol: Solution<'_>) -> bool;
-}
-
-/// Trait for extracting an integer value from a solution.
-pub trait IntValuation {
-	/// Return the integer value for this view in the given solution.
-	fn val(&self, sol: Solution<'_>) -> IntVal;
-}
-
 /// Reference to a solution state of the [`Solver`](crate::solver::Solver).
 ///
 /// Solution allows the user to query the values that decision variable have
@@ -47,9 +35,19 @@ pub trait IntValuation {
 #[derive(Clone, Copy)]
 pub struct Solution<'a> {
 	/// SAT valuation used to retrieve Boolean assignments.
-	pub(crate) sat: &'a dyn Valuation,
+	pub(crate) sat: &'a dyn RawValuation,
 	/// Solver state used to resolve integer values and views.
 	pub(crate) state: &'a State,
+}
+
+/// Trait for extracting a solution value from a [`Solution`] for a given
+/// decision variable view.
+pub trait Valuation {
+	/// The type of value associated with this view in a solution.
+	type Val;
+
+	/// Return the value for this view in the given solution.
+	fn val(&self, sol: Solution<'_>) -> Self::Val;
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -63,16 +61,6 @@ pub enum Value {
 	Bool(bool),
 	/// An integer value.
 	Int(IntVal),
-}
-
-impl AnyView {
-	/// Return the value of this view in the given solution.
-	pub fn val(&self, sol: Solution<'_>) -> Value {
-		match self {
-			AnyView::Bool(view) => Value::Bool(BoolValuation::val(view, sol)),
-			AnyView::Int(view) => Value::Int(IntValuation::val(view, sol)),
-		}
-	}
 }
 
 impl From<IntVal> for AnyView {
@@ -93,13 +81,21 @@ impl From<View<bool>> for AnyView {
 	}
 }
 
-impl BoolValuation for Decision<bool> {
-	fn val(&self, sol: Solution<'_>) -> bool {
-		sol.sat.value(self.0)
+impl Valuation for AnyView {
+	type Val = Value;
+
+	/// Return the value of this view in the given solution.
+	fn val(&self, sol: Solution<'_>) -> Value {
+		match self {
+			AnyView::Bool(view) => Value::Bool(view.val(sol)),
+			AnyView::Int(view) => Value::Int(Valuation::val(view, sol)),
+		}
 	}
 }
 
-impl IntValuation for Decision<IntVal> {
+impl Valuation for Decision<IntVal> {
+	type Val = IntVal;
+
 	fn val(&self, sol: Solution<'_>) -> IntVal {
 		debug_assert_eq!(
 			IntInspectionActions::min(self, sol.state),
@@ -109,9 +105,17 @@ impl IntValuation for Decision<IntVal> {
 	}
 }
 
+impl Valuation for Decision<bool> {
+	type Val = bool;
+
+	fn val(&self, sol: Solution<'_>) -> bool {
+		sol.sat.value(self.0)
+	}
+}
+
 impl Debug for Solution<'_> {
 	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-		let sat_str: *const dyn Valuation = self.sat;
+		let sat_str: *const dyn RawValuation = self.sat;
 		f.debug_struct("Solution")
 			.field("sat", &(sat_str as *const std::ffi::c_void))
 			.field("state", &self.state)
@@ -140,21 +144,25 @@ impl From<bool> for Value {
 	}
 }
 
-impl BoolValuation for View<bool> {
-	fn val(&self, sol: Solution<'_>) -> bool {
+impl Valuation for View<IntVal> {
+	type Val = IntVal;
+
+	fn val(&self, sol: Solution<'_>) -> IntVal {
 		match self.0 {
-			BoolView::Lit(decision) => BoolValuation::val(&decision, sol),
-			BoolView::Const(b) => b,
+			IntView::Const(c) => c,
+			IntView::Linear(v) => Valuation::val(&v, sol),
+			IntView::Bool(v) => Valuation::val(&v, sol),
 		}
 	}
 }
 
-impl IntValuation for View<IntVal> {
-	fn val(&self, sol: Solution<'_>) -> IntVal {
+impl Valuation for View<bool> {
+	type Val = bool;
+
+	fn val(&self, sol: Solution<'_>) -> bool {
 		match self.0 {
-			IntView::Const(c) => c,
-			IntView::Linear(v) => IntValuation::val(&v, sol),
-			IntView::Bool(v) => IntValuation::val(&v, sol),
+			BoolView::Lit(decision) => decision.val(sol),
+			BoolView::Const(b) => b,
 		}
 	}
 }

--- a/crates/huub/src/tests.rs
+++ b/crates/huub/src/tests.rs
@@ -1,4 +1,8 @@
-use std::num::NonZero;
+use std::{
+	any::{Any, TypeId},
+	fmt::Debug,
+	num::NonZero,
+};
 
 use expect_test::{Expect, expect};
 use itertools::Itertools;
@@ -11,7 +15,7 @@ use crate::{
 	lower::{InitConfig, LoweringError},
 	model::{Model, deserialize::AnyView as ModelView},
 	solver::{
-		AnyView as SolverView, BoolValuation, IntValuation, Solver, Status, Value,
+		AnyView as SolverView, Solver, Status, Valuation, Value,
 		branchers::{IntBrancher, ValueSelection, VariableSelection},
 		decision::integer::{EncodingType, IntDecision},
 	},
@@ -33,9 +37,11 @@ fn it_works() {
 	let b = map.get(&mut slv, b);
 
 	assert_eq!(
-		slv.solve(|sol| {
-			assert_ne!(a.val(sol), b.val(sol));
-		}),
+		slv.solve()
+			.on_solution(|sol| {
+				assert_ne!(a.val(sol), b.val(sol));
+			})
+			.satisfy(),
 		Status::Satisfied
 	);
 }
@@ -155,8 +161,8 @@ fn test_duplicate_propagation() {
 	slv.expect_solutions(
 		&[a, b],
 		expect![[r#"
-    0, 0
-    0, 1"#]],
+		0, 0
+		0, 1"#]],
 	);
 }
 
@@ -193,10 +199,12 @@ fn test_unify_int_impossible() {
 	let b = map.get(&mut slv, b);
 
 	assert_eq!(
-		slv.solve(|sol| {
-			assert_eq!(a.val(sol), 5);
-			assert_eq!(b.val(sol), 2);
-		}),
+		slv.solve()
+			.on_solution(|sol| {
+				assert_eq!(a.val(sol), 5);
+				assert_eq!(b.val(sol), 2);
+			})
+			.satisfy(),
 		Status::Satisfied
 	);
 }
@@ -212,10 +220,16 @@ fn test_unify_int_lin_view_domains() {
 	let (mut slv, map): (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
 	let a = map.get(&mut slv, a);
 	let b = map.get(&mut slv, b);
+	let vars = vec![a, b];
 
-	let (res, _, solns) = slv.collect_all_solutions(&[a.into(), b.into()]);
+	let mut solns: Vec<Vec<i64>> = Vec::new();
+	let res = slv
+		.solve()
+		.all_solutions(vars.clone())
+		.collect_solutions_in(vars, &mut solns)
+		.satisfy();
 	assert_eq!(res, Status::Complete);
-	assert_eq!(solns, vec![vec![Value::Int(1), Value::Int(3)]]);
+	assert_eq!(solns, vec![vec![1, 3]]);
 }
 
 #[test]
@@ -330,32 +344,43 @@ impl Model {
 
 impl Solver {
 	pub(crate) fn assert_all_solutions<V: Into<SolverView> + Clone>(
-		self,
+		mut self,
 		vars: &[V],
 		pred: impl Fn(&[Value]) -> bool,
 	) {
 		let vars: Vec<_> = vars.iter().map(|v| v.clone().into()).collect();
-		let (status, _) = self.all_solutions(&vars, |sol| {
-			let mut soln = Vec::with_capacity(vars.len());
-			for var in &vars {
-				soln.push(var.val(sol));
-			}
-			assert!(pred(&soln));
-		});
+		let status = self
+			.solve()
+			.all_solutions(vars.clone())
+			.on_solution(|sol| {
+				let mut soln = Vec::with_capacity(vars.len());
+				for var in &vars {
+					soln.push(var.val(sol));
+				}
+				assert!(pred(&soln));
+			})
+			.satisfy();
 		assert_eq!(status, Status::Complete);
 	}
 
 	pub(crate) fn assert_unsatisfiable(&mut self) {
-		assert_eq!(self.solve(|_| unreachable!()), Status::Unsatisfiable);
+		assert_eq!(
+			self.solve().on_solution(|_| unreachable!()).satisfy(),
+			Status::Unsatisfiable
+		);
 	}
 
-	pub(crate) fn expect_solutions<V: Into<SolverView> + Clone>(
-		self,
-		vars: &[V],
-		expected: Expect,
-	) {
-		let vars: Vec<_> = vars.iter().map(|v| v.clone().into()).collect();
-		let (status, _, mut solns) = self.collect_all_solutions(&vars);
+	pub(crate) fn expect_solutions<V>(mut self, vars: &[V], expected: Expect)
+	where
+		V: Clone + Into<SolverView> + Valuation,
+		V::Val: Any + Debug + Ord,
+	{
+		let mut solns: Vec<Vec<V::Val>> = Vec::new();
+		let status = self
+			.solve()
+			.all_solutions(vars.iter().map(|v| v.clone().into()))
+			.collect_solutions_in(vars.to_vec(), &mut solns)
+			.satisfy();
 		assert_eq!(status, Status::Complete);
 		solns.sort();
 		let solns = format!(
@@ -363,9 +388,16 @@ impl Solver {
 			solns.iter().format_with("\n", |sol, f| {
 				f(&format_args!(
 					"{}",
-					sol.iter().format_with(", ", |elt, g| match elt {
-						Value::Bool(b) => g(&format_args!("{b}")),
-						Value::Int(i) => g(&format_args!("{i}")),
+					sol.iter().format_with(", ", |elt, g| {
+						if TypeId::of::<V::Val>() == TypeId::of::<Value>() {
+							let elt_any: &dyn Any = elt;
+							match elt_any.downcast_ref::<Value>().unwrap() {
+								Value::Bool(b) => g(&format_args!("{b}")),
+								Value::Int(i) => g(&format_args!("{i}")),
+							}
+						} else {
+							g(&format_args!("{elt:?}"))
+						}
 					})
 				))
 			})

--- a/crates/huub/src/views/linear_bool_view.rs
+++ b/crates/huub/src/views/linear_bool_view.rs
@@ -23,7 +23,7 @@ use crate::{
 	helpers::{div_ceil, div_floor},
 	solver::{
 		IntLitMeaning,
-		solution::{BoolValuation, IntValuation, Solution},
+		solution::{Solution, Valuation},
 	},
 	views::offset_view::OffsetView,
 };
@@ -437,16 +437,6 @@ where
 	}
 }
 
-impl<Var> IntValuation for LinearBoolView<NonZero<IntVal>, IntVal, Var>
-where
-	Var: BoolValuation,
-{
-	fn val(&self, sol: Solution<'_>) -> IntVal {
-		let b = self.var.val(sol);
-		self.transform_val(b as IntVal)
-	}
-}
-
 impl<Var> Mul<NonZero<IntVal>> for LinearBoolView<NonZero<IntVal>, IntVal, Var>
 where
 	Var: BoolOperations + Not<Output = Var>,
@@ -497,5 +487,17 @@ impl<Var> Sub<IntVal> for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
 impl<Var> SubAssign<IntVal> for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
 	fn sub_assign(&mut self, rhs: IntVal) {
 		self.offset -= rhs;
+	}
+}
+
+impl<Var> Valuation for LinearBoolView<NonZero<IntVal>, IntVal, Var>
+where
+	Var: Valuation<Val = bool>,
+{
+	type Val = IntVal;
+
+	fn val(&self, sol: Solution<'_>) -> IntVal {
+		let b = self.var.val(sol);
+		self.transform_val(b as IntVal)
 	}
 }

--- a/crates/huub/src/views/linear_view.rs
+++ b/crates/huub/src/views/linear_view.rs
@@ -20,7 +20,7 @@ use crate::{
 	helpers::{div_ceil, div_floor},
 	solver::{
 		IntLitMeaning,
-		solution::{IntValuation, Solution},
+		solution::{Solution, Valuation},
 	},
 	views::offset_view::OffsetView,
 };
@@ -398,15 +398,6 @@ where
 	}
 }
 
-impl<Var> IntValuation for LinearView<NonZero<IntVal>, IntVal, Var>
-where
-	Var: IntValuation,
-{
-	fn val(&self, sol: Solution<'_>) -> IntVal {
-		self.transform_val(self.var.val(sol))
-	}
-}
-
 impl<Var> Mul<NonZero<IntVal>> for LinearView<NonZero<IntVal>, IntVal, Var> {
 	type Output = Self;
 
@@ -443,5 +434,16 @@ impl<Var> Sub<IntVal> for LinearView<NonZero<IntVal>, IntVal, Var> {
 impl<Var> SubAssign<IntVal> for LinearView<NonZero<IntVal>, IntVal, Var> {
 	fn sub_assign(&mut self, rhs: IntVal) {
 		self.offset -= rhs;
+	}
+}
+
+impl<Var> Valuation for LinearView<NonZero<IntVal>, IntVal, Var>
+where
+	Var: Valuation<Val = IntVal>,
+{
+	type Val = IntVal;
+
+	fn val(&self, sol: Solution<'_>) -> IntVal {
+		self.transform_val(self.var.val(sol))
 	}
 }

--- a/crates/huub/src/views/offset_view.rs
+++ b/crates/huub/src/views/offset_view.rs
@@ -16,7 +16,7 @@ use crate::{
 	constraints::ReasonBuilder,
 	solver::{
 		IntLitMeaning,
-		solution::{IntValuation, Solution},
+		solution::{Solution, Valuation},
 	},
 	views::linear_view::LinearView,
 };
@@ -229,20 +229,22 @@ where
 	}
 }
 
-impl<Var> IntValuation for OffsetView<IntVal, Var>
-where
-	Var: IntValuation,
-{
-	fn val(&self, sol: Solution<'_>) -> IntVal {
-		self.var.val(sol) + self.offset
-	}
-}
-
 impl<Var> Neg for OffsetView<IntVal, Var> {
 	type Output = LinearView<NonZero<IntVal>, IntVal, Var>;
 
 	fn neg(self) -> Self::Output {
 		let lin: LinearView<NonZero<IntVal>, IntVal, Var> = self.into();
 		-lin
+	}
+}
+
+impl<Var> Valuation for OffsetView<IntVal, Var>
+where
+	Var: Valuation<Val = IntVal>,
+{
+	type Val = IntVal;
+
+	fn val(&self, sol: Solution<'_>) -> IntVal {
+		self.var.val(sol) + self.offset
 	}
 }

--- a/docs/src/modelling/getting-started.md
+++ b/docs/src/modelling/getting-started.md
@@ -92,14 +92,14 @@ This version of the decision variables will allow us to query the solution for t
 ### Running the solver
 
 Now we can search for solutions.
-For a simple constraint satisfaction problem (finding one solution without optimization), we use the `solve()` method with a callback:
+For a simple constraint satisfaction problem (finding one solution without optimization), we use the `solve()` builder with an `on_solution()` callback and finish with `satisfy()`:
 
 ```rust,ignore
 {{#include ../../../crates/huub/examples/send-more-money/main.rs:solve_and_print}}
 ```
 
 The callback function is called if a solution is found.
-Inside the callback, you can query decision variable values using the `val` method from the `IntValuation` trait.
+Inside the callback, you can query decision variable values using the `val` method from the `Valuation` trait.
 If no solution is found (either because of a set search limit or because none exists), then the callback is never called.
 
 ## Understanding the solving process

--- a/docs/src/modelling/search-branching.md
+++ b/docs/src/modelling/search-branching.md
@@ -88,7 +88,7 @@ To use a brancher, create it with a list of decisions, a decision selection stra
 # 	model::Model,
 # 	solver::{
 # 		branchers::{IntBrancher, ValueSelection, VariableSelection},
-# 		IntValuation, Solver,
+# 		Solver, Valuation,
 # 	},
 # };
 # let mut model = Model::default();
@@ -106,9 +106,12 @@ IntBrancher::new_in(
 	ValueSelection::IndomainMin,
 );
 
-solver.solve(|sol| {
-	println!("Found solution: x={}, y={}", x.val(sol), y.val(sol));
-});
+solver
+	.solve()
+	.on_solution(|sol| {
+		println!("Found solution: x={}, y={}", x.val(sol), y.val(sol));
+	})
+	.satisfy();
 ```
 
 **Note:** Once you have assigned all branchers to the solver, any remaining unfixed decisions will be handled by the SAT solver's automatic heuristics.
@@ -141,16 +144,19 @@ let warm_start_decisions = vec![b, x.lit(&mut solver, IntLitMeaning::Eq(5))];
 // Create and register the warm-start brancher
 WarmStartBrancher::new_in(&mut solver, warm_start_decisions);
 
-solver.solve(|solution| {
-	println!("Found solution");
-});
+solver
+	.solve()
+	.on_solution(|solution| {
+		println!("Found solution");
+	})
+	.satisfy();
 ```
 
 The warm-start brancher will try to enforce these decisions first, potentially finding a solution much faster than exploring from scratch.
 
 ## Finding Solutions
 
-Once you have created a solver, you can search for solutions using the `solve()` method:
+Once you have created a solver, you can search for solutions using the `solve()` builder:
 
 ```rust
 # extern crate huub;
@@ -162,10 +168,13 @@ Once you have created a solver, you can search for solutions using the `solve()`
 # let mut model = Model::default();
 # let x = model.new_int_decision(1..=9);
 # let (mut solver, _): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
-let status = solver.solve(|solution| {
-	// This callback is invoked if a solution is found.
-	println!("Found a solution!");
-});
+let status = solver
+	.solve()
+	.on_solution(|solution| {
+		// This callback is invoked if a solution is found.
+		println!("Found a solution!");
+	})
+	.satisfy();
 
 match status {
 	Status::Satisfied => println!("Found a solution"),
@@ -175,7 +184,7 @@ match status {
 }
 ```
 
-The `solve()` method returns immediately after finding the first solution.
+The `solve()` builder returns immediately after finding the first solution once you call `satisfy()`.
 For some applications, this is sufficient—you have a valid assignment to all decision variables.
 
 ## Setting Termination Limits
@@ -207,9 +216,12 @@ solver.set_terminate_callback(Some(move || {
 	}
 }));
 
-let status = solver.solve(|solution| {
-	println!("Found solution");
-});
+let status = solver
+	.solve()
+	.on_solution(|solution| {
+		println!("Found solution");
+	})
+	.satisfy();
 
 match status {
 	Status::Satisfied => println!("Found solution within time limit"),
@@ -230,7 +242,7 @@ When the callback returns `TerminationSignal::Terminate`, the solver will abando
 
 ## Finding Optimal Solutions
 
-To find the *best* solution (minimizing or maximizing an objective), Huub provides the `branch_and_bound()` method.
+To find the *best* solution (minimizing or maximizing an objective), use the `solve()` builder with `minimize()` or `maximize()`.
 This performs an iterative search: after finding each solution, it adds a constraint that the next solution must be better, and continues searching.
 
 ```rust
@@ -238,7 +250,7 @@ This performs an iterative search: after finding each solution, it adds a constr
 # use huub::{
 # 	lower::InitConfig,
 # 	model::Model,
-# 	solver::{Goal, IntValuation, Solver, Status},
+# 	solver::{Solver, Status, Valuation},
 # };
 # let mut model = Model::default();
 # let x = model.new_int_decision(0..=100);
@@ -246,11 +258,10 @@ This performs an iterative search: after finding each solution, it adds a constr
 # let cost = model.linear(x + y).define();
 # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
 # let cost = map.get(&mut solver, cost);
-let (status, stats, optimal_cost) = solver.branch_and_bound(
-	Goal::Minimize(cost),
-	// This callback is invoked for each solution that is found.
-	|sol| println!("Found (better) solution with cost {}", cost.val(sol)),
-);
+let (status, optimal_cost) = solver
+	.solve()
+	.on_solution(|sol| println!("Found (better) solution with cost {}", cost.val(sol)))
+	.minimize(cost);
 
 match status {
 	Status::Complete => {
@@ -282,7 +293,7 @@ For a maximization goal, it adds a constraint that the objective must be greater
 
 ## Finding All Solutions
 
-To find all possible solutions (not just the first one or the optimal one), use the `all_solutions()` method.
+To find all possible solutions (not just the first one or the optimal one), use `solve().all_solutions(...)`.
 This is useful for exploring the solution space, enumerating all valid assignments, or finding Pareto-optimal solutions.
 
 ```rust
@@ -290,7 +301,7 @@ This is useful for exploring the solution space, enumerating all valid assignmen
 # use huub::{
 # 	lower::InitConfig,
 # 	model::Model,
-# 	solver::{IntValuation, Solver, Status},
+# 	solver::{Solver, Status, Valuation},
 # };
 # let mut model = Model::default();
 # let x = model.new_int_decision(1..=3);
@@ -300,10 +311,14 @@ This is useful for exploring the solution space, enumerating all valid assignmen
 # let x = map.get(&mut solver, x);
 # let y = map.get(&mut solver, y);
 let mut num_sol = 0;
-let (status, stats) = solver.all_solutions(&vec![x.into(), y.into()], |solution| {
-	num_sol += 1;
-	println!("Solution: x={}, y={}", x.val(solution), y.val(solution));
-});
+let status = solver
+	.solve()
+	.all_solutions([x, y])
+	.on_solution(|solution| {
+		num_sol += 1;
+		println!("Solution: x={}, y={}", x.val(solution), y.val(solution));
+	})
+	.satisfy();
 
 match status {
 	Status::Complete => {
@@ -319,7 +334,7 @@ match status {
 }
 ```
 
-The method works by iteratively finding solutions and then adding "no-good" constraints that exclude each found solution from future searches.
+The builder works by iteratively finding solutions and then adding "no-good" constraints that exclude each found solution from future searches.
 The solver continues until either:
 
 - **Complete**: All solutions have been enumerated (trying to find another solution fails).
@@ -339,7 +354,7 @@ You can retrieve statistics about the search process to understand solver behavi
 # use huub::{lower::InitConfig, model::Model, solver::Solver};
 # let mut model = Model::default();
 # let (mut solver, _): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
-# let _ = solver.solve(|_| {});
+# let _ = solver.solve().on_solution(|_| {}).satisfy();
 let stats = solver.solver_statistics();
 
 println!("Conflicts: {}", stats.conflicts);

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+format_code_in_doc_comments = true
 group_imports = "StdExternalCrate"
 hard_tabs = true
 imports_granularity = "Crate"


### PR DESCRIPTION
Replace the direct solver entry points with a fluent builder-based `solve()` API.

This changes solving to go through `SolveArgs`, allowing search options,
callbacks, assumptions, solution collection, and optimization goals to be
configured incrementally without expanding the top-level solver surface.

Highlights:
- Folded satisfiability, optimization, and all-solutions behavior into `solve()`.
- Added builder steps for callbacks, assumptions, and exhaustive enumeration.
- Moved optimization goal handling out of `Solver` and into model deserialization.
- Updated FlatZinc/CLI integration to use the new builder flow.
- Refreshed documentation and doc tests to match the new API.

Breaking change: existing direct solve/branch-and-bound/all-solutions call
patterns must be rewritten to the builder chain.
