### PR TITLE
feat: propagate constraint builders immediately

### DIFF
--- a/crates/huub/examples/jobshop/main.rs
+++ b/crates/huub/examples/jobshop/main.rs
@@ -20,6 +20,7 @@ mod brancher;
 mod model;
 
 use std::{
+	error::Error,
 	fmt::{self, Display},
 	path::PathBuf,
 	sync::{
@@ -31,8 +32,8 @@ use std::{
 
 use clap::{ArgAction, Parser, ValueEnum, builder::BoolishValueParser};
 use huub::{
-	lower::Lowerer,
-	solver::{SearchStrategy, Solver, SwitchTrigger, TerminationSignal, Valuation},
+	lower::{Lowerer, LoweringError},
+	solver::{SearchStrategy, Solver, Status, SwitchTrigger, TerminationSignal, Valuation},
 };
 
 use crate::{
@@ -133,7 +134,7 @@ enum SearchTrigger {
 	Restarts,
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
 	let options = match Cli::try_parse_from(std::env::args_os()) {
 		Ok(options) => options,
 		Err(err) => {
@@ -151,12 +152,6 @@ fn main() {
 			std::process::exit(2);
 		}
 	};
-	let JobShopModel {
-		mut model,
-		start_time,
-		objective: objective_variable,
-	} = JobShopModel::new(&instance, options.objective_type);
-
 	println!(
 		"Parsed JSP instance: {} jobs, {} machines, {} operations, max time {}",
 		instance.n,
@@ -168,14 +163,26 @@ fn main() {
 	println!("Solver configurations:");
 	println!("{0}", options);
 
+	let JobShopModel {
+		mut model,
+		start_time,
+		objective: objective_variable,
+	} = match JobShopModel::new(&instance, options.objective_type) {
+		Ok(model) => model,
+		Err(LoweringError::Simplification(_)) => {
+			println!("Status: {:?}", Status::Unsatisfiable);
+			return Ok(());
+		}
+		Err(err) => return Err(err.into()),
+	};
+
 	// Configure solver initialization options.
 	let (mut slv, map): (Solver, _) = model
 		.lower()
 		.restart(options.restart)
 		.int_eager_limit(options.int_eager_limit)
 		.reason_eager(options.reason_eager)
-		.to_solver()
-		.unwrap();
+		.to_solver()?;
 
 	options
 		.branching_strategy
@@ -253,6 +260,7 @@ fn main() {
 			(Instant::now() - start).as_secs_f32()
 		);
 	}
+	Ok(())
 }
 
 /// Parses a time duration for the time limit flag.

--- a/crates/huub/examples/jobshop/model.rs
+++ b/crates/huub/examples/jobshop/model.rs
@@ -8,7 +8,7 @@ use std::{
 
 use clap::ValueEnum;
 use huub::{
-	lower::LoweringMap,
+	lower::{LoweringError, LoweringMap},
 	model::{self, Model, expressions::IntLinearExp},
 	solver::{self, Solver, Valuation},
 };
@@ -180,7 +180,10 @@ impl Instance {
 
 impl JobShopModel {
 	/// Create a new job shop model for the given instance and objective type.
-	pub(crate) fn new(instance: &Instance, objective_type: ObjectiveType) -> Self {
+	pub(crate) fn new(
+		instance: &Instance,
+		objective_type: ObjectiveType,
+	) -> Result<Self, LoweringError> {
 		let mut model = Model::default();
 		// ANCHOR: create_decision_variables
 		let mut start_time = Vec::with_capacity(instance.n);
@@ -193,7 +196,7 @@ impl JobShopModel {
 		for (job, job_start_time) in instance.jobs.iter().zip(&start_time) {
 			for (op_idx, op) in job.iter().enumerate().take(job.len().saturating_sub(1)) {
 				let op_end = job_start_time[op_idx] + op.processing_time as i64;
-				model.linear(job_start_time[op_idx + 1]).ge(op_end).post();
+				model.linear(job_start_time[op_idx + 1]).ge(op_end).post()?;
 			}
 		}
 		// ANCHOR_END: precedence_constraints
@@ -211,7 +214,7 @@ impl JobShopModel {
 				.disjunctive()
 				.start_times(op_start_times)
 				.durations(op_durations)
-				.post();
+				.post()?;
 		}
 		// ANCHOR_END: disjunctive_constraints
 
@@ -221,7 +224,7 @@ impl JobShopModel {
 			ObjectiveType::Makespan => {
 				let makespan = model.new_int_decision(0..=(instance.max_time as i64));
 				for completion_time in completion_times {
-					model.linear(makespan).ge(completion_time).post();
+					model.linear(makespan).ge(completion_time).post()?;
 				}
 				makespan
 			}
@@ -232,11 +235,11 @@ impl JobShopModel {
 		};
 		// ANCHOR_END: define_objective
 
-		JobShopModel {
+		Ok(JobShopModel {
 			model,
 			start_time,
 			objective: objective_variable,
-		}
+		})
 	}
 }
 
@@ -342,7 +345,7 @@ mod tests {
 			mut model,
 			objective,
 			..
-		} = JobShopModel::new(&instance, objective_type);
+		} = JobShopModel::new(&instance, objective_type).unwrap();
 		let (mut slv, map): (Solver, _) = model.lower().to_solver().unwrap();
 		let obj = map.get(&mut slv, objective);
 		let mut best = None;

--- a/crates/huub/examples/send-more-money/main.rs
+++ b/crates/huub/examples/send-more-money/main.rs
@@ -26,6 +26,7 @@ macro_rules! println {
 use std::{fmt::Write, sync::Mutex};
 
 use huub::{
+	lower::LoweringError,
 	model::Model,
 	solver::{Solver, Valuation},
 };
@@ -35,7 +36,7 @@ use huub::{
 static OUTPUT: Mutex<String> = Mutex::new(String::new());
 
 /// Runs the Send More Money solver and prints the solution.
-pub fn main() {
+pub fn main() -> Result<(), LoweringError> {
 	// ANCHOR: create_model
 	let mut model = Model::default();
 
@@ -55,7 +56,7 @@ pub fn main() {
 
 	// ANCHOR: unique_constraint
 	// All variables must be different
-	model.unique(vec![s, e, n, d, m, o, r, y]).post();
+	model.unique(vec![s, e, n, d, m, o, r, y]).post()?;
 	// ANCHOR_END: unique_constraint
 
 	// ANCHOR: arithmetic_constraint
@@ -63,18 +64,12 @@ pub fn main() {
 	let send = s * 1000 + e * 100 + n * 10 + d;
 	let more = m * 1000 + o * 100 + r * 10 + e;
 	let money = m * 10000 + o * 1000 + n * 100 + e * 10 + y;
-	model.linear(send + more).eq(money).post();
+	model.linear(send + more).eq(money).post()?;
 	// ANCHOR_END: arithmetic_constraint
 
 	// ANCHOR: convert_to_solver
 	// Convert the model to a solver
-	let (mut solver, map): (Solver, _) = match model.lower().to_solver() {
-		Ok(result) => result,
-		Err(e) => {
-			eprintln!("Error initializing solver: {}", e);
-			return;
-		}
-	};
+	let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
 	// ANCHOR_END: convert_to_solver
 
 	// ANCHOR: map_variables
@@ -106,6 +101,7 @@ M={m}, O={o}, N={n}, E={e}, Y={y}
 		})
 		.satisfy();
 	// ANCHOR_END: solve_and_print
+	Ok(())
 }
 
 #[cfg(test)]
@@ -115,7 +111,7 @@ mod tests {
 	#[test]
 	fn send_more_money() {
 		// Run the solver, collecting its output in `OUTPUT`
-		main();
+		main().unwrap();
 
 		// Parse the output to extract variable values
 		let output = OUTPUT.lock().unwrap();

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -975,12 +975,12 @@ mod tests {
 		// completion time: 3. No compulsory part.
 		let start_time_c = prb.new_int_decision(0..=4);
 		let usages = prb.new_int_decisions(3, 1..=2);
-		prb.cumulative()
-			.start_times(vec![start_time_a, start_time_b, start_time_c])
-			.durations(vec![3, 3, 3])
-			.usages(usages.clone())
-			.capacity(2)
-			.post();
+		prb.post_constraint_internal(CumulativeTimeTable::new(
+			vec![start_time_a, start_time_b, start_time_c],
+			vec![3, 3, 3],
+			usages.clone(),
+			2,
+		));
 
 		// First propagation: The compulsory parts of Task A and B ([0, 2])
 		// require that Task C cannot overlap with them due to capacity constraints.

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -490,7 +490,8 @@ mod tests {
 		prb.element(vec![a, b, c])
 			.index(index)
 			.result(result)
-			.post();
+			.post()
+			.unwrap();
 		index.remove_val(&mut prb, 2, []).unwrap();
 		let _: (Solver, _) = prb.lower().to_solver().unwrap();
 
@@ -510,7 +511,8 @@ mod tests {
 		prb.element(vec![a, b, c])
 			.index(index)
 			.result(result)
-			.post();
+			.post()
+			.unwrap();
 		index.remove_val(&mut prb, 0, []).unwrap();
 		let _: (Solver, _) = prb.lower().to_solver().unwrap();
 
@@ -627,10 +629,12 @@ mod tests {
 		let result = prb.new_int_decision(1..=2);
 		let index = prb.new_int_decision(0..=2);
 
-		prb.element(vec![a, b, c])
-			.index(index)
-			.result(result)
-			.post();
-		prb.assert_unsatisfiable();
+		assert!(
+			prb.element(vec![a, b, c])
+				.index(index)
+				.result(result)
+				.post()
+				.is_err()
+		);
 	}
 }

--- a/crates/huub/src/constraints/int_array_minimum.rs
+++ b/crates/huub/src/constraints/int_array_minimum.rs
@@ -42,7 +42,7 @@ impl<E, I1, I2> Constraint<E> for IntArrayMinimumBounds<I1, I2>
 where
 	E: ReasoningEngine,
 	I1: IntModelActions<E>,
-	I2: IntModelActions<E>,
+	I2: IntModelActions<E> + Into<I1>,
 {
 	fn simplify(
 		&mut self,
@@ -50,6 +50,20 @@ where
 	) -> Result<SimplificationStatus, E::Conflict> {
 		self.propagate(ctx)?;
 
+		// Filter out variables that are too large to be the minimum
+		let max_min = self.min.max(ctx);
+		self.vars.retain(|v| v.min(ctx) <= max_min);
+		debug_assert!(!self.vars.is_empty());
+
+		// If there is only one variable left, unify it with the minimum value and
+		// subsume the constraint.
+		if self.vars.len() == 1 {
+			self.vars[0].unify(ctx, self.min.clone())?;
+			return Ok(SimplificationStatus::Subsumed);
+		}
+
+		// If the minimum value is known and one of the variables is equal to it,
+		// tighten the minimum bounds of the others and subsume the constraint.
 		if let Some(c) = self.min.val(ctx)
 			&& self.vars.iter().any(|v| v.val(ctx) == Some(c))
 		{
@@ -144,7 +158,7 @@ mod tests {
 		let c = prb.new_int_decision(2..=5);
 		let y = prb.new_int_decision(1..=3);
 
-		prb.maximum(vec![a, b, c]).result(y).post();
+		prb.maximum(vec![a, b, c]).result(y).post().unwrap();
 
 		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vec![a, b, c, y]
@@ -173,8 +187,7 @@ mod tests {
 		let c = prb.new_int_decision(4..=10);
 		let y = prb.new_int_decision(13..=20);
 
-		prb.maximum(vec![a, b, c]).result(y).post();
-		prb.assert_unsatisfiable();
+		assert!(prb.maximum(vec![a, b, c]).result(y).post().is_err());
 	}
 
 	#[test]
@@ -186,7 +199,7 @@ mod tests {
 		let c = prb.new_int_decision(2..=3);
 		let y = prb.new_int_decision(3..=4);
 
-		prb.minimum(vec![a, b, c]).result(y).post();
+		prb.minimum(vec![a, b, c]).result(y).post().unwrap();
 		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vec![a, b, c, y]
 			.into_iter()
@@ -209,7 +222,6 @@ mod tests {
 		let c = prb.new_int_decision(4..=10);
 		let y = prb.new_int_decision(1..=2);
 
-		prb.minimum(vec![a, b, c]).result(y).post();
-		prb.assert_unsatisfiable();
+		assert!(prb.minimum(vec![a, b, c]).result(y).post().is_err());
 	}
 }

--- a/crates/huub/src/constraints/int_div.rs
+++ b/crates/huub/src/constraints/int_div.rs
@@ -476,7 +476,7 @@ mod tests {
 		let den = prb.new_int_decision(0..=4);
 		let res = prb.new_int_decision(-20..=20);
 
-		prb.div(num, den).result(res).post();
+		prb.div(num, den).result(res).post().unwrap();
 
 		prb.expect_solutions(
 			&[num, den, res],

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -1106,7 +1106,7 @@ mod tests {
 		let a = prb.new_int_decision(1..=2);
 		let r: View<bool> = false.into();
 
-		prb.linear(-a).le(-2).reified_by(r).post();
+		prb.linear(-a).le(-2).reified_by(r).post().unwrap();
 
 		prb.expect_solutions(&[a], expect![[r#"1"#]]);
 	}
@@ -1155,8 +1155,7 @@ mod tests {
 		let b = prb.new_int_decision(1..=2);
 		let c = prb.new_int_decision(1..=2);
 
-		prb.linear(a * 2 + b + c).ge(10).post();
-		prb.assert_unsatisfiable();
+		assert!(prb.linear(a * 2 + b + c).ge(10).post().is_err());
 	}
 
 	#[test]
@@ -1203,9 +1202,7 @@ mod tests {
 		let b = prb.new_int_decision(1..=4);
 		let c = prb.new_int_decision(1..=4);
 
-		prb.linear(a * 2 + b + c).le(3).post();
-
-		prb.assert_unsatisfiable();
+		assert!(prb.linear(a * 2 + b + c).le(3).post().is_err());
 	}
 
 	#[test]
@@ -1254,7 +1251,11 @@ mod tests {
 		let b = prb.new_int_decision(1..=2);
 		let c = prb.new_int_decision(1..=2);
 
-		prb.linear(a * 2 + b + c).ge(7).implied_by(r).post();
+		prb.linear(a * 2 + b + c)
+			.ge(7)
+			.implied_by(r)
+			.post()
+			.unwrap();
 
 		let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 		let a = map.get_any(&mut slv, a.into());
@@ -1287,7 +1288,11 @@ mod tests {
 		let b = prb.new_int_decision(1..=2);
 		let c = prb.new_int_decision(1..=2);
 
-		prb.linear(a * 2 + b + c).le(5).implied_by(r).post();
+		prb.linear(a * 2 + b + c)
+			.le(5)
+			.implied_by(r)
+			.post()
+			.unwrap();
 
 		let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 		let a = map.get_any(&mut slv, a.into());
@@ -1320,7 +1325,11 @@ mod tests {
 		let b = prb.new_int_decision(1..=2);
 		let c = prb.new_int_decision(1..=2);
 
-		prb.linear(a * 2 + b + c).ne(6).implied_by(r).post();
+		prb.linear(a * 2 + b + c)
+			.ne(6)
+			.implied_by(r)
+			.post()
+			.unwrap();
 
 		let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 		let a = map.get_any(&mut slv, a.into());

--- a/crates/huub/src/constraints/int_no_overlap.rs
+++ b/crates/huub/src/constraints/int_no_overlap.rs
@@ -862,7 +862,8 @@ mod tests {
 			.origins(vec![vec![x1, y1], vec![x2, y2]])
 			.sizes(vec![vec![size, size], vec![size, size]])
 			.strict(true)
-			.post();
+			.post()
+			.unwrap();
 
 		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vec![x1, y1, x2, y2]
@@ -899,7 +900,8 @@ mod tests {
 			.origins(vec![vec![x1, y1], vec![x2, y2]])
 			.sizes(vec![vec![size1, size1], vec![size2, size2]])
 			.strict(false)
-			.post();
+			.post()
+			.unwrap();
 
 		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vec![x1, y1, x2, y2]
@@ -938,7 +940,8 @@ mod tests {
 			.origins(vec![vec![x1, y1, z1], vec![x2, y2, z2]])
 			.sizes(vec![vec![size, size, size], vec![size, size, size]])
 			.strict(true)
-			.post();
+			.post()
+			.unwrap();
 
 		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vec![x1, y1, z1, x2, y2, z2]
@@ -970,12 +973,13 @@ mod tests {
 
 		let size = prb.new_int_decision(4..=4);
 
-		prb.no_overlap()
-			.origins(vec![vec![x1, y1], vec![x2, y2]])
-			.sizes(vec![vec![size, size], vec![size, size]])
-			.strict(true)
-			.post();
-
-		prb.assert_unsatisfiable();
+		assert!(
+			prb.no_overlap()
+				.origins(vec![vec![x1, y1], vec![x2, y2]])
+				.sizes(vec![vec![size, size], vec![size, size]])
+				.strict(true)
+				.post()
+				.is_err()
+		);
 	}
 }

--- a/crates/huub/src/constraints/int_table.rs
+++ b/crates/huub/src/constraints/int_table.rs
@@ -190,10 +190,12 @@ mod tests {
 		];
 		prb.table(vec![vars[0], vars[1]])
 			.values(table.clone())
-			.post();
+			.post()
+			.unwrap();
 		prb.table(vec![vars[1], vars[2]])
 			.values(table.clone())
-			.post();
+			.post()
+			.unwrap();
 
 		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vars.into_iter().map(|x| map.get(&mut slv, x)).collect_vec();
@@ -239,10 +241,12 @@ mod tests {
 		];
 		prb.table(vars[0..3].iter().cloned())
 			.values(table.clone())
-			.post();
+			.post()
+			.unwrap();
 		prb.table(vars[2..5].iter().cloned())
 			.values(table.clone())
-			.post();
+			.post()
+			.unwrap();
 
 		let (mut slv, map) = prb.lower().to_solver().unwrap();
 		let vars = vars.into_iter().map(|x| map.get(&mut slv, x)).collect_vec();

--- a/crates/huub/src/constraints/int_unique.rs
+++ b/crates/huub/src/constraints/int_unique.rs
@@ -815,9 +815,7 @@ mod tests {
 		.map(|domain| prb.new_int_decision(domain))
 		.collect();
 
-		prb.unique(prev.iter().copied()).post();
-
-		prb.assert_unsatisfiable();
+		assert!(prb.unique(prev.iter().copied()).post().is_err());
 	}
 
 	fn test_sudoku(grid: &[&str], expected: Status) {

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -35,7 +35,7 @@ use crate::{
 		SimplificationStatus,
 	},
 	helpers::bytes::Bytes,
-	lower::{Lowerer, LowererComplete, LoweringError},
+	lower::{Lowerer, LowererComplete},
 	model::{
 		decision::{boolean::BoolDecision, integer::IntDecision},
 		initilization_context::ModelInitContext,
@@ -186,6 +186,28 @@ impl ConRef {
 }
 
 impl Model {
+	/// Notify a single boolean advisor or propagator.
+	fn advise_of_bool_change(&mut self, con: ConRef, data: u64) -> bool {
+		if let Some(mut c) = self.constraints[con.index()].take() {
+			let ret = c.advise_of_bool_change(self, data);
+			self.constraints[con.index()] = Some(c);
+			ret
+		} else {
+			false
+		}
+	}
+
+	/// Notify a single integer advisor or propagator.
+	fn advise_of_int_change(&mut self, con: ConRef, data: u64, event: IntEvent) -> bool {
+		if let Some(mut c) = self.constraints[con.index()].take() {
+			let ret = c.advise_of_int_change(self, data, event);
+			self.constraints[con.index()] = Some(c);
+			ret
+		} else {
+			false
+		}
+	}
+
 	/// Create a [`ReasoningEngine::Conflict`] instance based on the failure to
 	/// set `subject`, that must be set because of `reason`.
 	fn create_conflict(
@@ -204,6 +226,30 @@ impl Model {
 			},
 			Err(false) => unreachable!("invalid reason"),
 		}
+	}
+
+	/// Initialize a constraint and register its subscriptions without
+	/// propagating it yet.
+	///
+	/// This is used by [`Model::post_constraint`] and by internal rewriting
+	/// paths that need to add a constraint before deciding whether to
+	/// propagate it immediately.
+	fn initialize_constraint<C: Constraint<Self>>(&mut self, constraint: C) -> (ConRef, bool) {
+		let con = ConRef::new(self.constraints.len());
+		let mut ctx = ModelInitContext::new(self, con);
+		let mut constraint = constraint;
+		constraint.initialize(&mut ctx);
+		let priority = ctx.priority;
+		let enqueue = ctx.enqueue();
+		self.constraints.push(Some(Box::new(constraint)));
+		let r = ConRef::new(self.constraints.len() - 1);
+		debug_assert_eq!(r, con);
+		self.propagator_queue.info.push(PropagatorInfo {
+			enqueued: false,
+			priority,
+		});
+		debug_assert_eq!(r.index(), self.propagator_queue.info.len() - 1);
+		(con, enqueue)
 	}
 
 	/// Returns a builder that can be used to lower the [`Model`] to a
@@ -291,126 +337,120 @@ impl Model {
 			.collect()
 	}
 
-	/// Notify all advisors of changes.
+	/// Notify propagators of the changes that happened since the last call to
+	/// this method.
 	pub(crate) fn notify_advisors(&mut self) {
-		// Notify propagators about all events that occurred
-		let advise_of_int_change = |model: &mut Model, con: ConRef, data: u64, event| {
-			if let Some(mut c) = model.constraints[con.index()].take() {
-				let ret = c.advise_of_int_change(model, data, event);
-				model.constraints[con.index()] = Some(c);
-				ret
-			} else {
-				false
-			}
-		};
-		let advise_of_bool_change = |model: &mut Model, con: ConRef, data: u64| {
-			if let Some(mut c) = model.constraints[con.index()].take() {
-				let ret = c.advise_of_bool_change(model, data);
-				model.constraints[con.index()] = Some(c);
-				ret
-			} else {
-				false
-			}
-		};
 		let mut int_events = mem::take(&mut self.int_events);
 		for (i, event) in int_events.drain() {
-			let constraints = mem::take(&mut self.int_vars[i as usize].constraints);
-			let iv = Decision(i);
-			constraints.for_each_activated_by(event, |act| match act {
+			self.notify_int_event(i, event);
+		}
+		self.int_events = int_events;
+		let mut bool_events = mem::take(&mut self.bool_events);
+		for bv in bool_events.drain(..) {
+			self.notify_bool_event(bv);
+		}
+		self.bool_events = bool_events;
+	}
+
+	/// Notify the propagators interested in a single boolean event.
+	pub(crate) fn notify_bool_event(&mut self, bv: Decision<bool>) {
+		debug_assert!(!bv.is_negated());
+		for &act in self.bool_vars[bv.idx()].constraints.clone().iter() {
+			match act.into() {
 				ActivationAction::Advise::<AdvRef, _>(adv) => {
 					let x: &Advisor = &self.advisors[adv.index()];
 					let Advisor {
 						con,
 						data,
-						negated,
 						bool2int,
-						condition,
+						..
 					} = x.clone();
-					let event = match event {
-						IntEvent::LowerBound if negated => IntEvent::UpperBound,
-						IntEvent::UpperBound if negated => IntEvent::LowerBound,
-						_ => event,
-					};
-					let enqueue = if let Some(cond) = condition {
-						let triggered = match cond {
-							IntLitMeaning::Eq(_) | IntLitMeaning::NotEq(_) => {
-								iv.val(self).is_some()
-							}
-							IntLitMeaning::GreaterEq(v) | IntLitMeaning::Less(v) => {
-								let (min, max) = iv.bounds(self);
-								v <= min || v > max
-							}
-						};
-						if triggered {
-							if bool2int {
-								advise_of_int_change(self, con, data, IntEvent::Fixed)
-							} else {
-								advise_of_bool_change(self, con, data)
-							}
-						} else {
-							false
-						}
+					let enqueue = if bool2int {
+						self.advise_of_int_change(con, data, IntEvent::Fixed)
 					} else {
-						advise_of_int_change(self, con, data, event)
+						self.advise_of_bool_change(con, data)
 					};
 					if enqueue {
 						self.propagator_queue.enqueue_propagator(con.raw());
 					}
 				}
-				ActivationAction::Enqueue(c) => self.propagator_queue.enqueue_propagator(c.raw()),
-			});
-			self.int_vars[i as usize].constraints = constraints;
-		}
-		self.int_events = int_events;
-		let mut bool_events = mem::take(&mut self.bool_events);
-		for bv in bool_events.drain(..) {
-			debug_assert!(!bv.is_negated());
-			for &act in self.bool_vars[bv.idx()].constraints.clone().iter() {
-				match act.into() {
-					ActivationAction::Advise::<AdvRef, _>(adv) => {
-						let x: &Advisor = &self.advisors[adv.index()];
-						let Advisor {
-							con,
-							data,
-							bool2int,
-							..
-						} = x.clone();
-						let enqueue = if bool2int {
-							advise_of_int_change(self, con, data, IntEvent::Fixed)
-						} else {
-							advise_of_bool_change(self, con, data)
-						};
-						if enqueue {
-							self.propagator_queue.enqueue_propagator(con.raw());
-						}
-					}
-					ActivationAction::Enqueue(c) => {
-						self.propagator_queue.enqueue_propagator(c.raw());
-					}
+				ActivationAction::Enqueue(c) => {
+					self.propagator_queue.enqueue_propagator(c.raw());
 				}
 			}
 		}
-		self.bool_events = bool_events;
+	}
+
+	/// Notify the propagators interested in a single integer event.
+	pub(crate) fn notify_int_event(&mut self, i: u32, event: IntEvent) {
+		let constraints = mem::take(&mut self.int_vars[i as usize].constraints);
+		let iv = Decision(i);
+		constraints.for_each_activated_by(event, |act| match act {
+			ActivationAction::Advise::<AdvRef, _>(adv) => {
+				let x: &Advisor = &self.advisors[adv.index()];
+				let Advisor {
+					con,
+					data,
+					negated,
+					bool2int,
+					condition,
+				} = x.clone();
+				let event = match event {
+					IntEvent::LowerBound if negated => IntEvent::UpperBound,
+					IntEvent::UpperBound if negated => IntEvent::LowerBound,
+					_ => event,
+				};
+				let enqueue = if let Some(cond) = condition {
+					let triggered = match cond {
+						IntLitMeaning::Eq(_) | IntLitMeaning::NotEq(_) => iv.val(self).is_some(),
+						IntLitMeaning::GreaterEq(v) | IntLitMeaning::Less(v) => {
+							let (min, max) = iv.bounds(self);
+							v <= min || v > max
+						}
+					};
+					if triggered {
+						if bool2int {
+							self.advise_of_int_change(con, data, IntEvent::Fixed)
+						} else {
+							self.advise_of_bool_change(con, data)
+						}
+					} else {
+						false
+					}
+				} else {
+					self.advise_of_int_change(con, data, event)
+				};
+				if enqueue {
+					self.propagator_queue.enqueue_propagator(con.raw());
+				}
+			}
+			ActivationAction::Enqueue(c) => self.propagator_queue.enqueue_propagator(c.raw()),
+		});
+		self.int_vars[i as usize].constraints = constraints;
 	}
 
 	/// Post a constraint to the model.
 	///
 	/// The constraint is added to the model. It will be enforced during
 	/// simplification and in any subsequent solving method.
-	pub fn post_constraint<C: Constraint<Self>>(&mut self, mut constraint: C) {
-		let con = ConRef::new(self.constraints.len());
-		let mut ctx = ModelInitContext::new(self, con);
-		constraint.initialize(&mut ctx);
-		let priority = ctx.priority;
-		let enqueue = ctx.enqueue();
-		self.constraints.push(Some(Box::new(constraint)));
-		let r = ConRef::new(self.constraints.len() - 1);
-		debug_assert_eq!(r, con);
-		self.propagator_queue.info.push(PropagatorInfo {
-			enqueued: false,
-			priority,
-		});
-		debug_assert_eq!(r.index(), self.propagator_queue.info.len() - 1);
+	pub fn post_constraint<C: Constraint<Self>>(
+		&mut self,
+		constraint: C,
+	) -> Result<(), Conflict<View<bool>>> {
+		let (con, enqueue) = self.initialize_constraint(constraint);
+		if enqueue {
+			self.propagate_single(con)?;
+		}
+		Ok(())
+	}
+
+	/// Internal implementation of [`Model::post_constraint`] that does not yet
+	/// propagate.
+	///
+	/// This function is used internally by [`Model::post_constraint`] and when
+	/// rewriting constraints within the propagation loop.
+	pub(crate) fn post_constraint_internal<C: Constraint<Self>>(&mut self, constraint: C) {
+		let (con, enqueue) = self.initialize_constraint(constraint);
 		if enqueue {
 			self.propagator_queue.enqueue_propagator(con.raw());
 		}
@@ -427,7 +467,7 @@ impl Model {
 	/// process (see [`Self::lower`]). You generally only need to call this
 	/// method manually if you want to inspect the results of propagation
 	/// (e.g. decision variable domains) during the modeling process.
-	pub fn propagate(&mut self) -> Result<(), LoweringError> {
+	pub fn propagate(&mut self) -> Result<(), Conflict<View<bool>>> {
 		self.notify_advisors();
 		while let Some(con) = self.propagator_queue.pop() {
 			self.propagate_single(ConRef::from_raw(con))?;
@@ -437,7 +477,7 @@ impl Model {
 
 	/// Propagate the constraint at index `con`, updating the domains of the
 	/// variables and rewriting the constraint if necessary.
-	pub(crate) fn propagate_single(&mut self, con: ConRef) -> Result<(), LoweringError> {
+	pub(crate) fn propagate_single(&mut self, con: ConRef) -> Result<(), Conflict<View<bool>>> {
 		let Some(mut con_obj) = self.constraints[con.index()].take() else {
 			return Ok(());
 		};
@@ -530,7 +570,7 @@ impl SimplificationActions for Model {
 	type Target = Model;
 
 	fn post_constraint<C: Constraint<Model>>(&mut self, constraint: C) {
-		self.post_constraint(constraint);
+		self.post_constraint_internal(constraint);
 	}
 }
 
@@ -608,7 +648,7 @@ mod tests {
 			bool_check,
 			int_check,
 		};
-		prb.post_constraint(t);
+		prb.post_constraint(t).unwrap();
 		i.tighten_min(&mut prb, 2, []).expect("tighten_min failed");
 		let (_, _): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");
 		assert_eq!(prb.trailed(bool_check), 1);
@@ -628,7 +668,7 @@ mod tests {
 			bool_check,
 			int_check,
 		};
-		prb.post_constraint(t);
+		prb.post_constraint(t).unwrap();
 		i.tighten_min(&mut prb, 1, []).expect("tighten_min failed");
 		let (_, _): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");
 		assert_eq!(prb.trailed(bool_check), 0);
@@ -648,7 +688,7 @@ mod tests {
 			bool_check,
 			int_check,
 		};
-		prb.post_constraint(t);
+		prb.post_constraint(t).unwrap();
 		i.tighten_min(&mut prb, 1, []).expect("tighten_min failed");
 		i.tighten_max(&mut prb, 2, []).expect("tighten_max failed");
 		let (mut slv, map): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");

--- a/crates/huub/src/model/decision/integer.rs
+++ b/crates/huub/src/model/decision/integer.rs
@@ -199,7 +199,7 @@ impl private::Sealed for IntVal {}
 impl Resolved<Decision<IntVal>> {
 	/// Internal method performing unification under the assumption that the
 	/// receiver is an integer decision index that is not already aliased, and
-	/// that it can be aliased to directly point to `other`.
+	/// that it can be aliased to directly point to `target`.
 	pub(crate) fn unify_internal(
 		self,
 		ctx: &mut Model,
@@ -219,6 +219,10 @@ impl Resolved<Decision<IntVal>> {
 			Domain::Alias(View(IntView::Const(v))) => target.fix(ctx, v, [])?,
 			_ => unreachable!(),
 		};
+		// Process any pending integer events for the variable being aliased.
+		if let Some(event) = ctx.int_events.remove(&(idx as u32)) {
+			ctx.notify_int_event(idx as u32, event);
+		}
 		// Transfer any constraints from the aliased variable to the target variable
 		let constraints = mem::take(&mut ctx.int_vars[idx].constraints);
 		// Move subscriptions to target decision variable
@@ -309,10 +313,10 @@ impl Resolved<Decision<IntVal>> {
 			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
 		} else {
 			let entry = ctx.int_events.entry(self.0.0).or_insert(IntEvent::Domain);
-			if dom.lower_bound().unwrap() == diff.lower_bound().unwrap() {
+			if dom.lower_bound().unwrap() != diff.lower_bound().unwrap() {
 				*entry += IntEvent::LowerBound;
 			}
-			if dom.upper_bound().unwrap() == diff.upper_bound().unwrap() {
+			if dom.upper_bound().unwrap() != diff.upper_bound().unwrap() {
 				*entry += IntEvent::UpperBound;
 			}
 
@@ -379,10 +383,10 @@ impl Resolved<Decision<IntVal>> {
 			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
 		} else {
 			let entry = ctx.int_events.entry(self.0.0).or_insert(IntEvent::Domain);
-			if dom.lower_bound().unwrap() == intersect.lower_bound().unwrap() {
+			if dom.lower_bound().unwrap() != intersect.lower_bound().unwrap() {
 				*entry += IntEvent::LowerBound;
 			}
-			if dom.upper_bound().unwrap() == intersect.upper_bound().unwrap() {
+			if dom.upper_bound().unwrap() != intersect.upper_bound().unwrap() {
 				*entry += IntEvent::UpperBound;
 			}
 

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -26,7 +26,7 @@ use crate::{
 	IntSet, IntVal,
 	actions::{
 		BoolPropagationActions, BoolSimplificationActions, IntSimplificationActions,
-		PropagationActions,
+		PropagationActions, ReasoningEngine,
 	},
 	lower::{Lowerer, LowererComplete, LoweringError},
 	model::{
@@ -605,6 +605,12 @@ impl Display for FlatZincError {
 
 impl Error for FlatZincError {}
 
+impl From<<Model as ReasoningEngine>::Conflict> for FlatZincError {
+	fn from(conflict: <Model as ReasoningEngine>::Conflict) -> Self {
+		Self::ReformulationError(LoweringError::from(conflict))
+	}
+}
+
 impl From<LoweringError> for FlatZincError {
 	fn from(reformulation_error: LoweringError) -> Self {
 		Self::ReformulationError(reformulation_error)
@@ -979,7 +985,7 @@ impl<'a> FznModelBuilder<'a> {
 		transitions: Vec<Vec<IntVal>>,
 		init_state: IntVal,
 		accept_states: FxHashSet<IntVal>,
-	) {
+	) -> Result<(), LoweringError> {
 		// TODO: Add the regular checking
 
 		let mut start: Vec<Vec<IntVal>> = Vec::new();
@@ -1019,18 +1025,19 @@ impl<'a> FznModelBuilder<'a> {
 
 		// Add table constraint to force a transition for the starting state
 		let sx: Vec<View<IntVal>> = vec![vars[0], state_vars[0]];
-		self.prb.table(sx).values(start).post();
+		self.prb.table(sx).values(start).post()?;
 
 		// Add table constraint to force valid transition for the intermediate
 		// states
 		for i in 1..vars.len() - 1 {
 			let mx: Vec<View<IntVal>> = vec![state_vars[i - 1], vars[i], state_vars[i]];
-			self.prb.table(mx).values(middle.clone()).post();
+			self.prb.table(mx).values(middle.clone()).post()?;
 		}
 
 		// Add table constraint to force ending in an accepting state
 		let ex: Vec<View<IntVal>> = vec![*state_vars.last().unwrap(), *vars.last().unwrap()];
-		self.prb.table(ex).values(end).post();
+		self.prb.table(ex).values(end).post()?;
+		Ok(())
 	}
 
 	/// Ensure all variables in the FlatZinc instance output are in the model
@@ -1113,13 +1120,13 @@ impl<'a> FznModelBuilder<'a> {
 						let AnyView::Bool(view) = view else {
 							unreachable!()
 						};
-						bv.unify(&mut me.prb, view).map_err(LoweringError::from)?;
+						bv.unify(&mut me.prb, view)?;
 					}
 					AnyView::Int(iv) => {
 						let AnyView::Int(view) = view else {
 							unreachable!()
 						};
-						iv.unify(&mut me.prb, view).map_err(LoweringError::from)?;
+						iv.unify(&mut me.prb, view)?;
 					}
 				},
 				Entry::Vacant(e) => {
@@ -1128,8 +1135,7 @@ impl<'a> FznModelBuilder<'a> {
 						let AnyView::Int(view) = view else {
 							unreachable!()
 						};
-						view.restrict_domain(&mut me.prb, dom, vec![])
-							.map_err(LoweringError::from)?;
+						view.restrict_domain(&mut me.prb, dom, vec![])?;
 					}
 					// Insert the view to use instead of a new variable for the name
 					e.insert(view);
@@ -1268,10 +1274,8 @@ impl<'a> FznModelBuilder<'a> {
 				let offset = sum / c;
 				let view = if let Some(scale) = NonZero::new(-cy / c) {
 					let y = lit_int_view(self, vy)?;
-					y.bounding_mul(&mut self.prb, scale.get())
-						.map_err(LoweringError::from)?
-						.bounding_add(&mut self.prb, offset)
-						.map_err(LoweringError::from)?
+					y.bounding_mul(&mut self.prb, scale.get())?
+						.bounding_add(&mut self.prb, offset)?
 				} else {
 					offset.into()
 				};
@@ -1366,8 +1370,8 @@ impl<'a> FznModelBuilder<'a> {
 		var: &Arc<Variable<FznIdent>>,
 	) -> Result<AnyView, FlatZincError> {
 		match self.map.entry(var.cloned_key()) {
-			Entry::Vacant(e) => Ok(e
-				.insert(match &var.ty {
+			Entry::Vacant(e) => {
+				let view = match &var.ty {
 					Type::Bool => AnyView::Bool(self.prb.new_bool_decision()),
 					Type::Int(dom) => match dom {
 						Some(dom) => AnyView::Int(self.prb.new_int_decision(dom.clone())),
@@ -1383,8 +1387,9 @@ impl<'a> FznModelBuilder<'a> {
 						}
 					},
 					_ => todo!("Variables of {:?} are not yet supported", var.ty),
-				})
-				.clone()),
+				};
+				Ok(e.insert(view).clone())
+			}
 			Entry::Occupied(e) => Ok(e.get().clone()),
 		}
 	}
@@ -1472,7 +1477,10 @@ impl<'a> FznModelBuilder<'a> {
 						.iter()
 						.map(|l| self.lit_bool(l).map(Into::into))
 						.try_collect()?;
-					self.prb.proposition(Formula::And(es)).reified_by(r).post();
+					self.prb
+						.proposition(Formula::And(es))
+						.reified_by(r)
+						.post()?;
 				}
 				ConstraintIdent::ArrayBoolXor => {
 					let [es] = c.args.as_slice() else {
@@ -1483,7 +1491,7 @@ impl<'a> FznModelBuilder<'a> {
 						.iter()
 						.map(|l| self.lit_bool(l).map(Into::into))
 						.try_collect()?;
-					self.prb.proposition(Formula::Xor(es)).post();
+					self.prb.proposition(Formula::Xor(es)).post()?;
 				}
 				ConstraintIdent::ArrayBoolElement => {
 					let [idx, arr, val] = c.args.as_slice() else {
@@ -1495,11 +1503,9 @@ impl<'a> FznModelBuilder<'a> {
 						.map(|l| self.par_bool(l))
 						.try_collect()?;
 					let idx = self.arg_int(idx)?;
-					let idx = idx
-						.bounding_sub(&mut self.prb, 1)
-						.map_err(LoweringError::from)?;
+					let idx = idx.bounding_sub(&mut self.prb, 1)?;
 					let val = self.arg_bool(val)?;
-					self.prb.element(arr).index(idx).result(val).post();
+					self.prb.element(arr).index(idx).result(val).post()?;
 				}
 				ConstraintIdent::ArrayIntElement => {
 					let [idx, arr, val] = c.args.as_slice() else {
@@ -1511,12 +1517,10 @@ impl<'a> FznModelBuilder<'a> {
 						.map(|l| self.par_int(l))
 						.try_collect()?;
 					let idx = self.arg_int(idx)?;
-					let idx = idx
-						.bounding_sub(&mut self.prb, 1)
-						.map_err(LoweringError::from)?;
+					let idx = idx.bounding_sub(&mut self.prb, 1)?;
 					let val = self.arg_int(val)?;
 
-					self.prb.element(arr).index(idx).result(val).post();
+					self.prb.element(arr).index(idx).result(val).post()?;
 				}
 				ConstraintIdent::ArrayVarBoolElement => {
 					let [idx, arr, val] = c.args.as_slice() else {
@@ -1528,12 +1532,10 @@ impl<'a> FznModelBuilder<'a> {
 						.map(|l| self.lit_bool(l))
 						.try_collect()?;
 					let idx = self.arg_int(idx)?;
-					let idx = idx
-						.bounding_sub(&mut self.prb, 1)
-						.map_err(LoweringError::from)?;
+					let idx = idx.bounding_sub(&mut self.prb, 1)?;
 					let val = self.arg_bool(val)?;
 
-					self.prb.element(arr).index(idx).result(val).post();
+					self.prb.element(arr).index(idx).result(val).post()?;
 				}
 				ConstraintIdent::ArrayVarIntElement => {
 					let [idx, arr, val] = c.args.as_slice() else {
@@ -1545,12 +1547,10 @@ impl<'a> FznModelBuilder<'a> {
 						.map(|l| self.lit_int(l))
 						.try_collect()?;
 					let idx = self.arg_int(idx)?;
-					let idx = idx
-						.bounding_sub(&mut self.prb, 1)
-						.map_err(LoweringError::from)?;
+					let idx = idx.bounding_sub(&mut self.prb, 1)?;
 					let val = self.arg_int(val)?;
 
-					self.prb.element(arr).index(idx).result(val).post();
+					self.prb.element(arr).index(idx).result(val).post()?;
 				}
 				ConstraintIdent::Bool2Int => {
 					let [b, i] = c.args.as_slice() else {
@@ -1558,7 +1558,7 @@ impl<'a> FznModelBuilder<'a> {
 					};
 					let b = self.arg_bool(b)?;
 					let i = self.arg_int(i)?;
-					i.unify(&mut self.prb, b).map_err(LoweringError::from)?;
+					i.unify(&mut self.prb, b)?;
 				}
 				ConstraintIdent::BoolLinEq => {
 					let [coeffs, vars, sum] = c.args.as_slice() else {
@@ -1580,17 +1580,13 @@ impl<'a> FznModelBuilder<'a> {
 					let mut terms = Vec::with_capacity(vars.len() + 1);
 					for (x, c) in vars.into_iter().zip(coeffs) {
 						if let Some(c) = NonZero::new(c) {
-							terms.push(
-								View::from(x)
-									.bounding_mul(&mut self.prb, c.get())
-									.map_err(LoweringError::from)?,
-							);
+							terms.push(View::from(x).bounding_mul(&mut self.prb, c.get())?);
 						}
 					}
 					terms.push(-sum);
 					let lin_exp: IntLinearExp = terms.into_iter().sum();
 
-					self.prb.linear(lin_exp).eq(0).post();
+					self.prb.linear(lin_exp).eq(0).post()?;
 				}
 				ConstraintIdent::BoolClause => {
 					let [pos, neg] = c.args.as_slice() else {
@@ -1623,13 +1619,11 @@ impl<'a> FznModelBuilder<'a> {
 									LoweringError::Simplification(self.prb.declare_conflict([])),
 								));
 							}
-							1 => lits[0]
-								.require(&mut self.prb, vec![])
-								.map_err(LoweringError::from)?,
+							1 => lits[0].require(&mut self.prb, vec![])?,
 							_ => {
 								self.prb
 									.proposition(Formula::Or(lits.into_iter().map_into().collect()))
-									.post();
+									.post()?;
 							}
 						}
 					}
@@ -1644,7 +1638,7 @@ impl<'a> FznModelBuilder<'a> {
 					self.prb
 						.proposition(Formula::Equiv(vec![a.into(), b.into()]))
 						.reified_by(r)
-						.post();
+						.post()?;
 				}
 				ConstraintIdent::BoolNot => {
 					let [a, b] = c.args.as_slice() else {
@@ -1652,7 +1646,7 @@ impl<'a> FznModelBuilder<'a> {
 					};
 					let a = self.arg_bool(a)?;
 					let b = self.arg_bool(b)?;
-					a.unify(&mut self.prb, !b).map_err(LoweringError::from)?;
+					a.unify(&mut self.prb, !b)?;
 				}
 				ConstraintIdent::BoolXor => {
 					let [a, b, rest @ ..] = c.args.as_slice() else {
@@ -1668,7 +1662,7 @@ impl<'a> FznModelBuilder<'a> {
 						let r = self.arg_bool(r)?;
 						f = Formula::Equiv(vec![r.into(), f]);
 					}
-					self.prb.proposition(f).post();
+					self.prb.proposition(f).post()?;
 				}
 				ConstraintIdent::DiffnInt { strict } => {
 					let [x, y, dx, dy] = c.args.as_slice() else {
@@ -1692,7 +1686,7 @@ impl<'a> FznModelBuilder<'a> {
 						.origins(origins?)
 						.sizes(sizes?)
 						.strict(strict)
-						.post();
+						.post()?;
 				}
 				ConstraintIdent::DiffnKInt { strict } => {
 					let [box_posn, box_size, d] = c.args.as_slice() else {
@@ -1741,7 +1735,7 @@ impl<'a> FznModelBuilder<'a> {
 						.origins(origins)
 						.sizes(sizes)
 						.strict(strict)
-						.post();
+						.post()?;
 				}
 				ConstraintIdent::AllDifferentInt => {
 					let [args] = c.args.as_slice() else {
@@ -1768,7 +1762,7 @@ impl<'a> FznModelBuilder<'a> {
 						.unique(args)
 						.maybe_bounds_propagation(bounds)
 						.maybe_value_propagation(value)
-						.post();
+						.post()?;
 				}
 				ConstraintIdent::ArrayIntMaximum | ConstraintIdent::ArrayIntMinimum => {
 					let [m, args] = c.args.as_slice() else {
@@ -1784,7 +1778,7 @@ impl<'a> FznModelBuilder<'a> {
 						ConstraintIdent::ArrayIntMaximum => self.prb.maximum(args).result(m).post(),
 						ConstraintIdent::ArrayIntMinimum => self.prb.minimum(args).result(m).post(),
 						_ => unreachable!(),
-					}
+					}?;
 				}
 				ConstraintIdent::BoolClauseReif => {
 					let [pos, neg, r] = c.args.as_slice() else {
@@ -1802,7 +1796,10 @@ impl<'a> FznModelBuilder<'a> {
 						let e = self.lit_bool(l)?;
 						lits.push((!e).into());
 					}
-					self.prb.proposition(Formula::Or(lits)).reified_by(r).post();
+					self.prb
+						.proposition(Formula::Or(lits))
+						.reified_by(r)
+						.post()?;
 				}
 				ConstraintIdent::Cumulative => {
 					let [starts, durations, heights, r] = c.args.as_slice() else {
@@ -1830,7 +1827,7 @@ impl<'a> FznModelBuilder<'a> {
 						.durations(durations)
 						.usages(heights)
 						.capacity(r)
-						.post();
+						.post()?;
 				}
 				ConstraintIdent::DisjuctiveStrict => {
 					let [starts, durations] = c.args.as_slice() else {
@@ -1871,7 +1868,7 @@ impl<'a> FznModelBuilder<'a> {
 						.maybe_edge_finding_propagation(edge_finding)
 						.maybe_not_last_propagation(not_last)
 						.maybe_detectable_precedence_propagation(detectable_precedence)
-						.post();
+						.post()?;
 				}
 				ConstraintIdent::Regular => {
 					let [x, q, s, d, q0, f] = c.args.as_slice() else {
@@ -1913,7 +1910,8 @@ impl<'a> FznModelBuilder<'a> {
 
 					// Convert regular constraint in to table constraints and add them to the
 					// model
-					self.convert_regular_to_tables(x, d, q0, f);
+					self.convert_regular_to_tables(x, d, q0, f)
+						.map_err(FlatZincError::from)?;
 				}
 				ConstraintIdent::TableInt => {
 					let [args, table] = c.args.as_slice() else {
@@ -1944,7 +1942,7 @@ impl<'a> FznModelBuilder<'a> {
 						.into_iter()
 						.map(|c| c.collect())
 						.collect();
-					self.prb.table(args).values(table).post();
+					self.prb.table(args).values(table).post()?;
 				}
 				ConstraintIdent::SeqPrecedeChainInt => {
 					let [args] = c.args.as_slice() else {
@@ -1952,7 +1950,7 @@ impl<'a> FznModelBuilder<'a> {
 					};
 					let args = self.arg_array(args)?;
 					let args: Vec<_> = args.iter().map(|l| self.lit_int(l)).try_collect()?;
-					self.prb.value_precede(args).post();
+					self.prb.value_precede(args).post()?;
 				}
 				ConstraintIdent::ValuePrecedeChain => {
 					let [values, variables] = c.args.as_slice() else {
@@ -1968,7 +1966,7 @@ impl<'a> FznModelBuilder<'a> {
 						.iter()
 						.map(|l| self.lit_int(l))
 						.try_collect()?;
-					self.prb.value_precede(variables).values(values).post();
+					self.prb.value_precede(variables).values(values).post()?;
 				}
 				ConstraintIdent::IntAbs => {
 					let [origin, abs] = c.args.as_slice() else {
@@ -1976,7 +1974,7 @@ impl<'a> FznModelBuilder<'a> {
 					};
 					let origin = self.arg_int(origin)?;
 					let abs = self.arg_int(abs)?;
-					self.prb.abs(origin).result(abs).post();
+					self.prb.abs(origin).result(abs).post()?;
 				}
 				ConstraintIdent::IntDiv => {
 					let [num, denom, res] = c.args.as_slice() else {
@@ -1985,7 +1983,7 @@ impl<'a> FznModelBuilder<'a> {
 					let num = self.arg_int(num)?;
 					let denom = self.arg_int(denom)?;
 					let res = self.arg_int(res)?;
-					self.prb.div(num, denom).result(res).post();
+					self.prb.div(num, denom).result(res).post()?;
 				}
 				ConstraintIdent::IntLe | ConstraintIdent::IntNe => {
 					let [a, b] = c.args.as_slice() else {
@@ -1999,7 +1997,7 @@ impl<'a> FznModelBuilder<'a> {
 						ConstraintIdent::IntNe => lin.ne(b),
 						_ => unreachable!(),
 					}
-					.post();
+					.post()?;
 				}
 				ConstraintIdent::IntEqImp
 				| ConstraintIdent::IntEqReif
@@ -2030,7 +2028,7 @@ impl<'a> FznModelBuilder<'a> {
 						| ConstraintIdent::IntNeReif => lin.reified_by(r),
 						_ => unreachable!(),
 					}
-					.post();
+					.post()?;
 				}
 				ConstraintIdent::IntLinEq
 				| ConstraintIdent::IntLinLe
@@ -2051,10 +2049,7 @@ impl<'a> FznModelBuilder<'a> {
 					let rhs = self.arg_par_int(rhs)?;
 					let mut terms = Vec::with_capacity(vars.len());
 					for (x, c) in vars.into_iter().zip(coeffs) {
-						terms.push(
-							x.bounding_mul(&mut self.prb, c)
-								.map_err(LoweringError::from)?,
-						);
+						terms.push(x.bounding_mul(&mut self.prb, c)?);
 					}
 					let lin_exp: IntLinearExp = terms.into_iter().sum();
 					let lin = self.prb.linear(lin_exp);
@@ -2065,7 +2060,7 @@ impl<'a> FznModelBuilder<'a> {
 						ConstraintIdent::IntLinNe => lin.ne(rhs),
 						_ => unreachable!(),
 					}
-					.post();
+					.post()?;
 				}
 				ConstraintIdent::IntLinEqImp
 				| ConstraintIdent::IntLinEqReif
@@ -2090,10 +2085,7 @@ impl<'a> FznModelBuilder<'a> {
 					let reified = self.arg_bool(reified)?;
 					let mut terms = Vec::with_capacity(vars.len());
 					for (x, c) in vars.into_iter().zip(coeffs) {
-						terms.push(
-							x.bounding_mul(&mut self.prb, c)
-								.map_err(LoweringError::from)?,
-						);
+						terms.push(x.bounding_mul(&mut self.prb, c)?);
 					}
 
 					let lin = self.prb.linear(terms.into_iter().sum::<IntLinearExp>());
@@ -2112,7 +2104,7 @@ impl<'a> FznModelBuilder<'a> {
 						| ConstraintIdent::IntLinNeReif => lin.reified_by(reified),
 						_ => unreachable!(),
 					}
-					.post();
+					.post()?;
 				}
 				ConstraintIdent::IntMax | ConstraintIdent::IntMin => {
 					let [a, b, m] = c.args.as_slice() else {
@@ -2125,7 +2117,7 @@ impl<'a> FznModelBuilder<'a> {
 						ConstraintIdent::IntMax => self.prb.maximum([a, b]).result(m).post(),
 						ConstraintIdent::IntMin => self.prb.minimum([a, b]).result(m).post(),
 						_ => unreachable!(),
-					}
+					}?;
 				}
 				ConstraintIdent::IntPow => {
 					let [base, exponent, res] = c.args.as_slice() else {
@@ -2135,7 +2127,7 @@ impl<'a> FznModelBuilder<'a> {
 					let exponent = self.arg_int(exponent)?;
 					let res = self.arg_int(res)?;
 
-					self.prb.pow(base, exponent).result(res).post();
+					self.prb.pow(base, exponent).result(res).post()?;
 				}
 				ConstraintIdent::IntTimes => {
 					let [x, y, z] = c.args.as_slice() else {
@@ -2144,7 +2136,7 @@ impl<'a> FznModelBuilder<'a> {
 					let a = self.arg_int(x)?;
 					let b = self.arg_int(y)?;
 					let m = self.arg_int(z)?;
-					self.prb.mul(a, b).result(m).post();
+					self.prb.mul(a, b).result(m).post()?;
 				}
 				ConstraintIdent::SetIn => {
 					let [x, s] = c.args.as_slice() else {
@@ -2153,8 +2145,7 @@ impl<'a> FznModelBuilder<'a> {
 					let x = self.arg_int(x)?;
 					let s = self.arg_par_set(s)?;
 
-					x.restrict_domain(&mut self.prb, &s, vec![])
-						.map_err(LoweringError::from)?;
+					x.restrict_domain(&mut self.prb, &s, vec![])?;
 				}
 				ConstraintIdent::SetInReif => {
 					let [x, s, r] = c.args.as_slice() else {
@@ -2164,7 +2155,7 @@ impl<'a> FznModelBuilder<'a> {
 					let s = self.arg_par_set(s)?;
 					let r = self.arg_bool(r)?;
 
-					self.prb.contains(s).member(x).result(r).post();
+					self.prb.contains(s).member(x).result(r).post()?;
 				}
 				ConstraintIdent::IntEq | ConstraintIdent::BoolEq => unreachable!(),
 			}

--- a/crates/huub/src/model/expressions.rs
+++ b/crates/huub/src/model/expressions.rs
@@ -27,8 +27,9 @@ pub use crate::model::expressions::{
 };
 use crate::{
 	IntSet, IntVal,
-	actions::IntInspectionActions,
+	actions::{IntInspectionActions, IntPropagationActions, IntSimplificationActions},
 	constraints::{
+		Conflict,
 		cumulative::CumulativeTimeTable,
 		disjunctive::{Disjunctive, DisjunctivePropagator},
 		int_abs::IntAbsBounds,
@@ -57,12 +58,12 @@ impl Model {
 		&mut self,
 		#[builder(into, start_fn)] origin: View<IntVal>,
 		#[builder(into)] result: View<IntVal>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		self.post_constraint(IntAbsBounds {
 			origin,
 			abs: result,
 			origin_positive: origin.geq(0),
-		});
+		})
 	}
 
 	/// Create constraint that enforces that the given Boolean decision variable
@@ -74,12 +75,12 @@ impl Model {
 		#[builder(start_fn, into)] collection: IntSet,
 		#[builder(into)] member: View<IntVal>,
 		#[builder(into)] result: View<bool>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		self.post_constraint(IntSetContainsReif {
 			var: member,
 			set: collection,
 			reif: result,
-		});
+		})
 	}
 
 	/// Create a constraint that enforces that the given a list of integer
@@ -95,7 +96,7 @@ impl Model {
 		durations: Vec<impl Into<View<IntVal>>>,
 		usages: Vec<impl Into<View<IntVal>>>,
 		capacity: impl Into<View<IntVal>>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		assert_eq!(
 			start_times.len(),
 			durations.len(),
@@ -111,7 +112,7 @@ impl Model {
 			durations.into_iter().map_into().collect(),
 			usages.into_iter().map_into().collect(),
 			capacity.into(),
-		));
+		))
 	}
 
 	/// Create a constraint that enforces that the given a list of integer
@@ -129,7 +130,7 @@ impl Model {
 		edge_finding_propagation: Option<bool>,
 		not_last_propagation: Option<bool>,
 		detectable_precedence_propagation: Option<bool>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		assert_eq!(
 			start_times.len(),
 			durations.len(),
@@ -145,7 +146,7 @@ impl Model {
 			edge_finding_propagation,
 			not_last_propagation,
 			detectable_precedence_propagation,
-		});
+		})
 	}
 
 	/// Create a constraint that enforces that a numerator integer decision
@@ -157,12 +158,12 @@ impl Model {
 		#[builder(into, start_fn)] numerator: View<IntVal>,
 		#[builder(into, start_fn)] denominator: View<IntVal>,
 		#[builder(into)] result: View<IntVal>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		self.post_constraint(IntDivBounds {
 			numerator,
 			denominator,
 			result,
-		});
+		})
 	}
 
 	/// Create a constraint that enforces that a result decision variable takes
@@ -174,8 +175,8 @@ impl Model {
 		#[builder(start_fn)] array: Vec<E>,
 		#[builder(getter(name = index_internal, vis = ""), into)] index: View<IntVal>,
 		result: <E as ElementConstraint>::Result,
-	) {
-		<E as ElementConstraint>::element_constraint(self, array, index, result);
+	) -> Result<(), Conflict<View<bool>>> {
+		<E as ElementConstraint>::element_constraint(self, array, index, result)
 	}
 
 	/// Create a linear equation constraint.
@@ -214,7 +215,7 @@ impl Model {
 		#[builder(setters(name = comparator_internal, vis = ""))] comparator: Comparator,
 		#[builder(setters(name = rhs_internal, vis = ""))] rhs: IntLinearExp,
 		#[builder(setters(name = reif_internal, vis = ""))] reif: Option<Reification>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		// Subtract the RHS from the LHS to get a linear expression with a constant 0 on
 		// the RHS
 		expr -= rhs;
@@ -241,23 +242,22 @@ impl Model {
 			})
 			.collect();
 
-		let mut negate_terms = || {
-			terms.iter_mut().for_each(|v| {
-				*v = v
-					.bounding_neg(self)
-					.expect("TODO: need to defer failure to propagate");
-			});
+		let mut negate_terms = || -> Result<(), Conflict<View<bool>>> {
+			for v in &mut terms {
+				*v = v.bounding_neg(self)?;
+			}
+			Ok(())
 		};
 		let (comparator, rhs) = match comparator {
 			Comparator::Less => (LinComparator::LessEq, rhs - 1),
 			Comparator::LessEqual => (LinComparator::LessEq, rhs),
 			Comparator::Equal => (LinComparator::Equal, rhs),
 			Comparator::GreaterEqual => {
-				negate_terms();
+				negate_terms()?;
 				(LinComparator::LessEq, -rhs)
 			}
 			Comparator::Greater => {
-				negate_terms();
+				negate_terms()?;
 				(LinComparator::LessEq, -rhs - 1)
 			}
 			Comparator::NotEqual => (LinComparator::NotEqual, rhs),
@@ -269,14 +269,14 @@ impl Model {
 				rhs: rhs.into(),
 				reif,
 				comparator,
-			});
+			})
 		} else {
 			self.post_constraint(IntLinear::<OverflowImpossible> {
 				terms,
 				rhs,
 				reif,
 				comparator,
-			});
+			})
 		}
 	}
 
@@ -287,10 +287,10 @@ impl Model {
 		&mut self,
 		#[builder(start_fn)] vars: impl IntoIterator<Item = View<IntVal>>,
 		#[builder(into)] result: View<IntVal>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		self.minimum(vars.into_iter().map(|v| -v))
 			.result(-result)
-			.post();
+			.post()
 	}
 
 	/// Create a constraint that enforces that an integer decision variable
@@ -300,11 +300,11 @@ impl Model {
 		&mut self,
 		#[builder(start_fn)] vars: impl IntoIterator<Item = View<IntVal>>,
 		#[builder(into)] result: View<IntVal>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		self.post_constraint(IntArrayMinimumBounds {
 			vars: vars.into_iter().collect(),
 			min: result,
-		});
+		})
 	}
 
 	/// Create a constraint that enforces that the product of the two integer
@@ -315,21 +315,21 @@ impl Model {
 		#[builder(start_fn)] factor1: View<IntVal>,
 		#[builder(start_fn)] factor2: View<IntVal>,
 		result: View<IntVal>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		if IntMulBounds::<_, _, _, View<IntVal>>::can_overflow(self, &factor1, &factor2) {
 			self.post_constraint(IntMulBounds::<OverflowPossible, _, _, _> {
 				factor1,
 				factor2,
 				product: result,
 				overflow_mode: PhantomData,
-			});
+			})
 		} else {
 			self.post_constraint(IntMulBounds::<OverflowImpossible, _, _, _> {
 				factor1,
 				factor2,
 				product: result,
 				overflow_mode: PhantomData,
-			});
+			})
 		}
 	}
 
@@ -359,13 +359,13 @@ impl Model {
 		origins: Vec<Vec<View<IntVal>>>,
 		sizes: Vec<Vec<View<IntVal>>>,
 		#[builder(default = true)] strict: bool,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		if strict {
 			let prop = IntNoOverlapSweep::<true, _, _>::new(self, origins, sizes);
-			self.post_constraint(prop);
+			self.post_constraint(prop)
 		} else {
 			let prop = IntNoOverlapSweep::<false, _, _>::new(self, origins, sizes);
-			self.post_constraint(prop);
+			self.post_constraint(prop)
 		}
 	}
 
@@ -378,21 +378,21 @@ impl Model {
 		#[builder(start_fn, into)] base: View<IntVal>,
 		#[builder(start_fn, into)] exponent: View<IntVal>,
 		#[builder(into)] result: View<IntVal>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		if IntPowBounds::<_, _, _, View<IntVal>>::can_overflow(self, &base, &exponent) {
 			self.post_constraint(IntPowBounds::<OverflowPossible, _, _, _> {
 				base,
 				exponent,
 				result,
 				overflow_mode: PhantomData,
-			});
+			})
 		} else {
 			self.post_constraint(IntPowBounds::<OverflowImpossible, _, _, _> {
 				base,
 				exponent,
 				result,
 				overflow_mode: PhantomData,
-			});
+			})
 		}
 	}
 
@@ -403,7 +403,7 @@ impl Model {
 		&mut self,
 		#[builder(start_fn, into)] mut formula: BoolFormula,
 		#[builder(setters(name = reif_internal, vis = ""))] reif: Option<Reification>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		match reif {
 			Some(Reification::ReifiedBy(b)) => {
 				formula = BoolFormula::Equiv(vec![BoolFormula::Atom(b), formula]);
@@ -413,7 +413,7 @@ impl Model {
 			}
 			None => {}
 		}
-		self.post_constraint(formula);
+		self.post_constraint(formula)
 	}
 
 	/// Create a `table` constraint that enforces that given list of integer
@@ -424,14 +424,14 @@ impl Model {
 		&mut self,
 		#[builder(start_fn)] vars: impl IntoIterator<Item = View<IntVal>>,
 		values: impl IntoIterator<Item = Vec<IntVal>>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		let vars: Vec<_> = vars.into_iter().collect();
 		let table: Vec<_> = values.into_iter().collect();
 		assert!(
 			table.iter().all(|tup| tup.len() == vars.len()),
 			"The number of values in each row of the table must be equal to the number of decision variables."
 		);
-		self.post_constraint(IntTable { vars, table });
+		self.post_constraint(IntTable { vars, table })
 	}
 
 	/// Create a constraint that enforces that all the given integer decisions
@@ -471,14 +471,14 @@ impl Model {
 		#[builder(start_fn)] vars: impl IntoIterator<Item = View<IntVal>>,
 		bounds_propagation: Option<bool>,
 		value_propagation: Option<bool>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		let vars: Vec<_> = vars.into_iter().map_into().collect();
 		self.post_constraint(IntUnique {
 			bounds_prop: IntUniqueBounds::new(vars.clone()),
 			value_prop: IntUniqueValue::new(vars),
 			bounds_propagation,
 			value_propagation,
-		});
+		})
 	}
 
 	/// Create a value precede (chain) constraint that enforces that the first
@@ -494,19 +494,19 @@ impl Model {
 		#[builder(start_fn)] vars: impl IntoIterator<Item = View<IntVal>>,
 		#[builder(with = |values: impl IntoIterator<Item = IntVal>| values.into_iter().collect())]
 		values: Option<Vec<IntVal>>,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		let mut offset = 0;
 		let vars: Vec<_> = vars.into_iter().collect();
 		// If there are no decision variables, then the constraint is trivially
 		// satisfied.
 		if vars.is_empty() {
-			return;
+			return Ok(());
 		}
 		if let Some(values) = values {
 			// If the list of values doesn't contain at least two values, then the
 			// constraint is trivially satisfied.
 			if values.len() <= 1 {
-				return;
+				return Ok(());
 			}
 			// If the values are not consecutive or if the largest value does not cover the
 			// full decision variable domain, then we need the general value
@@ -514,9 +514,10 @@ impl Model {
 			if !values.iter().tuple_windows().all(|(&x, &y)| x + 1 == y)
 				|| *values.last().unwrap() < vars.iter().map(|v| v.max(self)).max().unwrap()
 			{
+				vars[0].exclude(self, &values[1..].iter().map(|&v| v..=v).collect(), [])?;
+
 				let con = IntValuePrecedeChainValue::new(self, values.into_iter().collect(), vars);
-				self.post_constraint(con);
-				return;
+				return self.post_constraint(con);
 			}
 			// Otherwise this is a sequential precede chain constraint, and we can
 			// normalize it to start at 1. The `values` array might not have started
@@ -526,13 +527,16 @@ impl Model {
 
 		let vars = vars
 			.into_iter()
-			.map(|v| {
-				v.bounding_sub(self, offset)
-					.expect("TODO: need to defer failure to propagate")
-			})
-			.collect();
-		let con = IntSeqPrecedeChainBounds::new(self, vars);
-		self.post_constraint(con);
+			.map(|v| v.bounding_sub(self, offset))
+			.collect::<Result<Vec<_>, _>>()?;
+		vars[0].tighten_max(self, 1, [])?;
+		match vars.len() {
+			1 => Ok(()),
+			_ => {
+				let con = IntSeqPrecedeChainBounds::new(self, vars);
+				self.post_constraint(con)
+			}
+		}
 	}
 }
 
@@ -547,7 +551,7 @@ impl<S: model_abs_builder::State> ModelAbsBuilder<'_, S> {
 		let res = self
 			.self_receiver
 			.new_int_decision(0..=cmp::max(min.abs(), max.abs()));
-		self.result(res).post();
+		self.result(res).post().unwrap();
 		res
 	}
 }
@@ -561,7 +565,7 @@ impl<S: model_contains_builder::State> ModelContainsBuilder<'_, S> {
 		S::Result: model_contains_builder::IsUnset,
 	{
 		let res = self.self_receiver.new_bool_decision();
-		self.result(res).post();
+		self.result(res).post().unwrap();
 		res
 	}
 }
@@ -599,7 +603,7 @@ impl<S: model_div_builder::State> ModelDivBuilder<'_, S> {
 		};
 
 		let res = self.self_receiver.new_int_decision(range);
-		self.result(res).post();
+		self.result(res).post().unwrap();
 		res
 	}
 }
@@ -614,7 +618,7 @@ impl<E: ElementConstraint, S: model_element_builder::State> ModelElementBuilder<
 	{
 		let index = self.index_internal();
 		let res = E::define_result(self.self_receiver, &self.array, *index);
-		self.result(res.clone()).post();
+		self.result(res.clone()).post().unwrap();
 		res
 	}
 }
@@ -633,7 +637,8 @@ impl<'a, S: model_linear_builder::State> ModelLinearBuilder<'a, S> {
 			.new_int_decision((IntVal::MIN + 1)..=IntVal::MAX);
 		self.comparator_internal(Comparator::Equal)
 			.rhs_internal(res.into())
-			.post();
+			.post()
+			.unwrap();
 		res
 	}
 
@@ -776,7 +781,9 @@ impl<'a, S: model_linear_builder::State> ModelLinearBuilder<'a, S> {
 		S::Comparator: model_linear_builder::IsSet,
 	{
 		let res = self.self_receiver.new_bool_decision();
-		self.reif_internal(Reification::ReifiedBy(res)).post();
+		self.reif_internal(Reification::ReifiedBy(res))
+			.post()
+			.unwrap();
 		res
 	}
 }
@@ -795,7 +802,7 @@ where
 		let res = self
 			.self_receiver
 			.new_int_decision(IntVal::MIN..=IntVal::MAX);
-		self.result(res).post();
+		self.result(res).post().unwrap();
 		res
 	}
 }
@@ -814,7 +821,7 @@ where
 		let res = self
 			.self_receiver
 			.new_int_decision(IntVal::MIN..=IntVal::MAX);
-		self.result(res).post();
+		self.result(res).post().unwrap();
 		res
 	}
 }
@@ -829,7 +836,7 @@ impl<S: model_mul_builder::State> ModelMulBuilder<'_, S> {
 		let res = self
 			.self_receiver
 			.new_int_decision(IntVal::MIN..=IntVal::MAX);
-		self.result(res).post();
+		self.result(res).post().unwrap();
 		res
 	}
 }
@@ -844,7 +851,7 @@ impl<S: model_pow_builder::State> ModelPowBuilder<'_, S> {
 		let res = self
 			.self_receiver
 			.new_int_decision(IntVal::MIN..=IntVal::MAX);
-		self.result(res).post();
+		self.result(res).post().unwrap();
 		res
 	}
 }
@@ -881,7 +888,7 @@ impl<'a, S: model_proposition_builder::State> ModelPropositionBuilder<'a, S> {
 		S::Reif: model_proposition_builder::IsUnset,
 	{
 		let res = self.self_receiver.new_bool_decision();
-		self.reified_by(res).post();
+		self.reified_by(res).post().unwrap();
 		res
 	}
 }

--- a/crates/huub/src/model/expressions/element.rs
+++ b/crates/huub/src/model/expressions/element.rs
@@ -7,6 +7,7 @@ use crate::{
 	IntSet, IntVal,
 	actions::IntInspectionActions,
 	constraints::{
+		Conflict,
 		bool_array_element::BoolDecisionArrayElement,
 		int_array_element::{IntArrayElementBounds, IntValArrayElement},
 		int_set_contains::IntSetContainsReif,
@@ -33,7 +34,7 @@ pub trait ElementConstraint: Sized {
 		array: Vec<Self>,
 		index: View<IntVal>,
 		result: Self::Result,
-	);
+	) -> Result<(), Conflict<View<bool>>>;
 }
 
 impl ElementConstraint for IntVal {
@@ -54,9 +55,9 @@ impl ElementConstraint for IntVal {
 		array: Vec<Self>,
 		index: View<IntVal>,
 		result: Self::Result,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		let con = IntValArrayElement(IntArrayElementBounds::new(prb, array, index, result));
-		prb.post_constraint(con);
+		prb.post_constraint(con)
 	}
 }
 
@@ -83,9 +84,9 @@ impl ElementConstraint for View<IntVal> {
 		array: Vec<Self>,
 		index: View<IntVal>,
 		result: Self::Result,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		let con = IntArrayElementBounds::new(prb, array, index, result);
-		prb.post_constraint(con);
+		prb.post_constraint(con)
 	}
 }
 
@@ -102,12 +103,12 @@ impl ElementConstraint for View<bool> {
 		array: Vec<Self>,
 		index: View<IntVal>,
 		result: Self::Result,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		prb.post_constraint(Self::Constraint {
 			index,
 			array,
 			result,
-		});
+		})
 	}
 }
 
@@ -124,7 +125,7 @@ impl ElementConstraint for bool {
 		array: Vec<Self>,
 		index: View<IntVal>,
 		result: Self::Result,
-	) {
+	) -> Result<(), Conflict<View<bool>>> {
 		// Convert array of boolean values to a set literals of the indices where
 		// the value is true
 		let mut ranges = Vec::new();
@@ -148,6 +149,6 @@ impl ElementConstraint for bool {
 			var: index,
 			set: IntSet::from_iter(ranges),
 			reif: result,
-		});
+		})
 	}
 }

--- a/crates/huub/src/model/view/boolean.rs
+++ b/crates/huub/src/model/view/boolean.rs
@@ -156,7 +156,7 @@ impl Resolved<View<bool>> {
 				let x = BoolFormula::Atom(View(x));
 				let y = BoolFormula::Atom(View(y));
 
-				ctx.post_constraint(BoolFormula::Equiv(vec![x, y]));
+				ctx.post_constraint_internal(BoolFormula::Equiv(vec![x, y]));
 				Ok(())
 			}
 		}

--- a/crates/huub/src/model/view/integer.rs
+++ b/crates/huub/src/model/view/integer.rs
@@ -183,7 +183,7 @@ impl Resolved<View<IntVal>> {
 				} else if can_define_x {
 					(lin_x, lin_y)
 				} else {
-					ctx.post_constraint(IntEq {
+					ctx.post_constraint_internal(IntEq {
 						vars: [self.0, other.0],
 					});
 					return Ok(());

--- a/crates/huub/src/tests.rs
+++ b/crates/huub/src/tests.rs
@@ -12,7 +12,6 @@ use tracing_test::traced_test;
 use crate::{
 	IntSet, IntVal,
 	constraints::int_linear::{IntLinearLessEqBounds, IntLinearNotEqValue},
-	lower::LoweringError,
 	model::{Model, deserialize::AnyView as ModelView},
 	solver::{
 		AnyView as SolverView, Solver, Status, Valuation, Value,
@@ -28,9 +27,11 @@ fn it_works() {
 	let b = prb.new_bool_decision();
 
 	prb.proposition(Formula::Or(vec![(!a).into(), (!b).into()]))
-		.post();
+		.post()
+		.unwrap();
 	prb.proposition(Formula::Or(vec![a.into(), b.into()]))
-		.post();
+		.post()
+		.unwrap();
 
 	let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 	let a = map.get(&mut slv, a);
@@ -175,7 +176,7 @@ fn test_require_bool_view_over_aliased_int_decision() {
 	let x = prb.new_int_decision(1..=2);
 
 	assert!(x.unify(&mut prb, a + 1).is_ok());
-	prb.proposition(Formula::Atom(x.eq(1))).post();
+	prb.proposition(Formula::Atom(x.eq(1))).post().unwrap();
 
 	let vars = [ModelView::from(a), ModelView::from(x)];
 	prb.expect_solutions(
@@ -192,7 +193,7 @@ fn test_unify_int_impossible() {
 	let a = prb.new_int_decision(1..=5);
 	let b = prb.new_int_decision(1..=2);
 
-	prb.linear(a * 2).eq(b * 5).post();
+	prb.linear(a * 2).eq(b * 5).post().unwrap();
 
 	let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 	let a = map.get(&mut slv, a);
@@ -215,7 +216,7 @@ fn test_unify_int_lin_view_domains() {
 	let a = prb.new_int_decision(IntSet::from_iter([1..=1, 3..=3, 5..=5]));
 	let b = prb.new_int_decision(IntSet::from(1..=3));
 
-	prb.linear(a * 6).eq(b * 2).post();
+	prb.linear(a * 6).eq(b * 2).post().unwrap();
 
 	let (mut slv, map): (Solver, _) = prb.lower().to_solver().unwrap();
 	let a = map.get(&mut slv, a);
@@ -238,7 +239,7 @@ fn test_unify_int_view_for_bool_1() {
 	let a = prb.new_bool_decision();
 	let b = prb.new_bool_decision();
 
-	prb.linear(a * 2).eq(b * 2).post();
+	prb.linear(a * 2).eq(b * 2).post().unwrap();
 
 	prb.expect_solutions(
 		&[a, b],
@@ -254,7 +255,7 @@ fn test_unify_int_view_for_bool_2() {
 	let a = prb.new_bool_decision();
 	let b = prb.new_bool_decision();
 
-	prb.linear(a * -2).eq(b * -3).post();
+	prb.linear(a * -2).eq(b * -3).post().unwrap();
 
 	prb.expect_solutions(
 		&[a, b],
@@ -269,7 +270,7 @@ fn test_unify_int_view_for_bool_3() {
 	let a = prb.new_bool_decision();
 	let b = prb.new_bool_decision();
 
-	prb.linear(a * -2).eq(b * 3).post();
+	prb.linear(a * -2).eq(b * 3).post().unwrap();
 
 	prb.expect_solutions(
 		&[a, b],
@@ -284,7 +285,7 @@ fn test_unify_int_view_for_bool_4() {
 	let a = prb.new_bool_decision();
 	let b = prb.new_bool_decision();
 
-	prb.linear(a * 2 + b * 3).eq(0).post();
+	prb.linear(a * 2 + b * 3).eq(0).post().unwrap();
 
 	prb.expect_solutions(
 		&[a, b],
@@ -299,7 +300,7 @@ fn test_unify_int_view_for_bool_5() {
 	let a = prb.new_bool_decision();
 	let b = prb.new_bool_decision();
 
-	prb.linear(a * 2).eq(b * 3).post();
+	prb.linear(a * 2).eq(b * 3).post().unwrap();
 
 	prb.expect_solutions(
 		&[a, b],
@@ -314,20 +315,10 @@ fn test_unify_int_view_for_bool_6() {
 	let a = prb.new_bool_decision();
 	let b = prb.new_bool_decision();
 
-	prb.linear(a * 2 + 2).eq(b * 3).post();
-
-	prb.assert_unsatisfiable();
+	assert!(prb.linear(a * 2 + 2).eq(b * 3).post().is_err());
 }
 
 impl Model {
-	pub(crate) fn assert_unsatisfiable(&mut self) {
-		let err: Result<(Solver, _), _> = self.lower().to_solver();
-		assert!(
-			matches!(err, Err(LoweringError::Simplification(_))),
-			"expected unsatisfiable"
-		);
-	}
-
 	pub(crate) fn expect_solutions<V: Into<ModelView> + Clone>(
 		mut self,
 		vars: &[V],

--- a/docs/src/modelling/constraints.md
+++ b/docs/src/modelling/constraints.md
@@ -6,9 +6,10 @@ While decision variables represent the unknowns, constraints encode the problem 
 
 ## Understanding constraints and propagation
 
-When you post constraints to Huub, they are stored in the model.
-Once you convert the model to a solver (via `lower().to_solver()`), Huub's *constraint propagation* eliminates values from domains that would violate the constraints.
-This reduction happens automatically, even before the solver begins searching for solutions.
+When you post a constraint to Huub, it is immediately propagated.
+If that propagation finds an inconsistency, `.post()` returns an error.
+Huub performs broader propagation across the model when requested (via `.propagate()`) or when you convert the model to a solver (via `.lower().to_solver()`).
+Here, propagation continues until it no longer triggers any other constraint propagation, i.e. fix-point.
 
 For example, if you post the constraint that `x != y` (x and y are different), and x can be {1, 2, 3} while y is {3}, then:
 1. The constraint discovers that y = 3

--- a/docs/src/modelling/getting-started.md
+++ b/docs/src/modelling/getting-started.md
@@ -46,7 +46,7 @@ In this problem, we have to post two constraints.
 
 The `unique()` constraint ensures that all decisions in the vector have different values.
 It is important that each decision variable only appears once in the argument vector, since the `unique()` constraint enforces that *each position* in the vector takes a different value.
-Constraint-builder methods, like `unique()` are finalized using the `.post()` method, which adds it to the model.
+Constraint-builder methods, like `unique()`, are finalized using the `.post()` method, which adds the constraint to the model and immediately propagates it.
 
 **2. Arithmetic constraint:** The addition `SEND+MORE=MONEY` must be correct.
 The key insight here is to connect the individual digits into the larger numbers by multiplying them and adding them together.
@@ -65,6 +65,7 @@ Similar to our strategy above we can first create expressions for `SEND`, `MORE`
 
 The `linear()` method takes a linear expression and returns a builder.
 We then call `.eq()` to specify that the expression should equal another expression, and again use `.post()` to add the constraint to the model.
+Like other posted constraints, this call can already detect contradictions and return an error.
 
 ## Solving the problem
 


### PR DESCRIPTION
- Change constraint builders to propagate immediately and return `Result<(), Conflict>`.
- Update minimum simplification to subsume and simplify earlier, preserving correct propagation.
- Fix integer model event handling so aliased decisions still notify their queued propagators before subscriptions move.
- Correct integer bound-change event emission for `exclude` and `restrict_domain`.
