### PR TITLE
feat: refactor lowering API to a fluent builder pattern

### DIFF
--- a/crates/huub-cli/src/cli.rs
+++ b/crates/huub-cli/src/cli.rs
@@ -15,7 +15,7 @@ use clap::{
 	ArgAction, ColorChoice, Parser, ValueEnum,
 	builder::{BoolishValueParser, StyledStr, styling::Styles},
 };
-use huub::lower::InitConfig;
+use huub::lower::Lowerer;
 use tracing_subscriber::fmt::writer::BoxMakeWriter;
 
 /// Long description for the command-line interface.
@@ -109,11 +109,11 @@ pub struct Cli<'a> {
 	pub(crate) color: ColorChoice,
 
 	/// Maximum domain size for eagerly creating order literals.
-	#[arg(long, value_name = "usize", default_value_t = InitConfig::default().int_eager_limit(), help_heading = CLI_SECTION_INIT)]
+	#[arg(long, value_name = "usize", default_value_t = Lowerer::DEFAULT_INT_EAGER_LIMIT, help_heading = CLI_SECTION_INIT)]
 	pub(crate) int_eager_limit: usize,
 
 	/// Control whether the solver may restart, overwritten by `-f`.
-	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = InitConfig::default().restart(), help_heading = CLI_SECTION_SEARCH)]
+	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_RESTART, help_heading = CLI_SECTION_SEARCH)]
 	pub(crate) restart: bool,
 	/// Set the overarching search strategy used by the solver, overwritten by
 	/// `-f`.
@@ -134,34 +134,34 @@ pub struct Cli<'a> {
 	pub(crate) search_interval: u64,
 
 	/// Control globally blocked clause elimination (conditioning).
-	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = InitConfig::default().conditioning(), help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_CONDITIONING, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) conditioning: bool,
 	/// Control SAT inprocessing during search.
-	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = InitConfig::default().inprocessing(), help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_INPROCESSING, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) inprocessing: bool,
 	/// Run the given number of SAT preprocessing rounds before search.
 	#[arg(
 		long,
 		value_name = "usize",
-		default_value_t = InitConfig::default().preprocessing(),
+		default_value_t = Lowerer::DEFAULT_PREPROCESSING,
 		help_heading = CLI_SECTION_PROCESSING
 	)]
 	pub(crate) preprocessing: usize,
 	/// Control failed-literal probing in the SAT solver.
-	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = InitConfig::default().probing(), help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_PROBING, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) probing: bool,
 	/// Request explanation clauses for all literals propagated at the conflict
 	/// level.
-	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = InitConfig::default().reason_eager(), help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_REASON_EAGER, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) reason_eager: bool,
 	/// Control global forward subsumption in the SAT solver.
-	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = InitConfig::default().subsumption(), help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_SUBSUMPTION, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) subsumption: bool,
 	/// Control bounded variable elimination in the SAT solver.
-	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = InitConfig::default().variable_elimination(), help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_VARIABLE_ELIMINATION, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) variable_elimination: bool,
 	/// Control clause vivification.
-	#[arg(long = "vivify", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = InitConfig::default().vivification(), help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long = "vivify", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_VIVIFICATION, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) vivification: bool,
 
 	// --- API options, not set through CLI ---
@@ -241,24 +241,6 @@ fn parse_time_limit(s: &str) -> Result<Duration, humantime::DurationError> {
 }
 
 impl<'a> Cli<'a> {
-	/// Build the solver initialization configuration from the CLI arguments.
-	pub(crate) fn init_config(&self) -> InitConfig {
-		let mut config = InitConfig::default();
-		config = config
-			.with_int_eager_limit(self.int_eager_limit)
-			.with_preprocessing(self.preprocessing)
-			.with_conditioning(self.conditioning)
-			.with_inprocessing(self.inprocessing)
-			.with_probing(self.probing)
-			.with_reason_eager(self.reason_eager)
-			.with_restart(self.free_search || self.restart)
-			.with_subsumption(self.subsumption)
-			.with_variable_elimination(self.variable_elimination)
-			.with_vivification(self.vivification);
-
-		config
-	}
-
 	/// Collect the active tracing targets after applying user overrides.
 	pub(crate) fn trace_targets(&self) -> Vec<String> {
 		let mut trace_targets = vec!["solver".to_owned(), "flatzinc".to_owned()];
@@ -396,7 +378,7 @@ mod tests {
 	use std::{path::PathBuf, time::Duration};
 
 	use clap::ColorChoice;
-	use huub::lower::InitConfig;
+	use huub::lower::Lowerer;
 
 	use crate::cli::Cli;
 
@@ -487,19 +469,19 @@ mod tests {
 	fn solver_backed_defaults() {
 		let cli = Cli::try_parse_from(["huub", "instance.fzn.json"]).unwrap();
 
-		assert_eq!(cli.int_eager_limit, InitConfig::default().int_eager_limit());
-		assert_eq!(cli.restart, InitConfig::default().restart());
-		assert_eq!(cli.conditioning, InitConfig::default().conditioning());
-		assert_eq!(cli.inprocessing, InitConfig::default().inprocessing());
-		assert_eq!(cli.preprocessing, InitConfig::default().preprocessing());
-		assert_eq!(cli.probing, InitConfig::default().probing());
-		assert_eq!(cli.reason_eager, InitConfig::default().reason_eager());
-		assert_eq!(cli.subsumption, InitConfig::default().subsumption());
+		assert_eq!(cli.int_eager_limit, Lowerer::DEFAULT_INT_EAGER_LIMIT);
+		assert_eq!(cli.restart, Lowerer::DEFAULT_RESTART);
+		assert_eq!(cli.conditioning, Lowerer::DEFAULT_CONDITIONING);
+		assert_eq!(cli.inprocessing, Lowerer::DEFAULT_INPROCESSING);
+		assert_eq!(cli.preprocessing, Lowerer::DEFAULT_PREPROCESSING);
+		assert_eq!(cli.probing, Lowerer::DEFAULT_PROBING);
+		assert_eq!(cli.reason_eager, Lowerer::DEFAULT_REASON_EAGER);
+		assert_eq!(cli.subsumption, Lowerer::DEFAULT_SUBSUMPTION);
 		assert_eq!(
 			cli.variable_elimination,
-			InitConfig::default().variable_elimination()
+			Lowerer::DEFAULT_VARIABLE_ELIMINATION
 		);
-		assert_eq!(cli.vivification, InitConfig::default().vivification());
+		assert_eq!(cli.vivification, Lowerer::DEFAULT_VIVIFICATION);
 	}
 
 	#[test]

--- a/crates/huub-cli/src/lib.rs
+++ b/crates/huub-cli/src/lib.rs
@@ -40,7 +40,7 @@ use huub::{
 	lower::LoweringError,
 	model::deserialize::{
 		Goal,
-		flatzinc::{FlatZincError, FznIdent},
+		flatzinc::{FlatZincError, FznIdent, HuubFlatZinc},
 	},
 	solver::{
 		AnyView, SearchStrategy, Solution, Solver, Status, SwitchTrigger, TerminationSignal,
@@ -122,7 +122,20 @@ impl<'a> Cli<'a> {
 			)
 		})?;
 
-		let (mut slv, meta): (Solver, _) = match Solver::from_fzn(&fzn, &self.init_config()) {
+		let (mut slv, meta): (Solver, _) = match fzn
+			.lower()
+			.int_eager_limit(self.int_eager_limit)
+			.preprocessing(self.preprocessing)
+			.conditioning(self.conditioning)
+			.inprocessing(self.inprocessing)
+			.probing(self.probing)
+			.reason_eager(self.reason_eager)
+			.restart(self.free_search || self.restart)
+			.subsumption(self.subsumption)
+			.variable_elimination(self.variable_elimination)
+			.vivification(self.vivification)
+			.to_solver()
+		{
 			Err(FlatZincError::ReformulationError(
 				LoweringError::Simplification(_) | LoweringError::Lowering(_),
 			)) => {

--- a/crates/huub/examples/jobshop/main.rs
+++ b/crates/huub/examples/jobshop/main.rs
@@ -31,7 +31,7 @@ use std::{
 
 use clap::{ArgAction, Parser, ValueEnum, builder::BoolishValueParser};
 use huub::{
-	lower::InitConfig,
+	lower::Lowerer,
 	solver::{SearchStrategy, Solver, SwitchTrigger, TerminationSignal, Valuation},
 };
 
@@ -60,7 +60,7 @@ struct Cli {
 		action = ArgAction::Set,
 		value_parser = BoolishValueParser::new(),
 		value_name = "bool",
-		default_value_t = InitConfig::default().reason_eager()
+		default_value_t = Lowerer::DEFAULT_REASON_EAGER
 	)]
 	reason_eager: bool,
 	/// The time limit before stopping the solver.
@@ -71,7 +71,7 @@ struct Cli {
 	#[arg(
 		long,
 		value_name = "usize",
-		default_value_t = InitConfig::default().int_eager_limit()
+		default_value_t = Lowerer::DEFAULT_INT_EAGER_LIMIT
 	)]
 	int_eager_limit: usize,
 	/// Whether to enable restarting.
@@ -80,7 +80,7 @@ struct Cli {
 		action = ArgAction::Set,
 		value_parser = BoolishValueParser::new(),
 		value_name = "bool",
-		default_value_t = InitConfig::default().restart()
+		default_value_t = Lowerer::DEFAULT_RESTART
 	)]
 	restart: bool,
 	/// Set the overarching search strategy used by the solver.
@@ -169,11 +169,13 @@ fn main() {
 	println!("{0}", options);
 
 	// Configure solver initialization options.
-	let init_config = InitConfig::default()
-		.with_restart(options.restart)
-		.with_int_eager_limit(options.int_eager_limit)
-		.with_reason_eager(options.reason_eager);
-	let (mut slv, map): (Solver, _) = model.to_solver(&init_config).unwrap();
+	let (mut slv, map): (Solver, _) = model
+		.lower()
+		.restart(options.restart)
+		.int_eager_limit(options.int_eager_limit)
+		.reason_eager(options.reason_eager)
+		.to_solver()
+		.unwrap();
 
 	options
 		.branching_strategy

--- a/crates/huub/examples/jobshop/model.rs
+++ b/crates/huub/examples/jobshop/model.rs
@@ -294,10 +294,7 @@ impl fmt::Display for Solution {
 
 #[cfg(test)]
 mod tests {
-	use huub::{
-		lower::InitConfig,
-		solver::{Solver, Valuation},
-	};
+	use huub::solver::{Solver, Valuation};
 
 	use crate::model::{Instance, JobShopModel, ObjectiveType};
 
@@ -346,7 +343,7 @@ mod tests {
 			objective,
 			..
 		} = JobShopModel::new(&instance, objective_type);
-		let (mut slv, map): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map): (Solver, _) = model.lower().to_solver().unwrap();
 		let obj = map.get(&mut slv, objective);
 		let mut best = None;
 		slv.solve()

--- a/crates/huub/examples/send-more-money/main.rs
+++ b/crates/huub/examples/send-more-money/main.rs
@@ -26,7 +26,6 @@ macro_rules! println {
 use std::{fmt::Write, sync::Mutex};
 
 use huub::{
-	lower::InitConfig,
 	model::Model,
 	solver::{Solver, Valuation},
 };
@@ -69,7 +68,7 @@ pub fn main() {
 
 	// ANCHOR: convert_to_solver
 	// Convert the model to a solver
-	let (mut solver, map): (Solver, _) = match model.to_solver(&InitConfig::default()) {
+	let (mut solver, map): (Solver, _) = match model.lower().to_solver() {
 		Ok(result) => result,
 		Err(e) => {
 			eprintln!("Error initializing solver: {}", e);

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -985,7 +985,7 @@ mod tests {
 		// First propagation: The compulsory parts of Task A and B ([0, 2])
 		// require that Task C cannot overlap with them due to capacity constraints.
 		// This pushes the earliest start time of Task C to 3.
-		let _ = prb.propagate(ConRef::from_raw(0));
+		let _ = prb.propagate_single(ConRef::from_raw(0));
 		let time_bounds = start_time_a.bounds(&prb);
 		assert_eq!(time_bounds, (0, 2));
 		let usage_bounds = usages[0].bounds(&prb);
@@ -1004,7 +1004,7 @@ mod tests {
 		// Second propagation: With Task C's start time now at least 3, only A and B
 		// overlap in [0, 2]. The combined usage of A and B in this interval must not
 		// exceed the capacity (2), so their usage upper bounds are tightened to 1.
-		let _ = prb.propagate(ConRef::from_raw(0));
+		let _ = prb.propagate_single(ConRef::from_raw(0));
 		let time_bounds = start_time_a.bounds(&prb);
 		assert_eq!(time_bounds, (0, 2));
 		let usage_bounds = usages[0].bounds(&prb);

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -471,7 +471,6 @@ mod tests {
 		IntSet,
 		actions::{IntInspectionActions, IntPropagationActions},
 		constraints::int_array_element::IntArrayElementBounds,
-		lower::InitConfig,
 		model::Model,
 		solver::{
 			Solver,
@@ -493,7 +492,7 @@ mod tests {
 			.result(result)
 			.post();
 		index.remove_val(&mut prb, 2, []).unwrap();
-		let _: (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
+		let _: (Solver, _) = prb.lower().to_solver().unwrap();
 
 		assert_eq!(index.domain(&prb), (0..=1).into());
 		assert_eq!(result.bounds(&prb), (1, 3));
@@ -513,7 +512,7 @@ mod tests {
 			.result(result)
 			.post();
 		index.remove_val(&mut prb, 0, []).unwrap();
-		let _: (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
+		let _: (Solver, _) = prb.lower().to_solver().unwrap();
 
 		assert_eq!(index.domain(&prb), (1..=2).into());
 		assert_eq!(result.bounds(&prb), (3, 4));

--- a/crates/huub/src/constraints/int_array_minimum.rs
+++ b/crates/huub/src/constraints/int_array_minimum.rs
@@ -133,7 +133,7 @@ mod tests {
 	use itertools::Itertools;
 	use tracing_test::traced_test;
 
-	use crate::{lower::InitConfig, model::Model};
+	use crate::model::Model;
 
 	#[test]
 	#[traced_test]
@@ -146,7 +146,7 @@ mod tests {
 
 		prb.maximum(vec![a, b, c]).result(y).post();
 
-		let (mut slv, map) = prb.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vec![a, b, c, y]
 			.into_iter()
 			.map(|x| map.get(&mut slv, x))
@@ -187,7 +187,7 @@ mod tests {
 		let y = prb.new_int_decision(3..=4);
 
 		prb.minimum(vec![a, b, c]).result(y).post();
-		let (mut slv, map) = prb.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vec![a, b, c, y]
 			.into_iter()
 			.map(|x| map.get(&mut slv, x))

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -1086,7 +1086,6 @@ mod tests {
 	use crate::{
 		IntSet, IntVal,
 		constraints::int_linear::{DoubleIntVal, IntLinearLessEqBounds, IntLinearNotEqValue},
-		lower::InitConfig,
 		model::{Model, view::View},
 		solver::{
 			Solver,
@@ -1257,7 +1256,7 @@ mod tests {
 
 		prb.linear(a * 2 + b + c).ge(7).implied_by(r).post();
 
-		let (mut slv, map): (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 		let a = map.get_any(&mut slv, a.into());
 		let b = map.get_any(&mut slv, b.into());
 		let c = map.get_any(&mut slv, c.into());
@@ -1290,7 +1289,7 @@ mod tests {
 
 		prb.linear(a * 2 + b + c).le(5).implied_by(r).post();
 
-		let (mut slv, map): (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 		let a = map.get_any(&mut slv, a.into());
 		let b = map.get_any(&mut slv, b.into());
 		let c = map.get_any(&mut slv, c.into());
@@ -1323,7 +1322,7 @@ mod tests {
 
 		prb.linear(a * 2 + b + c).ne(6).implied_by(r).post();
 
-		let (mut slv, map): (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 		let a = map.get_any(&mut slv, a.into());
 		let b = map.get_any(&mut slv, b.into());
 		let c = map.get_any(&mut slv, c.into());

--- a/crates/huub/src/constraints/int_no_overlap.rs
+++ b/crates/huub/src/constraints/int_no_overlap.rs
@@ -843,7 +843,7 @@ mod tests {
 	use itertools::Itertools;
 	use tracing_test::traced_test;
 
-	use crate::{lower::InitConfig, model::Model};
+	use crate::model::Model;
 
 	#[test]
 	#[traced_test]
@@ -864,7 +864,7 @@ mod tests {
 			.strict(true)
 			.post();
 
-		let (mut slv, map) = prb.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vec![x1, y1, x2, y2]
 			.into_iter()
 			.map(|x| map.get(&mut slv, x))
@@ -901,7 +901,7 @@ mod tests {
 			.strict(false)
 			.post();
 
-		let (mut slv, map) = prb.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vec![x1, y1, x2, y2]
 			.into_iter()
 			.map(|x| map.get(&mut slv, x))
@@ -940,7 +940,7 @@ mod tests {
 			.strict(true)
 			.post();
 
-		let (mut slv, map) = prb.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vec![x1, y1, z1, x2, y2, z2]
 			.into_iter()
 			.map(|v| map.get(&mut slv, v))

--- a/crates/huub/src/constraints/int_table.rs
+++ b/crates/huub/src/constraints/int_table.rs
@@ -170,7 +170,7 @@ mod tests {
 	use expect_test::expect;
 	use itertools::Itertools;
 
-	use crate::{lower::InitConfig, model::Model};
+	use crate::model::Model;
 
 	#[test]
 	fn test_binary_table_sat() {
@@ -195,7 +195,7 @@ mod tests {
 			.values(table.clone())
 			.post();
 
-		let (mut slv, map) = prb.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vars.into_iter().map(|x| map.get(&mut slv, x)).collect_vec();
 		slv.expect_solutions(
 			&vars,
@@ -244,7 +244,7 @@ mod tests {
 			.values(table.clone())
 			.post();
 
-		let (mut slv, map) = prb.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vars.into_iter().map(|x| map.get(&mut slv, x)).collect_vec();
 		slv.expect_solutions(
 			&vars,

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -25,7 +25,6 @@
 //!
 //! ```
 //! # use huub::{
-//! # 	lower::InitConfig,
 //! # 	model::Model,
 //! # 	solver::{Solver, Status, Valuation},
 //! # };
@@ -36,7 +35,7 @@
 //! model.linear(x + y).eq(5).post();
 //! model.unique(vec![x, y]).post();
 //!
-//! let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+//! let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 //! let x = map.get(&mut solver, x);
 //! let y = map.get(&mut solver, y);
 //!

--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -6,22 +6,37 @@ use std::{
 	error::Error,
 	fmt::{self, Debug, Display},
 	marker::PhantomData,
+	num::NonZeroI32,
 };
 
+use bon::Builder;
 use itertools::Itertools;
 use pindakaas::{
-	ClauseDatabase, Lit as RawLit, Unsatisfiable, solver::propagation::ExternalPropagation,
+	ClauseDatabase, Lit as RawLit, Unsatisfiable,
+	solver::{cadical::Cadical, propagation::ExternalPropagation},
 };
 use rangelist::IntervalIterator;
 use rustc_hash::FxHashSet;
+use tracing::warn;
 
+#[cfg(feature = "flatzinc")]
+use crate::model::deserialize::{
+	Goal,
+	flatzinc::{FlatZincError, FlatZincLowerData, FlatZincModelMeta, FlatZincSolverMeta},
+};
 use crate::{
 	IntSet, IntVal,
 	actions::{
 		BoolInspectionActions, ConstructionActions, IntDecisionActions, IntInspectionActions,
 		PostingActions, ReasoningContext, ReasoningEngine, Trailed,
 	},
-	constraints::{BoxedPropagator, Conflict, ReasonBuilder},
+	constraints::{
+		BoxedPropagator, Conflict, Constraint, ReasonBuilder,
+		bool_array_element::BoolDecisionArrayElement,
+		int_array_element::{IntArrayElementBounds, IntValArrayElement},
+		int_table::IntTable,
+		int_unique::IntUnique,
+	},
 	helpers::bytes::Bytes,
 	model::{self, Model, decision::integer::Domain, resolved::Resolved},
 	solver::{
@@ -33,30 +48,63 @@ use crate::{
 	views::LinearBoolView,
 };
 
-/// Configuration object for the reformulation process of creating a [`Solver`]
-/// object from a [`Model`].
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
-pub struct InitConfig {
+/// Internal type to represent a complete [`Lowerer`] builder.
+#[derive(Builder)]
+#[builder(
+	builder_type(
+		name = Lowerer,
+		vis = "pub",
+		doc {
+			/// A builder for the lowering process, which converts a high-level
+			/// [`Model`] or a `FlatZinc` instance into a lower-level representation
+			/// (typically a [`Solver`]).
+			///
+			/// This builder allows configuring various SAT solver options and preprocessing
+			/// techniques before starting the lowering process.
+		},
+	),
+	start_fn(name = builder_internal, vis = "pub(crate)"),
+	finish_fn(name = finish_internal, vis = "")
+)]
+#[allow(
+	clippy::missing_docs_in_private_items,
+	reason = "cargo clippy triggers on origin for unknown reason"
+)]
+pub(crate) struct LowererComplete<Origin = ()> {
+	/// A origin source from which the model was created, used to define wrapper
+	/// methods for the lowering process.
+	#[builder(start_fn)]
+	origin: Origin,
 	/// Whether to enable the globally blocked clause elimination (conditioning)
+	#[builder(default = Lowerer::DEFAULT_CONDITIONING)]
 	conditioning: bool,
 	/// Whether to enable inprocessing in the SAT solver.
+	#[builder(default = Lowerer::DEFAULT_INPROCESSING)]
 	inprocessing: bool,
 	/// The maximum cardinality of the domain of an integer variable before its
 	/// order encoding is created lazily.
-	int_eager_limit: Option<usize>,
+	#[builder(default = Lowerer::DEFAULT_INT_EAGER_LIMIT)]
+	int_eager_limit: usize,
 	/// The number of preprocessing rounds in the SAT solver
-	preprocessing: Option<usize>,
+	#[builder(default = Lowerer::DEFAULT_PREPROCESSING)]
+	preprocessing: usize,
 	/// Whether to enable the failed literal probing in the SAT solver.
+	#[builder(default = Lowerer::DEFAULT_PROBING)]
 	probing: bool,
 	/// Whether to enable restarts in the SAT solver.
+	#[builder(default = Lowerer::DEFAULT_RESTART)]
 	restart: bool,
 	/// Whether to enable the global forward subsumption in the SAT solver.
+	#[builder(default = Lowerer::DEFAULT_SUBSUMPTION)]
 	subsumption: bool,
 	/// Whether to enable asking reason eagerly in the SAT solver.
+	#[builder(default = Lowerer::DEFAULT_REASON_EAGER)]
 	reason_eager: bool,
 	/// Whether to enable the bounded variable elimination in the SAT solver.
+	#[builder(default = Lowerer::DEFAULT_VARIABLE_ELIMINATION)]
 	variable_elimination: bool,
 	/// Whether to enable the vivification in the SAT solver.
+	#[builder(default = Lowerer::DEFAULT_VIVIFICATION)]
 	vivification: bool,
 }
 
@@ -189,133 +237,244 @@ pub(crate) struct LoweringMapBuilder {
 	pub(crate) int_map: Vec<Option<solver::View<IntVal>>>,
 }
 
-impl InitConfig {
-	/// The default maximum cardinality of the domain of an integer variable
-	/// before its order encoding is created lazily.
+impl Lowerer {
+	/// The default value when [`conditioning`](Lowerer::conditioning) is not
+	/// explicitly set.
+	pub const DEFAULT_CONDITIONING: bool = false;
+	/// The default value when [`inprocessing`](Lowerer::inprocessing) is not
+	/// explicitly set.
+	pub const DEFAULT_INPROCESSING: bool = false;
+	/// The default value when [`int_eager_limit`](Lowerer::int_eager_limit) is
+	/// not explicitly set.
 	pub const DEFAULT_INT_EAGER_LIMIT: usize = 255;
-
-	/// Get the default number of preprocessing rounds in the SAT solver.
+	/// The default value when [`preprocessing`](Lowerer::preprocessing) is not
+	/// explicitly set.
 	pub const DEFAULT_PREPROCESSING: usize = 0;
+	/// The default value when [`probing`](Lowerer::probing) is not explicitly
+	/// set.
+	pub const DEFAULT_PROBING: bool = false;
+	/// The default value when [`reason_eager`](Lowerer::reason_eager) is not
+	/// explicitly set.
+	pub const DEFAULT_REASON_EAGER: bool = false;
+	/// The default value when [`restart`](Lowerer::restart) is not explicitly
+	/// set.
+	pub const DEFAULT_RESTART: bool = false;
+	/// The default value when [`subsumption`](Lowerer::subsumption) is not
+	/// explicitly set.
+	pub const DEFAULT_SUBSUMPTION: bool = false;
+	/// The default value when
+	/// [`variable_elimination`](Lowerer::variable_elimination) is not
+	/// explicitly set.
+	pub const DEFAULT_VARIABLE_ELIMINATION: bool = false;
+	/// The default value when [`vivification`](Lowerer::vivification) is not
+	/// explicitly set.
+	pub const DEFAULT_VIVIFICATION: bool = false;
+}
 
-	/// Get whether to enable the globally blocked clause elimination
-	/// (conditioning) in the SAT solver.
-	pub fn conditioning(&self) -> bool {
-		self.conditioning
+impl<State: lowerer::State> Lowerer<&mut Model, State> {
+	/// Lower the [`Model`] to a [`Solver`].
+	///
+	/// This method will simplify the model, create the mapping between model
+	/// decisions and solver views, and then create the constraint data
+	/// structures within the solver.
+	pub fn to_solver<Sat>(self) -> Result<(Solver<Sat>, LoweringMap), LoweringError>
+	where
+		Solver<Sat>: Default,
+		Sat: ExternalPropagation + 'static,
+		State: lowerer::IsComplete,
+	{
+		self.finish_internal().into_solver_internal()
 	}
+}
 
-	/// Get whether to enable inprocessing in the SAT solver.
-	pub fn inprocessing(&self) -> bool {
-		self.inprocessing
+#[cfg(feature = "flatzinc")]
+impl<State: lowerer::State> Lowerer<Result<FlatZincLowerData, FlatZincError>, State> {
+	/// Lower the [`FlatZinc`](flatzinc_serde::FlatZinc) instance to a
+	/// [`Solver`].
+	///
+	/// This method will internally create a [`Model`] from the FlatZinc data
+	/// and then lower that model to a [`Solver`].
+	pub fn to_solver<Sat>(self) -> Result<(Solver<Sat>, FlatZincSolverMeta), FlatZincError>
+	where
+		Solver<Sat>: Default,
+		Sat: ExternalPropagation + 'static,
+	{
+		let complete = self.finish_internal();
+		let FlatZincLowerData { meta, mut model } = complete.origin?;
+
+		let (mut slv, map) = LowererComplete {
+			origin: &mut model,
+			conditioning: complete.conditioning,
+			inprocessing: complete.inprocessing,
+			int_eager_limit: complete.int_eager_limit,
+			preprocessing: complete.preprocessing,
+			probing: complete.probing,
+			restart: complete.restart,
+			subsumption: complete.subsumption,
+			reason_eager: complete.reason_eager,
+			variable_elimination: complete.variable_elimination,
+			vivification: complete.vivification,
+		}
+		.into_solver_internal()?;
+		if let Some(branching) = meta.branching {
+			branching.to_solver(&mut slv, &map);
+		}
+		let names = meta
+			.names
+			.into_iter()
+			.map(|(k, v)| (k, map.get_any(&mut slv, v)))
+			.collect();
+		let goal = meta.goal.map(|g| match g {
+			Goal::Minimize(v) => Goal::Minimize(map.get(&mut slv, v)),
+			Goal::Maximize(v) => Goal::Maximize(map.get(&mut slv, v)),
+		});
+		Ok((
+			slv,
+			FlatZincSolverMeta {
+				names,
+				stats: meta.stats,
+				goal,
+			},
+		))
 	}
+}
 
-	/// Get the maximum cardinality of the domain of an integer variable before
-	/// its order encoding is created lazily.
-	pub fn int_eager_limit(&self) -> usize {
-		self.int_eager_limit
-			.unwrap_or(Self::DEFAULT_INT_EAGER_LIMIT)
+#[cfg(feature = "flatzinc")]
+impl Lowerer<Result<FlatZincLowerData, FlatZincError>, lowerer::Empty> {
+	/// Lower the [`FlatZinc`](flatzinc_serde::FlatZinc) instance to a
+	/// [`Model`] with accompanying [`FlatZincModelMeta`] data.
+	pub fn to_model(self) -> Result<(Model, FlatZincModelMeta), FlatZincError> {
+		self.origin.map(|data| (data.model, data.meta))
 	}
+}
 
-	/// Get whether to enable preprocessing in the SAT solver.
-	pub fn preprocessing(&self) -> usize {
-		self.preprocessing.unwrap_or(Self::DEFAULT_PREPROCESSING)
-	}
+impl LowererComplete<&mut Model> {
+	/// Internal implementation for lowering a model to a solver.
+	fn into_solver_internal<Sat>(self) -> Result<(Solver<Sat>, LoweringMap), LoweringError>
+	where
+		Solver<Sat>: Default,
+		Sat: ExternalPropagation + 'static,
+	{
+		let LowererComplete {
+			origin: model,
+			conditioning,
+			inprocessing,
+			int_eager_limit,
+			preprocessing,
+			probing,
+			restart,
+			subsumption,
+			reason_eager,
+			variable_elimination,
+			vivification,
+		} = self;
 
-	/// Get whether to enable the failed literal probing in the SAT solver.
-	pub fn probing(&self) -> bool {
-		self.probing
-	}
+		let mut slv = Solver::<Sat>::default();
+		let any_slv: &mut dyn Any = &mut slv.sat;
+		if let Some(r) = any_slv.downcast_mut::<Cadical>() {
+			// Set the solver options for preprocessing/inprocessing
+			r.set_option("condition", conditioning as i32);
+			r.set_option("elim", variable_elimination as i32);
+			r.set_option("exteagerreasons", reason_eager as i32);
+			r.set_option("inprocessing", inprocessing as i32);
+			r.set_limit("preprocessing", preprocessing as i32);
+			r.set_option("probe", probing as i32);
+			r.set_option("subsume", subsumption as i32);
+			r.set_option("vivify", vivification as i32);
 
-	/// Get whether to enable asking for explanation clauses for all literals
-	/// propagated on the level of a conflict.
-	pub fn reason_eager(&self) -> bool {
-		self.reason_eager
-	}
+			// Set the solver options for search configurations
+			// Enable restart if the config is set to true or if there are no
+			// user search heuristics are provided
+			r.set_option("restart", restart as i32);
+		} else {
+			warn!(
+				target: "solver",
+				"ignore vivification and restart options for unknown solver"
+			);
+		}
 
-	/// Get whether to enable restarts in the SAT solver.
-	pub fn restart(&self) -> bool {
-		self.restart
-	}
+		model.propagate()?;
 
-	/// Get whether to enable the global forward subsumption in the SAT
-	/// solver.
-	pub fn subsumption(&self) -> bool {
-		self.subsumption
-	}
+		// Determine encoding types for integer variables
+		let mut int_eager_direct = FxHashSet::<Resolved<model::Decision<IntVal>>>::default();
+		let int_eager_order = FxHashSet::<Resolved<model::Decision<IntVal>>>::default();
 
-	/// Get whether to enable the bounded variable elimination in the SAT
-	/// solver.
-	pub fn variable_elimination(&self) -> bool {
-		self.variable_elimination
-	}
+		for c in model.constraints.iter().flatten() {
+			let c: &dyn Constraint<Model> = c.as_ref();
+			let c: &dyn Any = c;
+			if let Some(c) = c.downcast_ref::<BoolDecisionArrayElement>() {
+				let index = c.index.resolve_alias(model);
+				if let Some(var) = index.integer_decision() {
+					int_eager_direct.insert(var);
+				}
+			} else if let Some(c) = c.downcast_ref::<IntUnique>() {
+				for v in &c.bounds_prop.var {
+					let v = v.resolve_alias(model);
+					if let Some(var) = v.integer_decision() {
+						let Domain::Domain(dom) = &model.int_vars[var.idx()].domain else {
+							unreachable!()
+						};
+						if dom.card() <= Some(c.bounds_prop.var.len() * 100 / 80) {
+							int_eager_direct.insert(var);
+						}
+					}
+				}
+			} else if let Some(c) = c.downcast_ref::<IntArrayElementBounds<
+				model::View<IntVal>,
+				model::View<IntVal>,
+				model::View<IntVal>,
+			>>() {
+				let index = c.index.resolve_alias(model);
+				if let Some(var) = index.integer_decision() {
+					int_eager_direct.insert(var);
+				}
+			} else if let Some(c) = c.downcast_ref::<IntTable>() {
+				for &v in &c.vars {
+					let v = v.resolve_alias(model);
+					if let Some(var) = v.integer_decision() {
+						int_eager_direct.insert(var);
+					}
+				}
+			} else if let Some(c) =
+				c.downcast_ref::<IntValArrayElement<model::View<IntVal>, model::View<IntVal>>>()
+			{
+				let index = c.0.index.resolve_alias(model);
+				if let Some(var) = index.integer_decision() {
+					int_eager_direct.insert(var);
+				}
+			}
+		}
 
-	/// Get whether to enable the vivification in the SAT solver.
-	pub fn vivification(&self) -> bool {
-		self.vivification
-	}
+		// Create the mapping between model decisions and solver views.
+		let mut map_builder = LoweringMapBuilder {
+			bool_map: vec![None; model.bool_vars.len()],
+			int_eager_direct,
+			int_eager_limit,
+			int_eager_order,
+			int_map: vec![None; model.int_vars.len()],
+		};
 
-	/// Change whether to enable the globally blocked clause elimination
-	/// (conditioning) in the SAT solver.
-	pub fn with_conditioning(mut self, conditioning: bool) -> Self {
-		self.conditioning = conditioning;
-		self
-	}
+		// Ensure the creation of all integer variables.
+		for (idx, _) in model.int_vars.iter().enumerate() {
+			map_builder.get_or_create_int(model, &mut slv, model::Decision(idx as u32));
+		}
 
-	/// Change whether to enable inprocessing in the SAT solver.
-	pub fn with_inprocessing(mut self, inprocessing: bool) -> Self {
-		self.inprocessing = inprocessing;
-		self
-	}
+		// Ensure the creation of all Boolean variables.
+		for var in 1..=model.bool_vars.len() as u32 {
+			let raw = RawLit::from_raw(NonZeroI32::new(var as i32).unwrap());
+			map_builder.get_or_create_bool(model, &mut slv, model::Decision(raw).into());
+		}
 
-	/// Change the maximum cardinality of the domain of an integer variable
-	/// before its order encoding is created lazily.
-	pub fn with_int_eager_limit(mut self, limit: usize) -> Self {
-		self.int_eager_limit = Some(limit);
-		self
-	}
+		// Finalize the reformulation map (all variables must be created by now)
+		let map = map_builder.finalize();
 
-	/// Change the number of preprocessing rounds in the SAT solver.
-	pub fn with_preprocessing(mut self, preprocessing: usize) -> Self {
-		self.preprocessing = Some(preprocessing);
-		self
-	}
+		// Create constraint data structures within the solver
+		let mut ctx = LoweringContext::new(&mut slv, &map, &model.trail);
+		for c in model.constraints.iter().flatten() {
+			c.to_solver(&mut ctx)?;
+		}
 
-	/// Change whether to enable the failed literal probing in the SAT
-	/// solver.
-	pub fn with_probing(mut self, probing: bool) -> Self {
-		self.probing = probing;
-		self
-	}
-
-	/// Change whether to enable asking reason eagerly in the SAT solver.
-	pub fn with_reason_eager(mut self, reason_eager: bool) -> Self {
-		self.reason_eager = reason_eager;
-		self
-	}
-
-	/// Change whether to enable restarts in the SAT solver.
-	pub fn with_restart(mut self, restart: bool) -> Self {
-		self.restart = restart;
-		self
-	}
-
-	/// Change whether to enable the global forward subsumption in the SAT
-	/// solver.
-	pub fn with_subsumption(mut self, subsumption: bool) -> Self {
-		self.subsumption = subsumption;
-		self
-	}
-
-	/// Change whether to enable the bounded variable elimination in the SAT
-	/// solver.
-	pub fn with_variable_elimination(mut self, variable_elimination: bool) -> Self {
-		self.variable_elimination = variable_elimination;
-		self
-	}
-
-	/// Change whether to enable the vivification in the SAT solver.
-	pub fn with_vivification(mut self, vivification: bool) -> Self {
-		self.vivification = vivification;
-		self
+		Ok((slv, map))
 	}
 }
 
@@ -501,18 +660,17 @@ impl LoweringMap {
 	/// maps.
 	///
 	/// Model views belong to the modelling layer. Use this method after
-	/// [`Model::to_solver`](crate::model::Model::to_solver) to obtain the
+	/// [`Model::lower`](crate::model::Model::lower) to obtain the
 	/// corresponding solver view before querying solution values.
 	///
 	/// ```
 	/// # use huub::{
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
 	/// # let mut model = Model::default();
 	/// let model_x = model.new_int_decision(1..=3);
-	/// let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	///
 	/// let solver_x = map.get(&mut solver, model_x);
 	/// let status = solver

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -9,22 +9,16 @@ pub(crate) mod resolved;
 pub(crate) mod view;
 
 use std::{
-	any::Any,
 	fmt::Debug,
 	hash::Hash,
 	iter::{repeat_n, repeat_with},
 	marker::PhantomData,
 	mem,
-	num::NonZeroI32,
 };
 
-use pindakaas::{
-	ClauseDatabaseTools, Cnf, Lit as RawLit,
-	solver::{cadical::Cadical, propagation::ExternalPropagation},
-};
+use pindakaas::{ClauseDatabaseTools, Cnf};
 use rangelist::IntervalIterator;
-use rustc_hash::{FxHashMap, FxHashSet};
-use tracing::warn;
+use rustc_hash::FxHashMap;
 
 pub use crate::model::{
 	decision::{Decision, DecisionReference},
@@ -39,23 +33,15 @@ use crate::{
 	constraints::{
 		BoxedConstraint, Conflict, Constraint, DeferredReason, Reason, ReasonBuilder,
 		SimplificationStatus,
-		bool_array_element::BoolDecisionArrayElement,
-		int_array_element::{IntArrayElementBounds, IntValArrayElement},
-		int_table::IntTable,
-		int_unique::IntUnique,
 	},
 	helpers::bytes::Bytes,
-	lower::{InitConfig, LoweringContext, LoweringError, LoweringMap, LoweringMapBuilder},
+	lower::{Lowerer, LowererComplete, LoweringError},
 	model::{
-		decision::{
-			boolean::BoolDecision,
-			integer::{Domain, IntDecision},
-		},
+		decision::{boolean::BoolDecision, integer::IntDecision},
 		initilization_context::ModelInitContext,
-		resolved::Resolved,
 	},
 	solver::{
-		IntLitMeaning, Solver,
+		IntLitMeaning,
 		activation_list::ActivationAction,
 		queue::{PropagatorInfo, PropagatorQueue},
 	},
@@ -91,14 +77,13 @@ pub(crate) struct ConRef(u32);
 /// A [`Model`] is the construction and simplification layer of Huub. It stores
 /// decision variables, constraints, aliases, and simplifications, but it does
 /// not perform search itself. Search starts after the model is converted to a
-/// [`Solver`] with [`Self::to_solver`].
+/// [`Solver`](crate::solver::Solver) with [`Self::lower`].
 ///
 /// After lowering, values in a solution should be queried through the solver
-/// views returned by the [`LoweringMap`].
+/// views returned by the [`LoweringMap`](crate::lower::LoweringMap).
 ///
 /// ```
 /// # use huub::{
-/// # 	lower::InitConfig,
 /// # 	model::Model,
 /// # 	solver::{Solver, Status, Valuation},
 /// # };
@@ -108,7 +93,7 @@ pub(crate) struct ConRef(u32);
 ///
 /// model.linear(x + y).eq(4).post();
 ///
-/// let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+/// let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 /// # let x = map.get(&mut solver, x);
 /// # let y = map.get(&mut solver, y);
 /// # let mut pair = None;
@@ -128,7 +113,7 @@ pub struct Model {
 	/// A base [`Cnf`] object that contains pure Boolean parts of the problem.
 	pub(crate) cnf: Cnf,
 	/// A list of constraints that have been added to the model.
-	constraints: Vec<Option<BoxedConstraint>>,
+	pub(crate) constraints: Vec<Option<BoxedConstraint>>,
 	/// The definitions of the Boolean decision variables that have been
 	/// created.
 	pub(crate) bool_vars: Vec<BoolDecision>,
@@ -138,7 +123,7 @@ pub struct Model {
 	/// A queue of constraints that need to be propagated.
 	propagator_queue: PropagatorQueue,
 	/// Fake trailed storage
-	trail: Vec<[u8; 8]>,
+	pub(crate) trail: Vec<[u8; 8]>,
 	/// Reference for the current propagator being executed.
 	cur_prop: Option<ConRef>,
 	/// Integer variable changes that occurred during the execution of the
@@ -219,6 +204,30 @@ impl Model {
 			},
 			Err(false) => unreachable!("invalid reason"),
 		}
+	}
+
+	/// Returns a builder that can be used to lower the [`Model`] to a
+	/// [`Solver`](crate::solver::Solver) (via
+	/// [`to_solver()`](Lowerer::to_solver)).
+	///
+	/// The builder allows configuring various SAT solver options and
+	/// preprocessing techniques before starting the lowering process.
+	///
+	/// ```
+	/// # use huub::{
+	/// # 	model::Model,
+	/// # 	solver::{Solver, Valuation},
+	/// # };
+	/// # let mut model = Model::default();
+	/// # let x = model.new_int_decision(1..=3);
+	/// let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
+	/// let x = map.get(&mut solver, x);
+	///
+	/// solver.solve().satisfy();
+	/// # Ok::<(), Box<dyn std::error::Error>>(())
+	/// ```
+	pub fn lower(&mut self) -> Lowerer<&'_ mut Model> {
+		LowererComplete::builder_internal(self)
 	}
 
 	/// Create a new Boolean variable.
@@ -407,9 +416,28 @@ impl Model {
 		}
 	}
 
+	/// Propagate all constraints until the propagator queue is empty.
+	///
+	/// This method performs fixed-point iteration of all constraints currently
+	/// in the propagator queue. It will continue to propagate until no more
+	/// changes can be made to the domains of the decision variables, or until
+	/// an inconsistency is found.
+	///
+	/// Note that Huub performs propagation automatically during the lowering
+	/// process (see [`Self::lower`]). You generally only need to call this
+	/// method manually if you want to inspect the results of propagation
+	/// (e.g. decision variable domains) during the modeling process.
+	pub fn propagate(&mut self) -> Result<(), LoweringError> {
+		self.notify_advisors();
+		while let Some(con) = self.propagator_queue.pop() {
+			self.propagate_single(ConRef::from_raw(con))?;
+		}
+		Ok(())
+	}
+
 	/// Propagate the constraint at index `con`, updating the domains of the
 	/// variables and rewriting the constraint if necessary.
-	pub(crate) fn propagate(&mut self, con: ConRef) -> Result<(), LoweringError> {
+	pub(crate) fn propagate_single(&mut self, con: ConRef) -> Result<(), LoweringError> {
 		let Some(mut con_obj) = self.constraints[con.index()].take() else {
 			return Ok(());
 		};
@@ -441,152 +469,6 @@ impl Model {
 		}
 		self.notify_advisors();
 		Ok(())
-	}
-
-	/// Process the model to create a [`Solver`] instance that can be used to
-	/// solve it.
-	///
-	/// This method will return a [`Solver`] instance in addition to a
-	/// [`LoweringMap`], which can be used to map from [`model::View`](View)
-	/// to [`solver::View`](crate::solver::View). If an error occurs during the
-	/// reformulation process, or if it is found to be trivially unsatisfiable,
-	/// then an error will be returned.
-	///
-	/// ```
-	/// # use huub::{
-	/// # 	lower::InitConfig,
-	/// # 	model::Model,
-	/// # 	solver::{Solver, Status, Valuation},
-	/// # };
-	/// # let mut model = Model::default();
-	/// # let x = model.new_int_decision(1..=3);
-	/// let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
-	/// let x = map.get(&mut solver, x);
-	///
-	/// let status = solver
-	/// 	.solve()
-	/// 	.on_solution(|solution| {
-	/// 		assert!((1..=3).contains(&x.val(solution)));
-	/// 	})
-	/// 	.satisfy();
-	/// assert_eq!(status, Status::Satisfied);
-	/// # Ok::<(), Box<dyn std::error::Error>>(())
-	/// ```
-	pub fn to_solver<Sat>(
-		&mut self,
-		config: &InitConfig,
-	) -> Result<(Solver<Sat>, LoweringMap), LoweringError>
-	where
-		Solver<Sat>: Default,
-		Sat: ExternalPropagation + 'static,
-	{
-		let mut slv = Solver::<Sat>::default();
-		let any_slv: &mut dyn Any = &mut slv.sat;
-		if let Some(r) = any_slv.downcast_mut::<Cadical>() {
-			// Set the solver options for preprocessing/inprocessing
-			r.set_option("condition", config.conditioning() as i32);
-			r.set_option("elim", config.variable_elimination() as i32);
-			r.set_option("exteagerreasons", config.reason_eager() as i32);
-			r.set_option("inprocessing", config.inprocessing() as i32);
-			r.set_limit("preprocessing", config.preprocessing() as i32);
-			r.set_option("probe", config.probing() as i32);
-			r.set_option("subsume", config.subsumption() as i32);
-			r.set_option("vivify", config.vivification() as i32);
-
-			// Set the solver options for search configurations
-			// Enable restart if the config is set to true or if there are no
-			// user search heuristics are provided
-			r.set_option("restart", config.restart() as i32);
-		} else {
-			warn!(
-				target: "solver",
-				"ignore vivification and restart options for unknown solver"
-			);
-		}
-
-		self.notify_advisors();
-		while let Some(con) = self.propagator_queue.pop() {
-			self.propagate(ConRef::from_raw(con))?;
-		}
-
-		// Determine encoding types for integer variables
-		let mut int_eager_direct = FxHashSet::<Resolved<Decision<IntVal>>>::default();
-		let int_eager_order = FxHashSet::<Resolved<Decision<IntVal>>>::default();
-
-		for c in self.constraints.iter().flatten() {
-			let c: &dyn Constraint<Model> = c.as_ref();
-			let c: &dyn Any = c;
-			if let Some(c) = c.downcast_ref::<BoolDecisionArrayElement>() {
-				let index = c.index.resolve_alias(self);
-				if let Some(var) = index.integer_decision() {
-					int_eager_direct.insert(var);
-				}
-			} else if let Some(c) = c.downcast_ref::<IntUnique>() {
-				for v in &c.bounds_prop.var {
-					let v = v.resolve_alias(self);
-					if let Some(var) = v.integer_decision() {
-						let Domain::Domain(dom) = &self.int_vars[var.idx()].domain else {
-							unreachable!()
-						};
-						if dom.card() <= Some(c.bounds_prop.var.len() * 100 / 80) {
-							int_eager_direct.insert(var);
-						}
-					}
-				}
-			} else if let Some(c) =
-				c.downcast_ref::<IntArrayElementBounds<View<IntVal>, View<IntVal>, View<IntVal>>>()
-			{
-				let index = c.index.resolve_alias(self);
-				if let Some(var) = index.integer_decision() {
-					int_eager_direct.insert(var);
-				}
-			} else if let Some(c) = c.downcast_ref::<IntTable>() {
-				for &v in &c.vars {
-					let v = v.resolve_alias(self);
-					if let Some(var) = v.integer_decision() {
-						int_eager_direct.insert(var);
-					}
-				}
-			} else if let Some(c) =
-				c.downcast_ref::<IntValArrayElement<View<IntVal>, View<IntVal>>>()
-			{
-				let index = c.0.index.resolve_alias(self);
-				if let Some(var) = index.integer_decision() {
-					int_eager_direct.insert(var);
-				}
-			}
-		}
-
-		// Create the mapping between model decisions and solver views.
-		let mut map_builder = LoweringMapBuilder {
-			bool_map: vec![None; self.bool_vars.len()],
-			int_eager_direct,
-			int_eager_limit: config.int_eager_limit(),
-			int_eager_order,
-			int_map: vec![None; self.int_vars.len()],
-		};
-
-		// Ensure the creation of all integer variables.
-		for (idx, _) in self.int_vars.iter().enumerate() {
-			map_builder.get_or_create_int(self, &mut slv, Decision(idx as u32));
-		}
-
-		// Ensure the creation of all Boolean variables.
-		for var in 1..=self.bool_vars.len() as u32 {
-			let raw = RawLit::from_raw(NonZeroI32::new(var as i32).unwrap());
-			map_builder.get_or_create_bool(self, &mut slv, Decision(raw).into());
-		}
-
-		// Finalize the reformulation map (all variables must be created by now)
-		let map = map_builder.finalize();
-
-		// Create constraint data structures within the solver
-		let mut ctx = LoweringContext::new(&mut slv, &map, &self.trail);
-		for c in self.constraints.iter().flatten() {
-			c.to_solver(&mut ctx)?;
-		}
-
-		Ok((slv, map))
 	}
 }
 
@@ -680,7 +562,7 @@ mod tests {
 		constraints::{
 			BoolModelActions, Constraint, IntModelActions, Propagator, SimplificationStatus,
 		},
-		lower::{InitConfig, LoweringContext, LoweringError},
+		lower::{LoweringContext, LoweringError},
 		model::{Model, View, deserialize::AnyView},
 		solver::Solver,
 	};
@@ -701,9 +583,7 @@ mod tests {
 		let i1 = prb.new_int_decision(-1..=0);
 		i1.unify(&mut prb, !b - 1).expect("unify failed");
 
-		let (mut slv, map): (Solver, _) = prb
-			.to_solver(&InitConfig::default())
-			.expect("to_solver failed");
+		let (mut slv, map): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");
 		let b_slv = map.get_any(&mut slv, AnyView::from(b));
 		let i1_slv = map.get_any(&mut slv, AnyView::from(i1));
 		slv.expect_solutions(
@@ -730,9 +610,7 @@ mod tests {
 		};
 		prb.post_constraint(t);
 		i.tighten_min(&mut prb, 2, []).expect("tighten_min failed");
-		let (_, _): (Solver, _) = prb
-			.to_solver(&InitConfig::default())
-			.expect("to_solver failed");
+		let (_, _): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");
 		assert_eq!(prb.trailed(bool_check), 1);
 	}
 
@@ -752,9 +630,7 @@ mod tests {
 		};
 		prb.post_constraint(t);
 		i.tighten_min(&mut prb, 1, []).expect("tighten_min failed");
-		let (_, _): (Solver, _) = prb
-			.to_solver(&InitConfig::default())
-			.expect("to_solver failed");
+		let (_, _): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");
 		assert_eq!(prb.trailed(bool_check), 0);
 	}
 
@@ -775,9 +651,7 @@ mod tests {
 		prb.post_constraint(t);
 		i.tighten_min(&mut prb, 1, []).expect("tighten_min failed");
 		i.tighten_max(&mut prb, 2, []).expect("tighten_max failed");
-		let (mut slv, map): (Solver, _) = prb
-			.to_solver(&InitConfig::default())
-			.expect("to_solver failed");
+		let (mut slv, map): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");
 		assert_eq!(prb.trailed(int_check), 1);
 		let i_slv = map.get(&mut slv, i);
 		let (min, max) = i_slv.bounds(&slv);

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -17,7 +17,7 @@ use flatzinc_serde::{
 	NamedRef, Type, Variable, helpers::ArcKey,
 };
 use itertools::Itertools;
-use pindakaas::{propositional_logic::Formula, solver::propagation::ExternalPropagation};
+use pindakaas::propositional_logic::Formula;
 use rangelist::IntervalIterator;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::warn;
@@ -28,7 +28,7 @@ use crate::{
 		BoolPropagationActions, BoolSimplificationActions, IntSimplificationActions,
 		PropagationActions,
 	},
-	lower::{InitConfig, LoweringError},
+	lower::{Lowerer, LowererComplete, LoweringError},
 	model::{
 		Model,
 		deserialize::{AnyView, Branching, Goal},
@@ -36,7 +36,7 @@ use crate::{
 		view::{View, boolean::BoolView},
 	},
 	solver::{
-		self, Solver,
+		self,
 		branchers::{ValueSelection, VariableSelection},
 	},
 };
@@ -212,7 +212,7 @@ pub enum ConstraintIdent {
 }
 
 /// Errors that can occur when converting a [`FlatZinc`] instance to a [`Model`]
-/// or [`Solver`] object.
+/// or [`Solver`](crate::solver::Solver) object.
 #[derive(Debug)]
 pub enum FlatZincError {
 	/// FlatZinc instance contained a decision variable with an unsupported
@@ -240,8 +240,17 @@ pub enum FlatZincError {
 		found: String,
 	},
 	/// Error that occurred when constructing the [`Model`] object or
-	/// translating it to a [`Solver`] object.
+	/// translating it to a [`Solver`](crate::solver::Solver) object.
 	ReformulationError(LoweringError),
+}
+
+#[derive(Clone, Debug)]
+/// Intermediate data structure used during the lowering of a FlatZinc instance.
+pub struct FlatZincLowerData {
+	/// Metadata produced when building the model from the FlatZinc instance.
+	pub(crate) meta: FlatZincModelMeta,
+	/// The [`Model`] instance created from the FlatZinc instance.
+	pub(crate) model: Model,
 }
 
 /// Metadata produced when building a model from a FlatZinc instance.
@@ -313,6 +322,31 @@ pub(crate) struct FznModelBuilder<'a> {
 	processed: Vec<bool>,
 	/// Statistics about the extraction process
 	stats: FlatZincStatistics,
+}
+
+/// Trait that extends [`FlatZinc`] with Huub-specific functionality.
+///
+/// This trait provides the [`lower()`](HuubFlatZinc::lower) method, which is
+/// the recommended way to convert a FlatZinc instance into a Huub [`Model`] or
+/// [`Solver`](crate::solver::Solver).
+///
+/// ```rust,ignore
+/// use huub::model::deserialize::flatzinc::HuubFlatZinc;
+///
+/// // Lower to a model
+/// let (model, meta) = fzn.lower().to_model()?;
+///
+/// // Lower to a solver with custom configuration
+/// let (solver, meta) = fzn.lower()
+///     .preprocessing(2)
+///     .to_solver()?;
+/// ```
+pub trait HuubFlatZinc {
+	/// Returns a builder that can be used to lower the [`FlatZinc`] instance
+	/// to a [`Model`] (via [`to_model()`](Lowerer::to_model)) or directly to
+	/// a [`Solver`](crate::solver::Solver) (via
+	/// [`to_solver()`](Lowerer::to_solver)).
+	fn lower(&self) -> Lowerer<Result<FlatZincLowerData, FlatZincError>>;
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -521,6 +555,24 @@ impl TryFrom<&str> for ConstraintIdent {
 			"set_in_reif" => Ok(Self::SetInReif),
 			_ => Err(()),
 		}
+	}
+}
+
+impl HuubFlatZinc for FlatZinc<FznIdent> {
+	fn lower(&self) -> Lowerer<Result<FlatZincLowerData, FlatZincError>> {
+		let deserialize_model = |fzn: &FlatZinc<FznIdent>| {
+			let mut builder = FznModelBuilder::new(fzn);
+			builder.unify_variables()?;
+			builder.extract_views()?;
+			builder.post_constraints()?;
+			builder.ensure_output()?;
+
+			builder.finalize()
+		};
+
+		LowererComplete::builder_internal(
+			deserialize_model(self).map(|(model, meta)| FlatZincLowerData { meta, model }),
+		)
 	}
 }
 
@@ -2352,54 +2404,6 @@ impl Display for KnownIdent {
 			Self::Annotation(ident) => Display::fmt(ident, f),
 			Self::Constraint(ident) => Display::fmt(ident, f),
 		}
-	}
-}
-
-impl Model {
-	/// Create a new [`Model`] instance from a [`FlatZinc`] instance.
-	pub fn from_fzn(fzn: &FlatZinc<FznIdent>) -> Result<(Self, FlatZincModelMeta), FlatZincError> {
-		let mut builder = FznModelBuilder::new(fzn);
-		builder.unify_variables()?;
-		builder.extract_views()?;
-		builder.post_constraints()?;
-		builder.ensure_output()?;
-
-		builder.finalize()
-	}
-}
-
-impl<Sat: ExternalPropagation> Solver<Sat> {
-	/// Create a new [`Solver`] instance from a [`FlatZinc`] instance.
-	pub fn from_fzn(
-		fzn: &FlatZinc<FznIdent>,
-		config: &InitConfig,
-	) -> Result<(Self, FlatZincSolverMeta), FlatZincError>
-	where
-		Solver<Sat>: Default,
-		Sat: 'static,
-	{
-		let (mut prb, meta) = Model::from_fzn(fzn)?;
-		let (mut slv, map) = prb.to_solver(config)?;
-		if let Some(branching) = meta.branching {
-			branching.to_solver(&mut slv, &map);
-		}
-		let names = meta
-			.names
-			.into_iter()
-			.map(|(k, v)| (k, map.get_any(&mut slv, v)))
-			.collect();
-		let goal = meta.goal.map(|g| match g {
-			Goal::Minimize(v) => Goal::Minimize(map.get(&mut slv, v)),
-			Goal::Maximize(v) => Goal::Maximize(map.get(&mut slv, v)),
-		});
-		Ok((
-			slv,
-			FlatZincSolverMeta {
-				names,
-				stats: meta.stats,
-				goal,
-			},
-		))
 	}
 }
 

--- a/crates/huub/src/model/expressions.rs
+++ b/crates/huub/src/model/expressions.rs
@@ -187,7 +187,6 @@ impl Model {
 	///
 	/// ```
 	/// # use huub::{
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
@@ -196,7 +195,7 @@ impl Model {
 	/// let y = model.new_int_decision(0..=10);
 	///
 	/// model.linear(x * 2 + y).eq(7).post();
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	/// # let x = map.get(&mut solver, x);
 	/// # let y = map.get(&mut solver, y);
 	/// # let status = solver
@@ -440,7 +439,6 @@ impl Model {
 	///
 	/// ```
 	/// # use huub::{
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
@@ -448,7 +446,7 @@ impl Model {
 	/// let x = model.new_int_decisions(3, 1..=3);
 	/// # let x_clone = x.clone();
 	/// model.unique(x).post();
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	/// # let &[x, y, z] = x_clone
 	/// # 	.into_iter()
 	/// # 	.map(|var| map.get(&mut solver, var))
@@ -748,7 +746,6 @@ impl<'a, S: model_linear_builder::State> ModelLinearBuilder<'a, S> {
 	///
 	/// ```
 	/// # use huub::{
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
@@ -759,7 +756,7 @@ impl<'a, S: model_linear_builder::State> ModelLinearBuilder<'a, S> {
 	/// let at_least_three = model.linear(x - y).ge(3).reify();
 	///
 	/// # model.proposition(at_least_three).post();
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	/// # let x = map.get(&mut solver, x);
 	/// # let at_least_three = map.get(&mut solver, at_least_three);
 	/// # let status = solver

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -458,11 +458,11 @@ where
 	///
 	/// Collect all satisfying assignments:
 	/// ```
-	/// # use huub::{lower::InitConfig, model::Model, solver::{Solver, Status}};
+	/// # use huub::{model::Model, solver::{Solver, Status}};
 	/// # let mut model = Model::default();
 	/// # let x = model.new_int_decision(1..=3);
 	/// # let y = model.new_int_decision(1..=3);
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	/// # let x = map.get(&mut solver, x);
 	/// # let y = map.get(&mut solver, y);
 	/// let mut solutions = Vec::new();
@@ -852,12 +852,11 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 	/// Simple satisfiability solving:
 	/// ```
 	/// # use huub::{
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{Solver, Status},
 	/// # };
 	/// # let mut model = Model::default();
-	/// # let (mut solver, _): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, _): (Solver, _) = model.lower().to_solver()?;
 	/// let status = solver.solve().satisfy();
 	/// assert_eq!(status, Status::Satisfied);
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -866,14 +865,13 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 	/// Satisfiability with callback to inspect solution:
 	/// ```
 	/// # use huub::{
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
 	/// # let mut model = Model::default();
 	/// # let x = model.new_int_decision(1..=4);
 	/// # model.linear(x).ne(2).post();
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	/// # let x = map.get(&mut solver, x);
 	/// let mut value = None;
 	/// let status = solver
@@ -890,13 +888,12 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 	/// Optimization with callbacks:
 	/// ```
 	/// # use huub::{
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
 	/// # let mut model = Model::default();
 	/// # let x = model.new_int_decision(1..=4);
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	/// # let x = map.get(&mut solver, x);
 	/// let (status, optimum) = solver.solve().on_solution(|_| {}).minimize(x);
 	/// assert_eq!(status, Status::Complete);
@@ -907,13 +904,12 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 	/// With assumptions for incremental solving:
 	/// ```
 	/// # use huub::{
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{Solver, Status},
 	/// # };
 	/// # let mut model = Model::default();
 	/// # let b = model.new_bool_decision();
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	/// # let b = map.get(&mut solver, b);
 	/// let status = solver.solve().assuming([b]).on_failure(|_| {}).satisfy();
 	/// assert_eq!(status, Status::Satisfied);
@@ -923,13 +919,12 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 	/// Enumerating all solutions:
 	/// ```
 	/// # use huub::{
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{Solver, Status, Valuation},
 	/// # };
 	/// # let mut model = Model::default();
 	/// # let x = model.new_int_decision(1..=3);
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	/// # let x = map.get(&mut solver, x);
 	/// let mut count = 0;
 	/// let status = solver

--- a/crates/huub/src/solver/branchers.rs
+++ b/crates/huub/src/solver/branchers.rs
@@ -211,7 +211,6 @@ impl IntBrancher {
 	///
 	/// ```
 	/// # use huub::{
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{
 	/// # 		Solver, Status, Valuation,
@@ -222,7 +221,7 @@ impl IntBrancher {
 	/// # let x = model.new_int_decision(1..=3);
 	/// # let y = model.new_int_decision(1..=3);
 	/// # model.linear(x + y).eq(4).post();
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	/// # let x = map.get(&mut solver, x);
 	/// # let y = map.get(&mut solver, y);
 	/// IntBrancher::new_in(
@@ -355,13 +354,12 @@ impl WarmStartBrancher {
 	/// ```
 	/// # use huub::{
 	/// # 	actions::IntDecisionActions,
-	/// # 	lower::InitConfig,
 	/// # 	model::Model,
 	/// # 	solver::{IntLitMeaning, Solver, Status, Valuation, branchers::WarmStartBrancher},
 	/// # };
 	/// # let mut model = Model::default();
 	/// # let x = model.new_int_decision(1..=3);
-	/// # let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default())?;
+	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	/// # let x = map.get(&mut solver, x);
 	/// let prefer_two = x.lit(&mut solver, IntLitMeaning::Eq(2));
 	/// WarmStartBrancher::new_in(&mut solver, vec![prefer_two]);

--- a/crates/huub/src/tests.rs
+++ b/crates/huub/src/tests.rs
@@ -12,7 +12,7 @@ use tracing_test::traced_test;
 use crate::{
 	IntSet, IntVal,
 	constraints::int_linear::{IntLinearLessEqBounds, IntLinearNotEqValue},
-	lower::{InitConfig, LoweringError},
+	lower::LoweringError,
 	model::{Model, deserialize::AnyView as ModelView},
 	solver::{
 		AnyView as SolverView, Solver, Status, Valuation, Value,
@@ -32,7 +32,7 @@ fn it_works() {
 	prb.proposition(Formula::Or(vec![a.into(), b.into()]))
 		.post();
 
-	let (mut slv, map): (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
+	let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 	let a = map.get(&mut slv, a);
 	let b = map.get(&mut slv, b);
 
@@ -194,7 +194,7 @@ fn test_unify_int_impossible() {
 
 	prb.linear(a * 2).eq(b * 5).post();
 
-	let (mut slv, map): (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
+	let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 	let a = map.get(&mut slv, a);
 	let b = map.get(&mut slv, b);
 
@@ -217,7 +217,7 @@ fn test_unify_int_lin_view_domains() {
 
 	prb.linear(a * 6).eq(b * 2).post();
 
-	let (mut slv, map): (Solver, _) = prb.to_solver(&InitConfig::default()).unwrap();
+	let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 	let a = map.get(&mut slv, a);
 	let b = map.get(&mut slv, b);
 	let vars = vec![a, b];
@@ -321,7 +321,7 @@ fn test_unify_int_view_for_bool_6() {
 
 impl Model {
 	pub(crate) fn assert_unsatisfiable(&mut self) {
-		let err: Result<(Solver, _), _> = self.to_solver(&InitConfig::default());
+		let err: Result<(Solver, _), _> = self.lower().to_solver();
 		assert!(
 			matches!(err, Err(LoweringError::Simplification(_))),
 			"expected unsatisfiable"
@@ -333,7 +333,7 @@ impl Model {
 		vars: &[V],
 		expected: Expect,
 	) {
-		let (mut slv, map) = self.to_solver(&InitConfig::default()).unwrap();
+		let (mut slv, map) = self.lower().to_solver().unwrap();
 		let vars = vars
 			.iter()
 			.map(|v| map.get_any(&mut slv, v.clone().into()))

--- a/docs/src/modelling/constraints.md
+++ b/docs/src/modelling/constraints.md
@@ -7,7 +7,7 @@ While decision variables represent the unknowns, constraints encode the problem 
 ## Understanding constraints and propagation
 
 When you post constraints to Huub, they are stored in the model.
-Once you convert the model to a solver (via `to_solver`), Huub's *constraint propagation* eliminates values from domains that would violate the constraints.
+Once you convert the model to a solver (via `lower().to_solver()`), Huub's *constraint propagation* eliminates values from domains that would violate the constraints.
 This reduction happens automatically, even before the solver begins searching for solutions.
 
 For example, if you post the constraint that `x != y` (x and y are different), and x can be {1, 2, 3} while y is {3}, then:

--- a/docs/src/modelling/getting-started.md
+++ b/docs/src/modelling/getting-started.md
@@ -72,7 +72,8 @@ Now that we have defined the model, we need to convert it to a solver and run th
 
 ### Converting to a solver
 
-The first step is to convert the model to a solver object that can search for solutions:
+The first step is to convert the model to a solver object that can search for solutions.
+We do this using the `lower()` method, which returns a builder that allows for solver configuration before finalizing the conversion with `to_solver()`:
 
 ```rust,ignore
 {{#include ../../../crates/huub/examples/send-more-money/main.rs:convert_to_solver}}

--- a/docs/src/modelling/search-branching.md
+++ b/docs/src/modelling/search-branching.md
@@ -84,7 +84,6 @@ To use a brancher, create it with a list of decisions, a decision selection stra
 ```rust
 # extern crate huub;
 # use huub::{
-# 	lower::InitConfig,
 # 	model::Model,
 # 	solver::{
 # 		branchers::{IntBrancher, ValueSelection, VariableSelection},
@@ -94,7 +93,7 @@ To use a brancher, create it with a list of decisions, a decision selection stra
 # let mut model = Model::default();
 # let x = model.new_int_decision(0..=100);
 # let y = model.new_int_decision(0..=100);
-# let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
+# let (mut solver, map): (Solver, _) = model.lower().to_solver().unwrap();
 # let x = map.get(&mut solver, x);
 # let y = map.get(&mut solver, y);
 // Use an IntBrancher to branch on decisions [x, y] using FirstFail and
@@ -128,14 +127,13 @@ This makes warm-starting robust: if your partial solution turns out to be incomp
 # extern crate huub;
 # use huub::{
 # 	actions::IntDecisionActions,
-# 	lower::InitConfig,
 # 	model::Model,
 # 	solver::{branchers::WarmStartBrancher, IntLitMeaning, Solver},
 # };
 # let mut model = Model::default();
 # let b = model.new_bool_decision();
 # let x = model.new_int_decision(1..=10);
-# let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
+# let (mut solver, map): (Solver, _) = model.lower().to_solver().unwrap();
 # let b = map.get(&mut solver, b);
 # let x = map.get(&mut solver, x);
 // Warm start by suggesting certain boolean decisions should be true
@@ -161,13 +159,12 @@ Once you have created a solver, you can search for solutions using the `solve()`
 ```rust
 # extern crate huub;
 # use huub::{
-# 	lower::InitConfig,
 # 	model::Model,
 # 	solver::{Solver, Status},
 # };
 # let mut model = Model::default();
 # let x = model.new_int_decision(1..=9);
-# let (mut solver, _): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
+# let (mut solver, _): (Solver, _) = model.lower().to_solver().unwrap();
 let status = solver
 	.solve()
 	.on_solution(|solution| {
@@ -199,12 +196,11 @@ The `set_terminate_callback` method allows you to provide a closure that returns
 # use std::time::Instant;
 #
 # use huub::{
-# 	lower::InitConfig,
 # 	model::Model,
 # 	solver::{Solver, Status, TerminationSignal},
 # };
 # let mut model = Model::default();
-# let (mut solver, _): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
+# let (mut solver, map): (Solver, _) = model.lower().to_solver().unwrap();
 let start_time = Instant::now();
 let time_limit = std::time::Duration::from_secs(10);
 
@@ -248,7 +244,6 @@ This performs an iterative search: after finding each solution, it adds a constr
 ```rust
 # extern crate huub;
 # use huub::{
-# 	lower::InitConfig,
 # 	model::Model,
 # 	solver::{Solver, Status, Valuation},
 # };
@@ -256,7 +251,7 @@ This performs an iterative search: after finding each solution, it adds a constr
 # let x = model.new_int_decision(0..=100);
 # let y = model.new_int_decision(0..=100);
 # let cost = model.linear(x + y).define();
-# let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
+# let (mut solver, map): (Solver, _) = model.lower().to_solver().unwrap();
 # let cost = map.get(&mut solver, cost);
 let (status, optimal_cost) = solver
 	.solve()
@@ -299,7 +294,6 @@ This is useful for exploring the solution space, enumerating all valid assignmen
 ```rust
 # extern crate huub;
 # use huub::{
-# 	lower::InitConfig,
 # 	model::Model,
 # 	solver::{Solver, Status, Valuation},
 # };
@@ -307,7 +301,7 @@ This is useful for exploring the solution space, enumerating all valid assignmen
 # let x = model.new_int_decision(1..=3);
 # let y = model.new_int_decision(1..=3);
 # model.linear(x).ne(y).post();
-# let (mut solver, map): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
+# let (mut solver, map): (Solver, _) = model.lower().to_solver().unwrap();
 # let x = map.get(&mut solver, x);
 # let y = map.get(&mut solver, y);
 let mut num_sol = 0;
@@ -351,9 +345,9 @@ You can retrieve statistics about the search process to understand solver behavi
 
 ```rust
 # extern crate huub;
-# use huub::{lower::InitConfig, model::Model, solver::Solver};
+# use huub::{model::Model, solver::Solver};
 # let mut model = Model::default();
-# let (mut solver, _): (Solver, _) = model.to_solver(&InitConfig::default()).unwrap();
+# let (mut solver, _): (Solver, _) = model.lower().to_solver().unwrap();
 # let _ = solver.solve().on_solution(|_| {}).satisfy();
 let stats = solver.solver_statistics();
 
@@ -375,44 +369,43 @@ These statistics help you understand:
 ## SAT Solver Control Options
 
 Huub's underlying SAT solver includes various preprocessing and inprocessing techniques that can be tuned to control search behavior and performance.
-These are configured when creating the solver through the `InitConfig`:
+These are configured using the builder returned by `lower()` before calling `to_solver()`:
 
 ```rust
 # extern crate huub;
-# use huub::{lower::InitConfig, model::Model, solver::Solver};
+# use huub::{model::Model, solver::Solver};
 # let mut model = Model::default();
 # let x = model.new_int_decision(0..=10);
 // Enable/disable various SAT preprocessing and inprocessing techniques
-let mut config = InitConfig::default()
-	.with_preprocessing(2)
-	.with_inprocessing(true)
-	.with_probing(true)
-	.with_subsumption(true)
-	.with_variable_elimination(true)
-	.with_vivification(true)
-	.with_conditioning(true)
-	.with_reason_eager(true);
-
-# let (_, _): (Solver, _) = model.to_solver(&config).unwrap();
+let (mut solver, map): (Solver, _) = model.lower()
+	.preprocessing(2)
+	.inprocessing(true)
+	.probing(true)
+	.subsumption(true)
+	.variable_elimination(true)
+	.vivification(true)
+	.conditioning(true)
+	.reason_eager(true)
+	.to_solver()
+# .unwrap();
 ```
 
 **Key SAT solver options:**
 
-- **Preprocessing** (`with_preprocessing(n)`): Run N rounds of SAT preprocessing before search begins.
+- `preprocessing(n)`: Run N rounds of SAT preprocessing before search begins.
   More rounds can reduce the problem size but take more time upfront.
-- **Inprocessing** (`with_inprocessing(bool)`):
-  Enable or disable SAT inprocessing during search.
+- `inprocessing(bool)`: Enable or disable SAT inprocessing during search.
   Inprocessing simplifies clauses and removes redundant variables as the solver learns more.
   Can improve search efficiency but adds overhead.
-- **Probing** (`with_probing(bool)`): Enable or disable failed-literal probing, which tries to detect implications of setting variables to specific values.
+- `probing(bool)`: Enable or disable failed-literal probing, which tries to detect implications of setting variables to specific values.
   This helps find inconsistencies early, but it is computationally expensive.
-- **Subsumption** (`with_subsumption(bool)`): Enable or disable forward subsumption, which removes clauses that are subsumed by learned clauses.
+- `subsumption(bool)`: Enable or disable forward subsumption, which removes clauses that are subsumed by learned clauses.
   This reduces clause database bloat, but requires expensive checking.
-- **Variable Elimination** (`with_variable_elimination(bool)`): Enable or disable bounded variable elimination, which removes variables by adding resolvent clauses.
+- `variable_elimination(bool)`: Enable or disable bounded variable elimination, which removes variables by adding resolvent clauses.
   It can reduce the problem size significantly, but it is expensive.
-- **Vivification** (`with_vivification(bool)`): Enable or disable clause vivification, which strengthens clauses by removing literals that are implied. Helps derive stronger learned clauses.
-- **Conditioning** (`with_conditioning(bool)`): Enable or disable blocked clause elimination (conditioning), which removes clauses that are logically redundant with respect to the learned clause set.
-- **Reason Eager** (`with_reason_eager(bool)`): Eagerly compute explanation clauses for all literals propagated at the conflict level.
+- `vivification(bool)`: Enable or disable clause vivification, which strengthens clauses by removing literals that are implied. Helps derive stronger learned clauses.
+- `conditioning(bool)`: Enable or disable blocked clause elimination (conditioning), which removes clauses that are logically redundant with respect to the learned clause set.
+- `reason_eager(bool)`: Eagerly compute explanation clauses for all literals propagated at the conflict level.
   This improves explanations but adds memory overhead.
 
 These options trade off between problem size reduction (fewer variables/clauses means faster search) and preprocessing time.


### PR DESCRIPTION
This commit replaces the `Model::to_solver` method and the `Solver::from_fzn`
method with a unified, fluent builder-based API using the `bon` crate.
The new entry point for all conversion and reformulation tasks is the
`lower()` method, which returns a `Lowerer` builder. The `lower()` builder
is finalized with `.to_solver()` or `.to_model()`.
