### PR TITLE
feat: expose Solver::new_int_decision builder

### DIFF
--- a/crates/huub/examples/jobshop/brancher.rs
+++ b/crates/huub/examples/jobshop/brancher.rs
@@ -10,7 +10,7 @@ use huub::{
 	model::{self as huub_model, deserialize::Branching},
 	solver::{
 		self, IntLitMeaning, Solver,
-		branchers::{Brancher, Directive, ValueSelection, VariableSelection},
+		branchers::{Brancher, DecisionSelection, Directive, DomainSelection},
 	},
 };
 
@@ -359,8 +359,8 @@ impl StaticBranching {
 
 		Branching::Int(
 			vars,
-			VariableSelection::InputOrder,
-			ValueSelection::IndomainMin,
+			DecisionSelection::InputOrder,
+			DomainSelection::IndomainMin,
 		)
 	}
 }

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -934,23 +934,29 @@ mod tests {
 		actions::IntInspectionActions,
 		constraints::cumulative::CumulativeTimeTable,
 		model::{ConRef, Model},
-		solver::{
-			Solver, View,
-			decision::integer::{EncodingType, IntDecision},
-		},
+		solver::{LiteralStrategy, Solver, View},
 	};
 
 	/// Helper function to create a task with given start time, duration, and
 	/// usage.
 	fn create_task(
 		slv: &mut Solver,
-		start_time: IntSet,
-		duration: IntSet,
-		usage: IntSet,
+		start_time: impl Into<IntSet>,
+		duration: impl Into<IntSet>,
+		usage: impl Into<IntSet>,
 	) -> (View<IntVal>, View<IntVal>, View<IntVal>) {
-		let start = IntDecision::new_in(slv, start_time, EncodingType::Eager, EncodingType::Lazy);
-		let dur = IntDecision::new_in(slv, duration, EncodingType::Eager, EncodingType::Lazy);
-		let usage = IntDecision::new_in(slv, usage, EncodingType::Eager, EncodingType::Lazy);
+		let start = slv
+			.new_int_decision(start_time)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let dur = slv
+			.new_int_decision(duration)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let usage = slv
+			.new_int_decision(usage)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 		(start, dur, usage)
 	}
 
@@ -1025,24 +1031,18 @@ mod tests {
 	#[traced_test]
 	fn test_cumulative_val_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			(0..=4).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			(0..=4).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			(0..=4).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let a = slv
+			.new_int_decision(0..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(0..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(0..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 
 		let durations: Vec<View<IntVal>> = [2, 3, 1].into_iter().map_into().collect();
 		let resources_profile_1 = vec![1, 2, 3];
@@ -1084,24 +1084,18 @@ mod tests {
 	#[traced_test]
 	fn test_cumulative_val_unsat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			(0..=3).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			(0..=3).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			(0..=3).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let a = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 
 		let durations: Vec<View<IntVal>> = [2, 3, 2].into_iter().map_into().collect();
 		let resources_profile_1: Vec<View<IntVal>> = [2, 2, 3].into_iter().map_into().collect();
@@ -1133,12 +1127,10 @@ mod tests {
 		let start = vec![0, 3, 4, 6, 8, 8];
 		let duration = vec![3, 2, 5, 2, 1, 4];
 		let usage = vec![2, 3, 1, 4, 3, 2];
-		let capacity = IntDecision::new_in(
-			&mut slv,
-			(1..=6).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let capacity = slv
+			.new_int_decision(1..=6)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 		CumulativeTimeTable::post(&mut slv, start, duration, usage, capacity);
 
 		slv.expect_solutions(&[capacity], expect![[r#"6"#]]);
@@ -1151,12 +1143,10 @@ mod tests {
 		let start = vec![0, 3, 4, 6, 8, 8];
 		let duration = vec![3, 2, 5, 2, 1, 4];
 		let usage = vec![2, 3, 1, 4, 3, 2];
-		let capacity = IntDecision::new_in(
-			&mut slv,
-			(1..=4).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let capacity = slv
+			.new_int_decision(1..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 		CumulativeTimeTable::post(&mut slv, start, duration, usage, capacity);
 
 		slv.assert_unsatisfiable();
@@ -1166,26 +1156,9 @@ mod tests {
 	#[traced_test]
 	fn test_cumulative_var_dur_sat() {
 		let mut slv = Solver::default();
-		let (s_a, d_a, u_a) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(1..=3),
-			IntSet::from(2..=2),
-		);
-
-		let (s_b, d_b, u_b) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(1..=3),
-			IntSet::from(2..=2),
-		);
-
-		let (s_c, d_c, u_c) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(1..=3),
-			IntSet::from(2..=2),
-		);
+		let (s_a, d_a, u_a) = create_task(&mut slv, 0..=2, 1..=3, 2..=2);
+		let (s_b, d_b, u_b) = create_task(&mut slv, 0..=2, 1..=3, 2..=2);
+		let (s_c, d_c, u_c) = create_task(&mut slv, 0..=2, 1..=3, 2..=2);
 		let capacity = 2;
 
 		CumulativeTimeTable::post(
@@ -1224,26 +1197,9 @@ mod tests {
 	#[traced_test]
 	fn test_cumulative_var_dur_unsat() {
 		let mut slv = Solver::default();
-		let (s_a, d_a, u_a) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(2..=3),
-			IntSet::from(2..=2),
-		);
-
-		let (s_b, d_b, u_b) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(2..=3),
-			IntSet::from(2..=2),
-		);
-
-		let (s_c, d_c, u_c) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(2..=3),
-			IntSet::from(2..=2),
-		);
+		let (s_a, d_a, u_a) = create_task(&mut slv, 0..=2, 2..=3, 2..=2);
+		let (s_b, d_b, u_b) = create_task(&mut slv, 0..=2, 2..=3, 2..=2);
+		let (s_c, d_c, u_c) = create_task(&mut slv, 0..=2, 2..=3, 2..=2);
 		let capacity = 2;
 
 		CumulativeTimeTable::post(
@@ -1261,26 +1217,9 @@ mod tests {
 	#[traced_test]
 	fn test_cumulative_var_usage_sat() {
 		let mut slv = Solver::default();
-		let (s_a, d_a, u_a) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(1..=1),
-			IntSet::from(1..=2),
-		);
-
-		let (s_b, d_b, u_b) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(3..=3),
-			IntSet::from(2..=3),
-		);
-
-		let (s_c, d_c, u_c) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(2..=2),
-			IntSet::from(2..=3),
-		);
+		let (s_a, d_a, u_a) = create_task(&mut slv, 0..=2, 1..=1, 1..=2);
+		let (s_b, d_b, u_b) = create_task(&mut slv, 0..=2, 3..=3, 2..=3);
+		let (s_c, d_c, u_c) = create_task(&mut slv, 0..=2, 2..=2, 2..=3);
 		let capacity = 3;
 
 		CumulativeTimeTable::post(
@@ -1307,26 +1246,9 @@ mod tests {
 	#[traced_test]
 	fn test_cumulative_var_usage_unsat() {
 		let mut slv = Solver::default();
-		let (s_a, d_a, u_a) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(2..=2),
-			IntSet::from(1..=3),
-		);
-
-		let (s_b, d_b, u_b) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(2..=2),
-			IntSet::from(2..=3),
-		);
-
-		let (s_c, d_c, u_c) = create_task(
-			&mut slv,
-			IntSet::from(0..=2),
-			IntSet::from(2..=2),
-			IntSet::from(2..=3),
-		);
+		let (s_a, d_a, u_a) = create_task(&mut slv, 0..=2, 2..=2, 1..=3);
+		let (s_b, d_b, u_b) = create_task(&mut slv, 0..=2, 2..=2, 2..=3);
+		let (s_c, d_c, u_c) = create_task(&mut slv, 0..=2, 2..=2, 2..=3);
 		let capacity = 2;
 
 		CumulativeTimeTable::post(

--- a/crates/huub/src/constraints/disjunctive.rs
+++ b/crates/huub/src/constraints/disjunctive.rs
@@ -1438,12 +1438,8 @@ mod tests {
 	use tracing_test::traced_test;
 
 	use crate::{
-		IntSet,
 		constraints::disjunctive::DisjunctivePropagator,
-		solver::{
-			Solver,
-			decision::integer::{EncodingType, IntDecision},
-		},
+		solver::{LiteralStrategy, Solver},
 	};
 
 	#[test]
@@ -1453,24 +1449,18 @@ mod tests {
 			itertools::iproduct!([true, false], [true, false], [true, false])
 		{
 			let mut slv = Solver::default();
-			let a = IntDecision::new_in(
-				&mut slv,
-				IntSet::from(0..=4),
-				EncodingType::Eager,
-				EncodingType::Lazy,
-			);
-			let b = IntDecision::new_in(
-				&mut slv,
-				IntSet::from(0..=4),
-				EncodingType::Eager,
-				EncodingType::Lazy,
-			);
-			let c = IntDecision::new_in(
-				&mut slv,
-				IntSet::from(0..=4),
-				EncodingType::Eager,
-				EncodingType::Lazy,
-			);
+			let a = slv
+				.new_int_decision(0..=4)
+				.order_literals(LiteralStrategy::Eager)
+				.view();
+			let b = slv
+				.new_int_decision(0..=4)
+				.order_literals(LiteralStrategy::Eager)
+				.view();
+			let c = slv
+				.new_int_decision(0..=4)
+				.order_literals(LiteralStrategy::Eager)
+				.view();
 
 			let durations = vec![2, 3, 1];
 			DisjunctivePropagator::post(

--- a/crates/huub/src/constraints/int_abs.rs
+++ b/crates/huub/src/constraints/int_abs.rs
@@ -200,30 +200,22 @@ mod tests {
 	use tracing_test::traced_test;
 
 	use crate::{
-		IntSet,
 		constraints::int_abs::IntAbsBounds,
-		solver::{
-			Solver,
-			decision::integer::{EncodingType, IntDecision},
-		},
+		solver::{LiteralStrategy, Solver},
 	};
 
 	#[test]
 	#[traced_test]
 	fn test_int_abs_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			(-3..=3).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-3..=3),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let a = slv
+			.new_int_decision(-3..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(-3..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntAbsBounds::post(&mut slv, a, b);
 

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -472,10 +472,7 @@ mod tests {
 		actions::{IntInspectionActions, IntPropagationActions},
 		constraints::int_array_element::IntArrayElementBounds,
 		model::Model,
-		solver::{
-			Solver,
-			decision::integer::{EncodingType, IntDecision},
-		},
+		solver::{LiteralStrategy, Solver},
 	};
 
 	#[test]
@@ -524,36 +521,26 @@ mod tests {
 	#[traced_test]
 	fn test_element_bounds_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(3..=4),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(2..=3),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(4..=5),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let y = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(3..=4),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let index = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=2),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let a = slv
+			.new_int_decision(3..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(2..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(4..=5)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let y = slv
+			.new_int_decision(3..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let index = slv
+			.new_int_decision(0..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntArrayElementBounds::post(&mut slv, vec![a, b, c], index, y).unwrap();
 
@@ -583,30 +570,22 @@ mod tests {
 	#[traced_test]
 	fn test_element_holes() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let y = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(3..=4),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let index = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([0..=0, 3..=3]),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let a = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let y = slv
+			.new_int_decision(3..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let index = slv
+			.new_int_decision(IntSet::from_iter([0..=0, 3..=3]))
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntArrayElementBounds::post(&mut slv, vec![a, b], index, y).unwrap();
 

--- a/crates/huub/src/constraints/int_div.rs
+++ b/crates/huub/src/constraints/int_div.rs
@@ -341,34 +341,25 @@ mod tests {
 		IntSet,
 		constraints::int_div::IntDivBounds,
 		model::Model,
-		solver::{
-			Solver,
-			decision::integer::{EncodingType, IntDecision},
-		},
+		solver::{LiteralStrategy, Solver},
 	};
 
 	#[test]
 	#[traced_test]
 	fn test_int_div_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			(-7..=7).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([-3..=-1, 1..=3]),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			(-7..=7).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let a = slv
+			.new_int_decision(-7..=7)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(IntSet::from_iter([-3..=-1, 1..=3]))
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(-7..=7)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntDivBounds::post(&mut slv, a, b, c).unwrap();
 

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -1084,13 +1084,10 @@ mod tests {
 	use tracing_test::traced_test;
 
 	use crate::{
-		IntSet, IntVal,
+		IntVal,
 		constraints::int_linear::{DoubleIntVal, IntLinearLessEqBounds, IntLinearNotEqValue},
 		model::{Model, view::View},
-		solver::{
-			Solver,
-			decision::integer::{EncodingType, IntDecision},
-		},
+		solver::{LiteralStrategy, Solver},
 	};
 
 	#[test]
@@ -1115,24 +1112,18 @@ mod tests {
 	#[traced_test]
 	fn test_linear_ge_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let a = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntLinearLessEqBounds::post(&mut slv, vec![a * NonZero::new(-2).unwrap(), -b, -c], -6);
 
@@ -1162,24 +1153,18 @@ mod tests {
 	#[traced_test]
 	fn test_linear_le_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let a = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntLinearLessEqBounds::post(&mut slv, vec![a * NonZero::new(2).unwrap(), b, c], 6);
 
@@ -1209,24 +1194,21 @@ mod tests {
 	#[traced_test]
 	fn test_linear_ne_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let a = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntLinearNotEqValue::post(&mut slv, vec![a * NonZero::new(2).unwrap(), b, c], 6);
 

--- a/crates/huub/src/constraints/int_mul.rs
+++ b/crates/huub/src/constraints/int_mul.rs
@@ -232,28 +232,15 @@ mod tests {
 	use crate::{
 		IntVal,
 		constraints::int_mul::IntMulBounds,
-		solver::{
-			Solver,
-			decision::integer::{EncodingType, IntDecision},
-		},
+		solver::{LiteralStrategy, Solver},
 	};
 
 	#[test]
 	#[traced_test]
 	fn overflow_intermediate_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			(IntVal::MIN..=IntVal::MAX).into(),
-			EncodingType::Lazy,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			(IntVal::MIN..=IntVal::MAX).into(),
-			EncodingType::Lazy,
-			EncodingType::Lazy,
-		);
+		let a = slv.new_int_decision(IntVal::MIN..=IntVal::MAX).view();
+		let b = slv.new_int_decision(IntVal::MIN..=IntVal::MAX).view();
 
 		IntMulBounds::post(&mut slv, a, b, 2);
 		slv.expect_solutions(
@@ -270,18 +257,8 @@ mod tests {
 	#[traced_test]
 	fn overflow_unsat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			(2..=IntVal::MAX).into(),
-			EncodingType::Lazy,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			(IntVal::MIN..=IntVal::MAX).into(),
-			EncodingType::Lazy,
-			EncodingType::Lazy,
-		);
+		let a = slv.new_int_decision(2..=IntVal::MAX).view();
+		let b = slv.new_int_decision(IntVal::MIN..=IntVal::MAX).view();
 
 		IntMulBounds::post(&mut slv, IntVal::MAX, a, b);
 		slv.assert_unsatisfiable();
@@ -291,24 +268,18 @@ mod tests {
 	#[traced_test]
 	fn simple_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			(-2..=1).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			(-1..=2).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			(-4..=2).into(),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let a = slv
+			.new_int_decision(-2..=1)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(-1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(-4..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntMulBounds::post(&mut slv, a, b, c);
 		slv.expect_solutions(
@@ -337,18 +308,8 @@ mod tests {
 	#[traced_test]
 	fn underflow_unsat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			(2..=IntVal::MAX).into(),
-			EncodingType::Lazy,
-			EncodingType::Lazy,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			(IntVal::MIN..=IntVal::MAX).into(),
-			EncodingType::Lazy,
-			EncodingType::Lazy,
-		);
+		let a = slv.new_int_decision(2..=IntVal::MAX).view();
+		let b = slv.new_int_decision(IntVal::MIN..=IntVal::MAX).view();
 
 		IntMulBounds::post(&mut slv, IntVal::MIN, a, b);
 		slv.assert_unsatisfiable();

--- a/crates/huub/src/constraints/int_pow.rs
+++ b/crates/huub/src/constraints/int_pow.rs
@@ -525,34 +525,24 @@ mod tests {
 	use crate::{
 		IntVal,
 		constraints::int_pow::IntPowBounds,
-		solver::{
-			Solver,
-			decision::integer::{EncodingType, IntDecision},
-		},
+		solver::{LiteralStrategy, Solver},
 	};
 
 	#[test]
 	#[traced_test]
 	fn test_int_pow_overflow() {
 		let mut slv = Solver::default();
-		let base = IntDecision::new_in(
-			&mut slv,
-			(10..=10).into(),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let exponent = IntDecision::new_in(
-			&mut slv,
-			(18..=19).into(),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let result = IntDecision::new_in(
-			&mut slv,
-			(0..=IntVal::MAX).into(),
-			EncodingType::Lazy,
-			EncodingType::Lazy,
-		);
+		let base = slv
+			.new_int_decision(10..=10)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let exponent = slv
+			.new_int_decision(18..=19)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let result = slv.new_int_decision(0..=IntVal::MAX).view();
 
 		IntPowBounds::post(&mut slv, base, exponent, result)
 			.expect("int_pow(a,b,c) was found to be unsatisfiable");
@@ -567,24 +557,21 @@ mod tests {
 	#[traced_test]
 	fn test_int_pow_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			(-2..=3).into(),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			(-2..=2).into(),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			(-2..=9).into(),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let a = slv
+			.new_int_decision(-2..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(-2..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(-2..=9)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntPowBounds::post(&mut slv, a, b, c)
 			.expect("int_pow(a,b,c) was found to be unsatisfiable");
@@ -626,24 +613,17 @@ mod tests {
 	#[traced_test]
 	fn test_int_pow_underflow() {
 		let mut slv = Solver::default();
-		let base = IntDecision::new_in(
-			&mut slv,
-			(-10..=-10).into(),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let exponent = IntDecision::new_in(
-			&mut slv,
-			(19..=19).into(),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let result = IntDecision::new_in(
-			&mut slv,
-			(IntVal::MIN..=0).into(),
-			EncodingType::Lazy,
-			EncodingType::Lazy,
-		);
+		let base = slv
+			.new_int_decision(-10..=-10)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let exponent = slv
+			.new_int_decision(19..=19)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let result = slv.new_int_decision(IntVal::MIN..=0).view();
 
 		IntPowBounds::post(&mut slv, base, exponent, result)
 			.expect("int_pow(a,b,c) was found to be unsatisfiable");

--- a/crates/huub/src/constraints/int_unique.rs
+++ b/crates/huub/src/constraints/int_unique.rs
@@ -597,34 +597,28 @@ mod tests {
 			int_unique::{IntUniqueBounds, IntUniqueValue},
 		},
 		model::Model,
-		solver::{
-			Solver, Status, Valuation,
-			decision::integer::{EncodingType, IntDecision},
-		},
+		solver::{LiteralStrategy, Solver, Status, Valuation},
 	};
 
 	#[test]
 	#[traced_test]
 	fn test_all_different_bounds_sat_1() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let a = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 		IntUniqueBounds::post(&mut slv, vec![a, b, c]);
 		slv.assert_all_solutions(&[a, b, c], |sol| sol.iter().all_unique());
 	}
@@ -632,42 +626,36 @@ mod tests {
 	#[traced_test]
 	fn test_all_different_bounds_sat_2() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(3..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(2..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(3..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let d = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(2..=5),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let e = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(3..=6),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let f = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=6),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let a = slv
+			.new_int_decision(3..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(2..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(3..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let d = slv
+			.new_int_decision(2..=5)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let e = slv
+			.new_int_decision(3..=6)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let f = slv
+			.new_int_decision(1..=6)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntUniqueBounds::post(&mut slv, vec![a, b, c, d, e, f]);
 		slv.assert_all_solutions(&[a, b, c, d, e, f], |sol| sol.iter().all_unique());
@@ -677,42 +665,36 @@ mod tests {
 	#[traced_test]
 	fn test_all_different_bounds_sat_3() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(3..=6),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(3..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(2..=5),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let d = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(2..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let e = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(3..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let f = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=6),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let a = slv
+			.new_int_decision(3..=6)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(3..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(2..=5)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let d = slv
+			.new_int_decision(2..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let e = slv
+			.new_int_decision(3..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let f = slv
+			.new_int_decision(1..=6)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntUniqueBounds::post(&mut slv, vec![a, b, c, d, e, f]);
 		slv.assert_all_solutions(&[a, b, c, d, e, f], |sol| sol.iter().all_unique());
@@ -722,24 +704,21 @@ mod tests {
 	#[traced_test]
 	fn test_all_different_bounds_unsat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let a = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntUniqueBounds::post(&mut slv, vec![a, b, c]);
 		IntLinearLessEqBounds::post(&mut slv, vec![-a, -b, -c], -8);
@@ -750,24 +729,21 @@ mod tests {
 	#[traced_test]
 	fn test_all_different_value_sat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let a = slv
+			.new_int_decision(1..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(1..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(1..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntUniqueValue::post(&mut slv, vec![a, b, c]);
 
@@ -778,24 +754,21 @@ mod tests {
 	#[traced_test]
 	fn test_all_different_value_unsat() {
 		let mut slv = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let b = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let c = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let a = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let b = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let c = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntUniqueValue::post(&mut slv, vec![a, b, c]);
 
@@ -808,7 +781,7 @@ mod tests {
 		let mut prb = Model::default();
 		let prev: Vec<_> = [
 			IntSet::from_iter([15..=15, 20..=20]),
-			IntSet::from(20..=20),
+			(20..=20).into(),
 			IntSet::from_iter([15..=15, 20..=20]),
 		]
 		.into_iter()
@@ -834,12 +807,10 @@ mod tests {
 							let num = IntVal::from(c.to_digit(10).unwrap());
 							num.into()
 						} else {
-							IntDecision::new_in(
-								&mut slv,
-								IntSet::from(1..=9),
-								EncodingType::Eager,
-								EncodingType::Eager,
-							)
+							slv.new_int_decision(1..=9)
+								.order_literals(LiteralStrategy::Eager)
+								.direct_literals(LiteralStrategy::Eager)
+								.view()
 						}
 					})
 					.collect();

--- a/crates/huub/src/constraints/int_value_precede.rs
+++ b/crates/huub/src/constraints/int_value_precede.rs
@@ -978,9 +978,8 @@ mod tests {
 		IntSet, IntVal,
 		constraints::int_value_precede::{IntSeqPrecedeChainBounds, IntValuePrecedeChainValue},
 		solver::{
-			Solver,
+			LiteralStrategy, Solver,
 			Value::{self, Int},
-			decision::integer::{EncodingType, IntDecision},
 		},
 	};
 
@@ -988,60 +987,51 @@ mod tests {
 	#[traced_test]
 	fn test_seq_precede_chain_paper() {
 		let mut slv = Solver::default();
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-1..=1),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x2 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([-1..=1, 5..=5]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x3 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([-1..=0, 3..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x4 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([0..=2, 4..=4]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x5 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([0..=1, 3..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x6 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([1..=1, 3..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x7 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(2..=5),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x8 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(4..=5),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x9 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x1 = slv
+			.new_int_decision(-1..=1)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x2 = slv
+			.new_int_decision(IntSet::from_iter([-1..=1, 5..=5]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x3 = slv
+			.new_int_decision(IntSet::from_iter([-1..=0, 3..=3]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x4 = slv
+			.new_int_decision(IntSet::from_iter([0..=2, 4..=4]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x5 = slv
+			.new_int_decision(IntSet::from_iter([0..=1, 3..=3]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x6 = slv
+			.new_int_decision(IntSet::from_iter([1..=1, 3..=3]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x7 = slv
+			.new_int_decision(2..=5)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x8 = slv
+			.new_int_decision(4..=5)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x9 = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntSeqPrecedeChainBounds::post(&mut slv, vec![x1, x2, x3, x4, x5, x6, x7, x8, x9]);
 		slv.assert_all_solutions(
@@ -1054,18 +1044,16 @@ mod tests {
 	#[traced_test]
 	fn test_seq_precede_chain_simple() {
 		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x0 = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x1 = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntSeqPrecedeChainBounds::post(&mut slv, vec![x0, x1]);
 		slv.expect_solutions(
@@ -1083,12 +1071,11 @@ mod tests {
 	#[traced_test]
 	fn test_seq_precede_chain_single_var() {
 		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-1..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x0 = slv
+			.new_int_decision(-1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntSeqPrecedeChainBounds::post(&mut slv, vec![x0]);
 		slv.expect_solutions(
@@ -1104,30 +1091,26 @@ mod tests {
 	#[traced_test]
 	fn test_seq_precede_chain_unrestricted() {
 		let mut slv = Solver::default();
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-1..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x2 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-1..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x3 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-1..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x4 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-1..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x1 = slv
+			.new_int_decision(-1..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x2 = slv
+			.new_int_decision(-1..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x3 = slv
+			.new_int_decision(-1..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x4 = slv
+			.new_int_decision(-1..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntSeqPrecedeChainBounds::post(&mut slv, vec![x1, x2, x3, x4]);
 		slv.assert_all_solutions(&[x1, x2, x3, x4], valid_sequence_precede);
@@ -1137,18 +1120,16 @@ mod tests {
 	#[traced_test]
 	fn test_val_precede_chain_all_enforced() {
 		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x0 = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x1 = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntValuePrecedeChainValue::post(&mut slv, vec![3, 2, 1], vec![x0, x1]);
 		slv.expect_solutions(
@@ -1163,18 +1144,16 @@ mod tests {
 	#[traced_test]
 	fn test_val_precede_chain_simple() {
 		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x0 = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x1 = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntValuePrecedeChainValue::post(&mut slv, vec![1, 3], vec![x0, x1]);
 		slv.expect_solutions(
@@ -1197,12 +1176,11 @@ mod tests {
 	#[traced_test]
 	fn test_val_precede_chain_single_var() {
 		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x0 = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntValuePrecedeChainValue::post(&mut slv, vec![2, 1], vec![x0]);
 		slv.expect_solutions(
@@ -1218,60 +1196,51 @@ mod tests {
 	#[traced_test]
 	fn test_value_precede_chain_complex() {
 		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([0..=0, 2..=2]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(2..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x2 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([-3..=-3, 1..=1]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x3 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([-2..=0, 2..=2]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x4 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=2),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x5 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=2),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x6 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([-2..=-1, 1..=1]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x7 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([-1..=-1, 3..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x8 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x0 = slv
+			.new_int_decision(IntSet::from_iter([0..=0, 2..=2]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x1 = slv
+			.new_int_decision(2..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x2 = slv
+			.new_int_decision(IntSet::from_iter([-3..=-3, 1..=1]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x3 = slv
+			.new_int_decision(IntSet::from_iter([-2..=0, 2..=2]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x4 = slv
+			.new_int_decision(0..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x5 = slv
+			.new_int_decision(1..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x6 = slv
+			.new_int_decision(IntSet::from_iter([-2..=-1, 1..=1]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x7 = slv
+			.new_int_decision(IntSet::from_iter([-1..=-1, 3..=3]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x8 = slv
+			.new_int_decision(1..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntValuePrecedeChainValue::post(
 			&mut slv,
@@ -1288,12 +1257,11 @@ mod tests {
 	#[traced_test]
 	fn test_value_precede_chain_holes() {
 		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([0..=1, 3..=3]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x0 = slv
+			.new_int_decision(IntSet::from_iter([0..=1, 3..=3]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntValuePrecedeChainValue::post(&mut slv, vec![1, 3], vec![x0]);
 		slv.expect_solutions(
@@ -1308,24 +1276,21 @@ mod tests {
 	#[traced_test]
 	fn test_value_precede_chain_out_of_bounds() {
 		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=1),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=1),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x2 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=1),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x0 = slv
+			.new_int_decision(0..=1)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x1 = slv
+			.new_int_decision(0..=1)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x2 = slv
+			.new_int_decision(0..=1)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntValuePrecedeChainValue::post(&mut slv, vec![1, 3], vec![x0, x1, x2]);
 		slv.assert_all_solutions(&[x0, x1, x2], valid_value_precede(vec![1, 3]));
@@ -1335,24 +1300,21 @@ mod tests {
 	#[traced_test]
 	fn test_value_precede_chain_simple() {
 		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x2 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x0 = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x1 = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x2 = slv
+			.new_int_decision(0..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntValuePrecedeChainValue::post(&mut slv, vec![1, 2], vec![x0, x1, x2]);
 		slv.assert_all_solutions(&[x0, x1, x2], valid_value_precede(vec![1, 2]));
@@ -1362,30 +1324,26 @@ mod tests {
 	#[traced_test]
 	fn test_value_precede_chain_unrestricted() {
 		let mut slv = Solver::default();
-		let x0 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-2..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x1 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-3..=2),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x2 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-2..=3),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
-		let x3 = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(-3..=2),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let x0 = slv
+			.new_int_decision(-2..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x1 = slv
+			.new_int_decision(-3..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x2 = slv
+			.new_int_decision(-2..=3)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
+		let x3 = slv
+			.new_int_decision(-3..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 
 		IntValuePrecedeChainValue::post(&mut slv, vec![2, -2, 1, -1], vec![x0, x1, x2, x3]);
 		slv.assert_all_solutions(&[x0, x1, x2, x3], valid_value_precede(vec![2, -2, 1, -1]));

--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -40,10 +40,7 @@ use crate::{
 	helpers::bytes::Bytes,
 	model::{self, Model, decision::integer::Domain, resolved::Resolved},
 	solver::{
-		self, IntLitMeaning, Solver,
-		decision::integer::{EncodingType, IntDecision},
-		engine::Engine,
-		view::boolean::BoolView,
+		self, IntLitMeaning, LiteralStrategy, Solver, engine::Engine, view::boolean::BoolView,
 	},
 	views::LinearBoolView,
 };
@@ -870,20 +867,24 @@ impl LoweringMapBuilder {
 							unreachable!()
 						};
 						let direct_enc = if self.int_eager_direct.contains(&var) {
-							EncodingType::Eager
+							LiteralStrategy::Eager
 						} else {
-							EncodingType::Lazy
+							LiteralStrategy::Lazy
 						};
 						let card = dom.card();
 						let order_enc = if self.int_eager_order.contains(&var)
 							|| self.int_eager_direct.contains(&var)
 							|| card.is_some() && card.unwrap() <= self.int_eager_limit
 						{
-							EncodingType::Eager
+							LiteralStrategy::Eager
 						} else {
-							EncodingType::Lazy
+							LiteralStrategy::Lazy
 						};
-						let view = IntDecision::new_in(slv, dom.clone(), order_enc, direct_enc);
+						let view = slv
+							.new_int_decision(dom.clone())
+							.order_literals(order_enc)
+							.direct_literals(direct_enc)
+							.view();
 						self.int_map[var.idx()] = Some(view);
 						view
 					}

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -310,7 +310,7 @@ impl Model {
 		let domain = domain.into();
 		match domain.card() {
 			Some(0) => {
-				unimplemented!("integer decision must have at least 1 value in their domain")
+				panic!("integer decision must have at least 1 value in their domain")
 			}
 			Some(1) => (*domain.lower_bound().unwrap()).into(),
 			_ => {

--- a/crates/huub/src/model/deserialize.rs
+++ b/crates/huub/src/model/deserialize.rs
@@ -12,7 +12,7 @@ use crate::{
 	solver::{
 		Solver,
 		branchers::{
-			BoolBrancher, IntBrancher, ValueSelection, VariableSelection, WarmStartBrancher,
+			BoolBrancher, DecisionSelection, DomainSelection, IntBrancher, WarmStartBrancher,
 		},
 	},
 };
@@ -36,14 +36,14 @@ pub enum AnyView {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum Branching {
-	/// Make a search decision by using the [`VariableSelection`] to select a
+	/// Make a search decision by using the [`DecisionSelection`] to select a
 	/// Boolean decision variable, and then set its value by using the
-	/// [`ValueSelection`].
-	Bool(Vec<View<bool>>, VariableSelection, ValueSelection),
-	/// Make a search decision by using the [`VariableSelection`] to select a
+	/// [`DomainSelection`].
+	Bool(Vec<View<bool>>, DecisionSelection, DomainSelection),
+	/// Make a search decision by using the [`DecisionSelection`] to select a
 	/// integer decision variable, and then limit the domain of the variable by
-	/// using the [`ValueSelection`].
-	Int(Vec<View<IntVal>>, VariableSelection, ValueSelection),
+	/// using the [`DomainSelection`].
+	Int(Vec<View<IntVal>>, DecisionSelection, DomainSelection),
 	/// Search by sequentially applying the given branching strategies.
 	Seq(Vec<Branching>),
 	/// Search by enforcing the given Boolean expressions, but abandon the

--- a/crates/huub/src/model/deserialize.rs
+++ b/crates/huub/src/model/deserialize.rs
@@ -19,6 +19,7 @@ use crate::{
 
 /// Reference to a decision in a [`Model`](crate::model::Model).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum AnyView {
 	/// Reference to a Boolean decision.
 	Bool(View<bool>),
@@ -33,6 +34,7 @@ pub enum AnyView {
 /// Note that a [`Branching`] might be ignored (or used as only a suggestion) in
 /// [`Solver`] depending on the configuration.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum Branching {
 	/// Make a search decision by using the [`VariableSelection`] to select a
 	/// Boolean decision variable, and then set its value by using the

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -1342,7 +1342,10 @@ impl<'a> FznModelBuilder<'a> {
 				}),
 			})?,
 			&Literal::Bool(v) => Ok(v.into()),
-			_ => todo!(),
+			other => Err(FlatZincError::InvalidArgumentType {
+				expected: "bool",
+				found: format!("{:?}", other).to_owned(),
+			}),
 		}
 	}
 
@@ -1360,7 +1363,10 @@ impl<'a> FznModelBuilder<'a> {
 			})?,
 			&Literal::Bool(v) => Ok((v as IntVal).into()),
 			&Literal::Int(v) => Ok(v.into()),
-			_ => todo!(),
+			other => Err(FlatZincError::InvalidArgumentType {
+				expected: "int",
+				found: format!("{:?}", other).to_owned(),
+			}),
 		}
 	}
 
@@ -1387,7 +1393,7 @@ impl<'a> FznModelBuilder<'a> {
 							self.prb.new_int_decision(FULL_INT_DOMAIN).into()
 						}
 					},
-					_ => todo!("Variables of {:?} are not yet supported", var.ty),
+					ty => panic!("Variables of {:?} are not supported", ty),
 				};
 				Ok(e.insert(view).clone())
 			}

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -214,6 +214,7 @@ pub enum ConstraintIdent {
 /// Errors that can occur when converting a [`FlatZinc`] instance to a [`Model`]
 /// or [`Solver`](crate::solver::Solver) object.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FlatZincError {
 	/// FlatZinc instance contained a decision variable with an unsupported
 	/// type.

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -37,7 +37,7 @@ use crate::{
 	},
 	solver::{
 		self,
-		branchers::{ValueSelection, VariableSelection},
+		branchers::{DecisionSelection, DomainSelection},
 	},
 };
 
@@ -699,8 +699,8 @@ impl<'a> FznModelBuilder<'a> {
 							.iter()
 							.map(|l| self.lit_bool(l))
 							.try_collect()?;
-						let var_sel = Self::ann_var_sel(var_sel)?;
-						let val_sel = Self::ann_val_sel(val_sel)?;
+						let var_sel = Self::ann_dcn_sel(var_sel)?;
+						let val_sel = Self::ann_dom_sel(val_sel)?;
 						Ok((Vec::new(), vec![Branching::Bool(vars, var_sel, val_sel)]))
 					} else {
 						Err(FlatZincError::InvalidNumArgs {
@@ -717,8 +717,8 @@ impl<'a> FznModelBuilder<'a> {
 							.iter()
 							.map(|l| self.lit_int(l))
 							.try_collect()?;
-						let var_sel = Self::ann_var_sel(var_sel)?;
-						let val_sel = Self::ann_val_sel(val_sel)?;
+						let var_sel = Self::ann_dcn_sel(var_sel)?;
+						let val_sel = Self::ann_dom_sel(val_sel)?;
 
 						Ok((Vec::new(), vec![Branching::Int(vars, var_sel, val_sel)]))
 					} else {
@@ -823,10 +823,10 @@ impl<'a> FznModelBuilder<'a> {
 		Ok((Vec::new(), Vec::new()))
 	}
 
-	/// Extract an [`ValueSelection`] from an [`AnnotationArgument`] in a
+	/// Extract an [`DomainSelection`] from an [`AnnotationArgument`] in a
 	/// [`FlatZinc`] instance, or return a
 	/// [`FlatZincError::InvalidArgumentType`] if an invalid type.
-	fn ann_val_sel(arg: &AnnotationArgument<FznIdent>) -> Result<ValueSelection, FlatZincError> {
+	fn ann_dom_sel(arg: &AnnotationArgument<FznIdent>) -> Result<DomainSelection, FlatZincError> {
 		let AnnotationArgument::Literal(AnnotationLiteral::Annotation(ann)) = arg else {
 			return Err(FlatZincError::InvalidArgumentType {
 				expected: "ann",
@@ -836,11 +836,11 @@ impl<'a> FznModelBuilder<'a> {
 		if let Annotation::Atom(FznIdent::Known(KnownIdent::Annotation(ann))) = ann {
 			match ann {
 				AnnotationIdent::ValSelIndomain | AnnotationIdent::ValSelIndomainMin => {
-					return Ok(ValueSelection::IndomainMin);
+					return Ok(DomainSelection::IndomainMin);
 				}
-				AnnotationIdent::ValSelIndomainMax => return Ok(ValueSelection::IndomainMax),
-				AnnotationIdent::ValSelOutdomainMax => return Ok(ValueSelection::OutdomainMax),
-				AnnotationIdent::ValSelOutdomainMin => return Ok(ValueSelection::OutdomainMin),
+				AnnotationIdent::ValSelIndomainMax => return Ok(DomainSelection::IndomainMax),
+				AnnotationIdent::ValSelOutdomainMax => return Ok(DomainSelection::OutdomainMax),
+				AnnotationIdent::ValSelOutdomainMin => return Ok(DomainSelection::OutdomainMin),
 				_ => {}
 			}
 		}
@@ -850,13 +850,13 @@ impl<'a> FznModelBuilder<'a> {
 			fallback = "indomain_min",
 			"unsupported value selection"
 		);
-		Ok(ValueSelection::IndomainMin)
+		Ok(DomainSelection::IndomainMin)
 	}
 
-	/// Extract an [`VariableSelection`] from an [`AnnotationArgument`] in a
+	/// Extract an [`DecisionSelection`] from an [`AnnotationArgument`] in a
 	/// [`FlatZinc`] instance, or return a
 	/// [`FlatZincError::InvalidArgumentType`] if an invalid type.
-	fn ann_var_sel(arg: &AnnotationArgument<FznIdent>) -> Result<VariableSelection, FlatZincError> {
+	fn ann_dcn_sel(arg: &AnnotationArgument<FznIdent>) -> Result<DecisionSelection, FlatZincError> {
 		let AnnotationArgument::Literal(AnnotationLiteral::Annotation(ann)) = arg else {
 			return Err(FlatZincError::InvalidArgumentType {
 				expected: "ann",
@@ -866,12 +866,12 @@ impl<'a> FznModelBuilder<'a> {
 		if let Annotation::Atom(FznIdent::Known(KnownIdent::Annotation(ann))) = ann {
 			match ann {
 				AnnotationIdent::VarSelAntiFirstFail => {
-					return Ok(VariableSelection::AntiFirstFail);
+					return Ok(DecisionSelection::AntiFirstFail);
 				}
-				AnnotationIdent::VarSelFirstFail => return Ok(VariableSelection::FirstFail),
-				AnnotationIdent::VarSelInputOrder => return Ok(VariableSelection::InputOrder),
-				AnnotationIdent::VarSelLargest => return Ok(VariableSelection::Largest),
-				AnnotationIdent::VarSelSmallest => return Ok(VariableSelection::Smallest),
+				AnnotationIdent::VarSelFirstFail => return Ok(DecisionSelection::FirstFail),
+				AnnotationIdent::VarSelInputOrder => return Ok(DecisionSelection::InputOrder),
+				AnnotationIdent::VarSelLargest => return Ok(DecisionSelection::Largest),
+				AnnotationIdent::VarSelSmallest => return Ok(DecisionSelection::Smallest),
 				_ => {}
 			}
 		}
@@ -881,7 +881,7 @@ impl<'a> FznModelBuilder<'a> {
 			fallback = "first_fail",
 			"unsupported value selection"
 		);
-		Ok(VariableSelection::FirstFail)
+		Ok(DecisionSelection::FirstFail)
 	}
 
 	/// Check whether an annotation atom is present in the given list of

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -18,21 +18,24 @@ use std::{
 	fmt::Debug,
 	hash::Hash,
 	mem,
+	num::NonZero,
 	ops::{Add, AddAssign, Not},
 	rc::Rc,
 };
 
-use bon::Builder;
+use bon::{Builder, bon};
 use itertools::Itertools;
 pub use pindakaas::solver::cadical::Cadical;
 use pindakaas::{
-	ClauseDatabase, ClauseDatabaseTools, Lit as RawLit, Unsatisfiable,
+	ClauseDatabase, ClauseDatabaseTools, Lit as RawLit, Unsatisfiable, VarRange,
 	solver::{
 		Assumptions, FailedAssumptions, LearnCallback, SolveResult as SatSolveResult,
 		TerminateCallback,
 		propagation::{ExternalPropagation, SolvingActions},
 	},
 };
+use rangelist::IntervalIterator;
+use rustc_hash::FxHashMap;
 use tracing::{debug, warn};
 
 pub use crate::solver::{
@@ -41,7 +44,7 @@ pub use crate::solver::{
 	view::{DefaultView, View, boolean::BoolView, integer::IntView},
 };
 use crate::{
-	Clause, IntVal,
+	Clause, IntSet, IntVal,
 	actions::{
 		BrancherInitActions, ConstructionActions, DecisionActions, IntDecisionActions,
 		IntInspectionActions, PostingActions, ReasoningContext, ReasoningEngine, Trailed,
@@ -51,6 +54,7 @@ use crate::{
 	helpers::bytes::Bytes,
 	solver::{
 		branchers::BoxedBrancher,
+		decision::integer::{DirectStorage, IntDecision, LazyOrderStorage, OrderStorage},
 		engine::{Engine, PropRef},
 		initialization_context::InitializationContext,
 		queue::PropagatorInfo,
@@ -101,6 +105,17 @@ pub enum IntLitMeaning {
 	GreaterEq(IntVal),
 	/// Literal representing the condition `x < i`.
 	Less(IntVal),
+}
+
+/// Strategy used to create SAT literals for complex decision variables.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum LiteralStrategy {
+	/// All literals are created before solving starts.
+	Eager,
+	/// Literals are created the first time they are requested.
+	#[default]
+	Lazy,
 }
 
 /// An assumption checker that can be used when no assumptions are used.
@@ -458,13 +473,10 @@ where
 	///
 	/// Collect all satisfying assignments:
 	/// ```
-	/// # use huub::{model::Model, solver::{Solver, Status}};
-	/// # let mut model = Model::default();
-	/// # let x = model.new_int_decision(1..=3);
-	/// # let y = model.new_int_decision(1..=3);
-	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
-	/// # let x = map.get(&mut solver, x);
-	/// # let y = map.get(&mut solver, y);
+	/// # use huub::solver::{Solver, Status};
+	/// # let mut solver: Solver = Solver::default();
+	/// # let x = solver.new_int_decision(1..=3).view();
+	/// # let y = solver.new_int_decision(1..=3).view();
 	/// let mut solutions = Vec::new();
 	/// let status = solver
 	/// 	.solve()
@@ -851,12 +863,8 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 	///
 	/// Simple satisfiability solving:
 	/// ```
-	/// # use huub::{
-	/// # 	model::Model,
-	/// # 	solver::{Solver, Status},
-	/// # };
-	/// # let mut model = Model::default();
-	/// # let (mut solver, _): (Solver, _) = model.lower().to_solver()?;
+	/// # use huub::solver::{Solver, Status};
+	/// # let mut solver: Solver = Solver::default();
 	/// let status = solver.solve().satisfy();
 	/// assert_eq!(status, Status::Satisfied);
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -864,15 +872,9 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 	///
 	/// Satisfiability with callback to inspect solution:
 	/// ```
-	/// # use huub::{
-	/// # 	model::Model,
-	/// # 	solver::{Solver, Status, Valuation},
-	/// # };
-	/// # let mut model = Model::default();
-	/// # let x = model.new_int_decision(1..=4);
-	/// # model.linear(x).ne(2).post();
-	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
-	/// # let x = map.get(&mut solver, x);
+	/// # use huub::solver::{Solver, Status, Valuation};
+	/// # let mut solver: Solver = Solver::default();
+	/// # let x = solver.new_int_decision(1..=4).view();
 	/// let mut value = None;
 	/// let status = solver
 	/// 	.solve()
@@ -881,20 +883,15 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 	/// 	})
 	/// 	.satisfy();
 	/// assert_eq!(status, Status::Satisfied);
-	/// assert_ne!(value, Some(2));
+	/// assert!(value.is_some());
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
 	/// ```
 	///
 	/// Optimization with callbacks:
 	/// ```
-	/// # use huub::{
-	/// # 	model::Model,
-	/// # 	solver::{Solver, Status, Valuation},
-	/// # };
-	/// # let mut model = Model::default();
-	/// # let x = model.new_int_decision(1..=4);
-	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
-	/// # let x = map.get(&mut solver, x);
+	/// # use huub::solver::{Solver, Status};
+	/// # let mut solver: Solver = Solver::default();
+	/// # let x = solver.new_int_decision(1..=4).view();
 	/// let (status, optimum) = solver.solve().on_solution(|_| {}).minimize(x);
 	/// assert_eq!(status, Status::Complete);
 	/// assert_eq!(optimum, Some(1));
@@ -903,29 +900,23 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 	///
 	/// With assumptions for incremental solving:
 	/// ```
-	/// # use huub::{
-	/// # 	model::Model,
-	/// # 	solver::{Solver, Status},
-	/// # };
-	/// # let mut model = Model::default();
-	/// # let b = model.new_bool_decision();
-	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
-	/// # let b = map.get(&mut solver, b);
-	/// let status = solver.solve().assuming([b]).on_failure(|_| {}).satisfy();
+	/// # use huub::solver::{Solver, Status};
+	/// # let mut solver: Solver = Solver::default();
+	/// # let b = solver.new_bool_decision();
+	/// let status = solver
+	/// 	.solve()
+	/// 	.assuming([b.into()])
+	/// 	.on_failure(|_| {})
+	/// 	.satisfy();
 	/// assert_eq!(status, Status::Satisfied);
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
 	/// ```
 	///
 	/// Enumerating all solutions:
 	/// ```
-	/// # use huub::{
-	/// # 	model::Model,
-	/// # 	solver::{Solver, Status, Valuation},
-	/// # };
-	/// # let mut model = Model::default();
-	/// # let x = model.new_int_decision(1..=3);
-	/// # let (mut solver, map): (Solver, _) = model.lower().to_solver()?;
-	/// # let x = map.get(&mut solver, x);
+	/// # use huub::solver::{Solver, Status};
+	/// # let mut solver: Solver = Solver::default();
+	/// # let x = solver.new_int_decision(1..=3).view();
 	/// let mut count = 0;
 	/// let status = solver
 	/// 	.solve()
@@ -989,6 +980,7 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 	}
 }
 
+#[bon]
 impl<Sat: ExternalPropagation> Solver<Sat> {
 	/// Method used to add a no-good clause from a solution. This clause can be
 	/// used to ensure that the same solution is not found again.
@@ -1107,6 +1099,144 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 		let lit = self.sat.new_lit();
 		self.engine.borrow_mut().state.statistics.eager_literals += 1;
 		Decision(lit)
+	}
+
+	/// Create a new integer decision variable with the given `domain`.
+	///
+	/// Use the optional `order_literals` and `direct_literals` setters to
+	/// choose whether order and direct literals are created eagerly or lazily.
+	/// Direct literal can only be eager when the order literals are also
+	/// eager. Both default to lazy.
+	///
+	/// Finalize the builder with `.view()` to always get a [`View<IntVal>`], or
+	/// with `.decision()` to get a [`Decision<IntVal>`] when the domain has at
+	/// least three values.
+	#[builder(finish_fn(name = view, doc {
+		/// Finalize the builder and return a [`View`] of the new integer decision.
+		///
+		/// This always succeeds, even for domains with one or two values, which
+		/// are represented more compactly than a full integer decision.
+	}))]
+	#[allow(
+		clippy::missing_docs_in_private_items,
+		reason = "unable to document domain member on generated builder"
+	)]
+	pub fn new_int_decision(
+		&mut self,
+		#[builder(start_fn, into)] domain: IntSet,
+		#[builder(default)] mut order_literals: LiteralStrategy,
+		#[builder(default)] direct_literals: LiteralStrategy,
+	) -> View<IntVal> {
+		let orig_domain_len = domain.card();
+		assert_ne!(
+			orig_domain_len,
+			Some(0),
+			"Unable to create integer variable empty domain"
+		);
+		if orig_domain_len == Some(1) {
+			return (*domain.lower_bound().unwrap()).into();
+		}
+		let lb = *domain.lower_bound().unwrap();
+		let ub = *domain.upper_bound().unwrap();
+		if orig_domain_len == Some(2) {
+			let lit = self.new_bool_decision();
+			return LinearBoolView::new(NonZero::new(ub - lb).unwrap(), lb, lit).into();
+		}
+		if (direct_literals, order_literals) == (LiteralStrategy::Eager, LiteralStrategy::Lazy) {
+			warn!(
+				target: "solver",
+				"coercing order_literals to eager because direct_literals is eager"
+			);
+			order_literals = LiteralStrategy::Eager;
+		};
+
+		let mut engine = self.engine.borrow_mut();
+		let upper_bound = engine.state.trail.track(ub);
+		let order_encoding = match order_literals {
+			LiteralStrategy::Eager => {
+				let card = orig_domain_len
+					.expect("unable to create literals eagerly for domains that exceed usize::MAX");
+				engine.state.statistics.eager_literals += (card - 1) as u64;
+				OrderStorage::Eager {
+					lower_bound: engine.state.trail.track(lb),
+					storage: self.sat.new_var_range(card - 1),
+				}
+			}
+			LiteralStrategy::Lazy => {
+				OrderStorage::Lazy(LazyOrderStorage::new_in(&mut engine.state.trail))
+			}
+		};
+		let direct_encoding = match direct_literals {
+			LiteralStrategy::Eager => {
+				let card = orig_domain_len
+					.expect("unable to create literals eagerly for domains that exceed usize::MAX");
+				engine.state.statistics.eager_literals += (card - 2) as u64;
+				DirectStorage::Eager(self.sat.new_var_range(card - 2))
+			}
+			LiteralStrategy::Lazy => DirectStorage::Lazy(FxHashMap::default()),
+		};
+		// Drop engine to allow SAT interaction
+		drop(engine);
+
+		// Enforce consistency constraints for eager literals
+		if let OrderStorage::Eager { storage, .. } = &order_encoding {
+			let mut direct_enc_iter = if let DirectStorage::Eager(vars) = &direct_encoding {
+				Some(*vars)
+			} else {
+				None
+			}
+			.into_iter()
+			.flatten();
+			for (ord_i, ord_j) in (*storage).tuple_windows() {
+				let ord_i: RawLit = ord_i.into(); // x<i
+				let ord_j: RawLit = ord_j.into(); // x<j, where j = i + n and n≥1
+				self.sat.add_clause([!ord_i, ord_j]).unwrap(); // x<i -> x<(i+n)
+				if matches!(direct_encoding, DirectStorage::Eager(_)) {
+					let eq_i: RawLit = direct_enc_iter.next().unwrap().into();
+					self.sat.add_clause([!eq_i, !ord_i]).unwrap(); // x=i -> x≥i
+					self.sat.add_clause([!eq_i, ord_j]).unwrap(); // x=i -> x<(i+n)
+					self.sat.add_clause([eq_i, ord_i, !ord_j]).unwrap(); // x≠i -> (x<i \/
+					// x≥(i+n))
+				}
+			}
+			debug_assert!(direct_enc_iter.next().is_none());
+		}
+
+		// Create the resulting integer variable
+		let mut engine = self.engine.borrow_mut();
+		engine.state.int_vars.push(IntDecision {
+			direct_encoding,
+			domain,
+			order_encoding,
+			upper_bound,
+		});
+		let iv = Decision((engine.state.int_vars.len() - 1) as u32);
+		// Create propagator activation list
+		engine.state.int_activation.push(Default::default());
+		debug_assert_eq!(
+			engine.state.int_vars.len(),
+			engine.state.int_activation.len()
+		);
+
+		// Setup the boolean to integer mapping
+		if let OrderStorage::Eager { storage, .. } = engine.state.int_vars[iv.idx()].order_encoding
+		{
+			let mut vars = storage;
+			if let DirectStorage::Eager(vars2) = &engine.state.int_vars[iv.idx()].direct_encoding {
+				debug_assert_eq!(Into::<i32>::into(vars.end()) + 1, vars2.start().into());
+				vars = VarRange::new(vars.start(), vars2.end());
+			}
+			engine.state.bool_to_int.insert_eager(vars, iv);
+			engine
+				.state
+				.trail
+				.grow_to_boolvar(vars.clone().next_back().unwrap());
+			for l in vars {
+				self.sat.add_observed_var(l);
+			}
+		}
+
+		iv.into()
 	}
 
 	/// Set the overarching search strategy to use during solving.
@@ -1295,5 +1425,31 @@ impl AddAssign for SolverStatistics {
 		self.user_search_directives += other.user_search_directives;
 		self.eager_literals = self.eager_literals.max(other.eager_literals);
 		self.lazy_literals = self.lazy_literals.max(other.lazy_literals);
+	}
+}
+
+impl<'a, Sat, State> SolverNewIntDecisionBuilder<'a, Sat, State>
+where
+	Sat: ExternalPropagation,
+	State: solver_new_int_decision_builder::State,
+{
+	/// Finalize the builder and return the [`Decision<IntVal>`] for the new
+	/// integer variable.
+	///
+	/// # Panics
+	///
+	/// Panics if the domain has fewer than three values, because those domains
+	/// are represented as constants or linear Boolean views instead of a full
+	/// integer decision.
+	pub fn decision(self) -> Decision<IntVal>
+	where
+		State: solver_new_int_decision_builder::IsComplete,
+	{
+		let IntView::Linear(lin_view) = self.view().0 else {
+			panic!("domain did not contain at least three values");
+		};
+		debug_assert_eq!(lin_view.offset, 0);
+		debug_assert_eq!(lin_view.scale.get(), 1);
+		lin_view.var
 	}
 }

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -125,6 +125,7 @@ pub(crate) struct NoAssumptions;
 
 /// The overarching search strategy used by the solver.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum SearchStrategy {
 	/// Use the user provided [`Brancher`](crate::solver::branchers::Brancher)s
 	/// until they are all exhausted, and only then defer to the SAT solver to
@@ -320,6 +321,7 @@ pub enum Status {
 
 /// Trigger for switching between search strategies.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum SwitchTrigger {
 	/// Switch after the given number of conflicts have been encountered.
 	Conflicts(u64),

--- a/crates/huub/src/solver/branchers.rs
+++ b/crates/huub/src/solver/branchers.rs
@@ -75,7 +75,7 @@ pub struct IntBrancher {
 /// Strategy for limiting the domain of a selected decision variable for a
 /// [`BoolBrancher`] or [`IntBrancher`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum ValueSelection {
+#[non_exhaustive]
 	/// Set the decision variable to its current maximum value.
 	IndomainMax,
 	/// Set the decision variable to its current minimum value.
@@ -91,7 +91,7 @@ pub enum ValueSelection {
 /// Strategy of selecting the next decision variable for a [`BoolBrancher`] or
 /// [`IntBrancher`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum VariableSelection {
+#[non_exhaustive]
 	/// Select the unfixed decision variable with the largest remaining domain
 	/// size, using the order of the variables in case of a tie.
 	AntiFirstFail,

--- a/crates/huub/src/solver/branchers.rs
+++ b/crates/huub/src/solver/branchers.rs
@@ -17,18 +17,18 @@ use crate::{
 	},
 };
 
-/// General brancher for Boolean variables that makes search decisions by
-/// following a given [`VariableSelection`] and [`ValueSelection`] strategy.
+/// General brancher for Boolean decision variables that makes search decisions
+/// by following a given [`DecisionSelection`] and [`DomainSelection`] strategy.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct BoolBrancher {
-	/// Boolean variables to be branched on.
+	/// Boolean decision variables to be branched on.
 	vars: Vec<Decision<bool>>,
-	/// [`VariableSelection`] strategy used to select the next decision variable
+	/// [`DecisionSelection`] strategy used to select the next decision variable
 	/// to branch on.
-	var_sel: VariableSelection,
-	/// [`ValueSelection`] strategy used to select the way in which to branch on
-	/// the selected decision variable.
-	val_sel: ValueSelection,
+	var_sel: DecisionSelection,
+	/// [`DomainSelection`] strategy used to select the way in which to branch
+	/// on the selected decision variable.
+	val_sel: DomainSelection,
 	/// The start of the unfixed variables in `vars`.
 	next: Trailed<usize>,
 }
@@ -57,17 +57,17 @@ pub enum Directive {
 }
 
 /// General brancher for integer variables that makes search decisions by
-/// following a given [`VariableSelection`] and [`ValueSelection`] strategy.
+/// following a given [`DecisionSelection`] and [`DomainSelection`] strategy.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IntBrancher {
 	/// Integer variables to be branched on.
 	vars: Vec<View<IntVal>>,
-	/// [`VariableSelection`] strategy used to select the next decision variable
+	/// [`DecisionSelection`] strategy used to select the next decision variable
 	/// to branch on.
-	var_sel: VariableSelection,
-	/// [`ValueSelection`] strategy used to select the way in which to branch on
-	/// the selected decision variable.
-	val_sel: ValueSelection,
+	var_sel: DecisionSelection,
+	/// [`DomainSelection`] strategy used to select the way in which to branch
+	/// on the selected decision variable.
+	val_sel: DomainSelection,
 	/// The start of the unfixed variables in `vars`.
 	next: Trailed<usize>,
 }
@@ -76,6 +76,7 @@ pub struct IntBrancher {
 /// [`BoolBrancher`] or [`IntBrancher`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
+pub enum DomainSelection {
 	/// Set the decision variable to its current maximum value.
 	IndomainMax,
 	/// Set the decision variable to its current minimum value.
@@ -92,6 +93,7 @@ pub struct IntBrancher {
 /// [`IntBrancher`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
+pub enum DecisionSelection {
 	/// Select the unfixed decision variable with the largest remaining domain
 	/// size, using the order of the variables in case of a tie.
 	AntiFirstFail,
@@ -125,8 +127,8 @@ impl BoolBrancher {
 	pub fn new_in(
 		solver: &mut impl BrancherInitActions,
 		vars: Vec<View<bool>>,
-		var_sel: VariableSelection,
-		val_sel: ValueSelection,
+		var_sel: DecisionSelection,
+		val_sel: DomainSelection,
 	) {
 		let vars: Vec<_> = vars
 			.into_iter()
@@ -165,11 +167,11 @@ where
 		// Boolean variable selection currently selects the first unfixed variable.
 		debug_assert!(matches!(
 			self.var_sel,
-			VariableSelection::InputOrder
-				| VariableSelection::Smallest
-				| VariableSelection::Largest
-				| VariableSelection::FirstFail
-				| VariableSelection::AntiFirstFail
+			DecisionSelection::InputOrder
+				| DecisionSelection::Smallest
+				| DecisionSelection::Largest
+				| DecisionSelection::FirstFail
+				| DecisionSelection::AntiFirstFail
 		));
 
 		let mut loc = None;
@@ -191,8 +193,8 @@ where
 		// select the next value to branch on based on the value selection strategy
 		Directive::Select(
 			match self.val_sel {
-				ValueSelection::IndomainMin | ValueSelection::OutdomainMax => !var,
-				ValueSelection::IndomainMax | ValueSelection::OutdomainMin => var,
+				DomainSelection::IndomainMin | DomainSelection::OutdomainMax => !var,
+				DomainSelection::IndomainMax | DomainSelection::OutdomainMin => var,
 			}
 			.into(),
 		)
@@ -214,7 +216,7 @@ impl IntBrancher {
 	/// # 	model::Model,
 	/// # 	solver::{
 	/// # 		Solver, Status, Valuation,
-	/// # 		branchers::{IntBrancher, ValueSelection, VariableSelection},
+	/// # 		branchers::{IntBrancher, DomainSelection, DecisionSelection},
 	/// # 	},
 	/// # };
 	/// # let mut model = Model::default();
@@ -227,8 +229,8 @@ impl IntBrancher {
 	/// IntBrancher::new_in(
 	/// 	&mut solver,
 	/// 	vec![x, y],
-	/// 	VariableSelection::FirstFail,
-	/// 	ValueSelection::IndomainMin,
+	/// 	DecisionSelection::FirstFail,
+	/// 	DomainSelection::IndomainMin,
 	/// );
 	///
 	/// # let status = solver
@@ -243,8 +245,8 @@ impl IntBrancher {
 	pub fn new_in(
 		solver: &mut impl BrancherInitActions,
 		vars: Vec<View<IntVal>>,
-		var_sel: VariableSelection,
-		val_sel: ValueSelection,
+		var_sel: DecisionSelection,
+		val_sel: DomainSelection,
 	) {
 		let vars: Vec<_> = vars
 			.into_iter()
@@ -279,23 +281,23 @@ where
 		}
 
 		let score = |var: View<IntVal>| match self.var_sel {
-			VariableSelection::AntiFirstFail | VariableSelection::FirstFail => {
+			DecisionSelection::AntiFirstFail | DecisionSelection::FirstFail => {
 				let (lb, ub) = var.bounds(actions);
 				ub - lb
 			}
-			VariableSelection::InputOrder => 0,
-			VariableSelection::Largest => var.max(actions),
-			VariableSelection::Smallest => var.min(actions),
+			DecisionSelection::InputOrder => 0,
+			DecisionSelection::Largest => var.max(actions),
+			DecisionSelection::Smallest => var.min(actions),
 		};
 
 		let is_better = |incumbent_score, new_score| match self.var_sel {
-			VariableSelection::AntiFirstFail | VariableSelection::Largest => {
+			DecisionSelection::AntiFirstFail | DecisionSelection::Largest => {
 				incumbent_score < new_score
 			}
-			VariableSelection::FirstFail | VariableSelection::Smallest => {
+			DecisionSelection::FirstFail | DecisionSelection::Smallest => {
 				incumbent_score > new_score
 			}
-			VariableSelection::InputOrder => unreachable!(),
+			DecisionSelection::InputOrder => unreachable!(),
 		};
 
 		let mut first_unfixed = begin;
@@ -315,7 +317,7 @@ where
 				}
 			} else {
 				selection = Some((self.vars[i], score(self.vars[i])));
-				if self.var_sel == VariableSelection::InputOrder {
+				if self.var_sel == DecisionSelection::InputOrder {
 					break;
 				}
 			}
@@ -333,10 +335,12 @@ where
 		let view = next_var.lit(
 			actions,
 			match self.val_sel {
-				ValueSelection::IndomainMin => IntLitMeaning::Less(next_var.min(actions) + 1),
-				ValueSelection::IndomainMax => IntLitMeaning::GreaterEq(next_var.max(actions)),
-				ValueSelection::OutdomainMin => IntLitMeaning::GreaterEq(next_var.min(actions) + 1),
-				ValueSelection::OutdomainMax => IntLitMeaning::Less(next_var.max(actions)),
+				DomainSelection::IndomainMin => IntLitMeaning::Less(next_var.min(actions) + 1),
+				DomainSelection::IndomainMax => IntLitMeaning::GreaterEq(next_var.max(actions)),
+				DomainSelection::OutdomainMin => {
+					IntLitMeaning::GreaterEq(next_var.min(actions) + 1)
+				}
+				DomainSelection::OutdomainMax => IntLitMeaning::Less(next_var.max(actions)),
 			},
 		);
 		Directive::Select(view)

--- a/crates/huub/src/solver/decision/integer.rs
+++ b/crates/huub/src/solver/decision/integer.rs
@@ -7,11 +7,7 @@ use std::{
 	ops::{Index, IndexMut, Neg, RangeBounds, RangeInclusive},
 };
 
-use itertools::Itertools;
-use pindakaas::{
-	ClauseDatabaseTools, Lit as RawLit, Var as RawVar, VarRange,
-	solver::propagation::ExternalPropagation,
-};
+use pindakaas::{Lit as RawLit, Var as RawVar, VarRange, solver::propagation::ExternalPropagation};
 use rangelist::{IntervalIterator, RangeList};
 use rustc_hash::FxHashMap;
 
@@ -26,9 +22,10 @@ use crate::{
 		decision::{Decision, DecisionReference, private},
 		engine::State,
 		solving_context::SolvingContext,
+		trail::Trail,
 		view::{View, boolean::BoolView},
 	},
-	views::{LinearBoolView, LinearView},
+	views::LinearView,
 };
 
 /// An entry in the [`DirectStorage`] that can be used to access the
@@ -71,15 +68,6 @@ struct DomainLocation<'a, const OFFSET: usize> {
 	range_iter: RangeIter<'a>,
 }
 
-/// A type to represent when certain literals are created
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) enum EncodingType {
-	/// The literal is created before solving starts
-	Eager,
-	/// The literal is created the first time it is mentioned
-	Lazy,
-}
-
 /// The structure used to store information about an integer variable within
 /// the solver.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -100,7 +88,7 @@ pub(crate) struct IntDecision {
 	/// variable.
 	///
 	/// Note that the lower bound is tracked within [`Self::order_encoding`].
-	upper_bound: Trailed<IntVal>,
+	pub(crate) upper_bound: Trailed<IntVal>,
 }
 
 /// The definition given to a lazily created literal.
@@ -895,128 +883,6 @@ impl IntDecision {
 		}
 	}
 
-	/// Create a new integer variable within the given solver, which the given
-	/// domain. The `order_encoding` and `direct_encoding` parameters determine
-	/// whether literals to reason about the integer variables are created
-	/// eagerly or lazily.
-	pub(crate) fn new_in<Sat: ExternalPropagation>(
-		slv: &mut Solver<Sat>,
-		domain: IntSet,
-		order_encoding: EncodingType,
-		direct_encoding: EncodingType,
-	) -> View<IntVal> {
-		let orig_domain_len = domain.card();
-		assert_ne!(
-			orig_domain_len,
-			Some(0),
-			"Unable to create integer variable empty domain"
-		);
-		if orig_domain_len == Some(1) {
-			return (*domain.lower_bound().unwrap()).into();
-		}
-		let lb = *domain.lower_bound().unwrap();
-		let ub = *domain.upper_bound().unwrap();
-		if orig_domain_len == Some(2) {
-			let lit = slv.new_bool_decision();
-			return LinearBoolView::new(NonZero::new(ub - lb).unwrap(), lb, lit).into();
-		}
-		debug_assert!(
-			direct_encoding != EncodingType::Eager || order_encoding == EncodingType::Eager
-		);
-
-		let mut engine = slv.engine.borrow_mut();
-		let upper_bound = engine.state.trail.track(ub);
-		let order_encoding = match order_encoding {
-			EncodingType::Eager => {
-				let card = orig_domain_len
-					.expect("unable to create literals eagerly for domains that exceed usize::MAX");
-				engine.state.statistics.eager_literals += (card - 1) as u64;
-				OrderStorage::Eager {
-					lower_bound: engine.state.trail.track(lb),
-					storage: slv.sat.new_var_range(card - 1),
-				}
-			}
-			EncodingType::Lazy => OrderStorage::Lazy(LazyOrderStorage {
-				min_index: 0,
-				max_index: 0,
-				lb_index: engine.state.trail.track(-1),
-				ub_index: engine.state.trail.track(-1),
-				storage: Vec::default(),
-			}),
-		};
-		let direct_encoding = match direct_encoding {
-			EncodingType::Eager => {
-				let card = orig_domain_len
-					.expect("unable to create literals eagerly for domains that exceed usize::MAX");
-				engine.state.statistics.eager_literals += (card - 2) as u64;
-				DirectStorage::Eager(slv.sat.new_var_range(card - 2))
-			}
-			EncodingType::Lazy => DirectStorage::Lazy(FxHashMap::default()),
-		};
-		// Drop engine to allow SAT interaction
-		drop(engine);
-
-		// Enforce consistency constraints for eager literals
-		if let OrderStorage::Eager { storage, .. } = &order_encoding {
-			let mut direct_enc_iter = if let DirectStorage::Eager(vars) = &direct_encoding {
-				Some(*vars)
-			} else {
-				None
-			}
-			.into_iter()
-			.flatten();
-			for (ord_i, ord_j) in (*storage).tuple_windows() {
-				let ord_i: RawLit = ord_i.into(); // x<i
-				let ord_j: RawLit = ord_j.into(); // x<j, where j = i + n and n≥1
-				slv.sat.add_clause([!ord_i, ord_j]).unwrap(); // x<i -> x<(i+n)
-				if matches!(direct_encoding, DirectStorage::Eager(_)) {
-					let eq_i: RawLit = direct_enc_iter.next().unwrap().into();
-					slv.sat.add_clause([!eq_i, !ord_i]).unwrap(); // x=i -> x≥i
-					slv.sat.add_clause([!eq_i, ord_j]).unwrap(); // x=i -> x<(i+n)
-					slv.sat.add_clause([eq_i, ord_i, !ord_j]).unwrap(); // x≠i -> (x<i \/
-					// x≥(i+n))
-				}
-			}
-			debug_assert!(direct_enc_iter.next().is_none());
-		}
-
-		// Create the resulting integer variable
-		let mut engine = slv.engine.borrow_mut();
-		engine.state.int_vars.push(Self {
-			direct_encoding,
-			domain,
-			order_encoding,
-			upper_bound,
-		});
-		let iv = Decision((engine.state.int_vars.len() - 1) as u32);
-		// Create propagator activation list
-		engine.state.int_activation.push(Default::default());
-		debug_assert_eq!(
-			engine.state.int_vars.len(),
-			engine.state.int_activation.len()
-		);
-
-		// Setup the boolean to integer mapping
-		if let OrderStorage::Eager { storage, .. } = engine.state.int_vars[iv.idx()].order_encoding
-		{
-			let mut vars = storage;
-			if let DirectStorage::Eager(vars2) = &engine.state.int_vars[iv.idx()].direct_encoding {
-				debug_assert_eq!(Into::<i32>::into(vars.end()) + 1, vars2.start().into());
-				vars = VarRange::new(vars.start(), vars2.end());
-			}
-			engine.state.bool_to_int.insert_eager(vars, iv);
-			engine
-				.state
-				.trail
-				.grow_to_boolvar(vars.clone().next_back().unwrap());
-			for l in vars {
-				slv.sat.add_observed_var(l);
-			}
-		}
-
-		iv.into()
-	}
-
 	/// Notify that a new lower bound has been propagated for the variable.
 	///
 	/// # Warning
@@ -1183,6 +1049,17 @@ impl DecisionReference for IntVal {
 impl private::Sealed for IntVal {}
 
 impl LazyOrderStorage {
+	/// Create an empty lazy storage for order literals.
+	pub(crate) fn new_in(trail: &mut Trail) -> Self {
+		Self {
+			min_index: 0,
+			max_index: 0,
+			lb_index: trail.track(-1),
+			ub_index: trail.track(-1),
+			storage: Vec::default(),
+		}
+	}
+
 	/// Find the the index of the node that contains the value or the node
 	/// "before" the value.
 	fn find_index(&self, start: u32, direction: SearchDirection, val: IntVal) -> u32 {
@@ -1581,11 +1458,8 @@ mod tests {
 		IntSet, IntVal,
 		actions::{IntDecisionActions, IntInspectionActions},
 		solver::{
-			IntLitMeaning, Solver,
-			decision::{
-				Decision,
-				integer::{EncodingType, IntDecision},
-			},
+			IntLitMeaning, LiteralStrategy, Solver,
+			decision::{Decision, integer::IntDecision},
 			view::{View, boolean::BoolView, integer::IntView},
 		},
 		views::LinearView,
@@ -1631,12 +1505,11 @@ mod tests {
 		use IntLitMeaning::*;
 
 		let mut slv: Solver = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(1..=4),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let a = slv
+			.new_int_decision(1..=4)
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 		let IntView::Linear(LinearView { var: a, .. }) = a.0 else {
 			unreachable!()
 		};
@@ -1690,12 +1563,11 @@ mod tests {
 		use IntLitMeaning::*;
 
 		let mut slv: Solver = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([1..=3, 8..=10]),
-			EncodingType::Eager,
-			EncodingType::Eager,
-		);
+		let a = slv
+			.new_int_decision(IntSet::from_iter([1..=3, 8..=10]))
+			.order_literals(LiteralStrategy::Eager)
+			.direct_literals(LiteralStrategy::Eager)
+			.view();
 		let IntView::Linear(LinearView { var: a, .. }) = a.0 else {
 			unreachable!()
 		};
@@ -1769,12 +1641,9 @@ mod tests {
 		use IntLitMeaning::*;
 
 		let mut slv: Solver = Solver::default();
-		let a = IntDecision::new_in(
-			&mut slv,
-			IntSet::from_iter([1..=3, 8..=10]),
-			EncodingType::Lazy,
-			EncodingType::Lazy,
-		);
+		let a = slv
+			.new_int_decision(IntSet::from_iter([1..=3, 8..=10]))
+			.view();
 		let IntView::Linear(LinearView { var: a, .. }) = a.0 else {
 			unreachable!()
 		};

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -1013,16 +1013,14 @@ mod tests {
 	use pindakaas::solver::propagation::Propagator as ExternalPropagator;
 
 	use crate::{
-		IntSet, IntVal,
+		IntVal,
 		actions::{
 			BoolPropagationActions, InitActions, IntDecisionActions, IntEvent, IntInitActions,
 			IntPropCond, IntPropagationActions, ReasoningEngine,
 		},
 		constraints::Propagator,
 		solver::{
-			BoolView, Decision, IntLitMeaning, Solver, View,
-			decision::integer::{EncodingType, IntDecision},
-			engine::Engine,
+			BoolView, Decision, IntLitMeaning, LiteralStrategy, Solver, View, engine::Engine,
 		},
 	};
 
@@ -1088,12 +1086,10 @@ mod tests {
 		let mut slv: Solver = Solver::default();
 		let notifications = Rc::new(RefCell::new(0));
 		let imply = slv.new_bool_decision();
-		let var = IntDecision::new_in(
-			&mut slv,
-			IntSet::from(0..=2),
-			EncodingType::Eager,
-			EncodingType::Lazy,
-		);
+		let var = slv
+			.new_int_decision(0..=2)
+			.order_literals(LiteralStrategy::Eager)
+			.view();
 		slv.add_propagator(
 			Box::new(ProducerAndListener {
 				req_first: imply,

--- a/crates/huub/src/tests.rs
+++ b/crates/huub/src/tests.rs
@@ -15,7 +15,7 @@ use crate::{
 	model::{Model, deserialize::AnyView as ModelView},
 	solver::{
 		AnyView as SolverView, LiteralStrategy, Solver, Status, Valuation, Value,
-		branchers::{IntBrancher, ValueSelection, VariableSelection},
+		branchers::{DecisionSelection, DomainSelection, IntBrancher},
 	},
 };
 
@@ -151,8 +151,8 @@ fn test_duplicate_propagation() {
 	IntBrancher::new_in(
 		&mut slv,
 		vec![a, b],
-		VariableSelection::InputOrder,
-		ValueSelection::IndomainMax,
+		DecisionSelection::InputOrder,
+		DomainSelection::IndomainMax,
 	);
 	slv.expect_solutions(
 		&[a, b],

--- a/crates/huub/src/tests.rs
+++ b/crates/huub/src/tests.rs
@@ -14,9 +14,8 @@ use crate::{
 	constraints::int_linear::{IntLinearLessEqBounds, IntLinearNotEqValue},
 	model::{Model, deserialize::AnyView as ModelView},
 	solver::{
-		AnyView as SolverView, Solver, Status, Valuation, Value,
+		AnyView as SolverView, LiteralStrategy, Solver, Status, Valuation, Value,
 		branchers::{IntBrancher, ValueSelection, VariableSelection},
-		decision::integer::{EncodingType, IntDecision},
 	},
 };
 
@@ -53,9 +52,9 @@ fn lin_multi_alias() {
 	use crate::actions::{IntInspectionActions, IntSimplificationActions};
 
 	let mut prb = Model::default();
-	let x = prb.new_int_decision(IntSet::from(1..=10));
-	let y = prb.new_int_decision(IntSet::from(1..=10));
-	let z = prb.new_int_decision(IntSet::from(1..=10));
+	let x = prb.new_int_decision(1..=10);
+	let y = prb.new_int_decision(1..=10);
+	let z = prb.new_int_decision(1..=10);
 	let x_trans = x * -1 - 1;
 	let y_trans = y + 1;
 	let z_trans = z + 1;
@@ -131,18 +130,14 @@ fn test_bounding_sub() {
 #[test]
 fn test_duplicate_propagation() {
 	let mut slv = Solver::default();
-	let a = IntDecision::new_in(
-		&mut slv,
-		IntSet::from(0..=1),
-		EncodingType::Eager,
-		EncodingType::Lazy,
-	);
-	let b = IntDecision::new_in(
-		&mut slv,
-		IntSet::from(0..=1),
-		EncodingType::Eager,
-		EncodingType::Lazy,
-	);
+	let a = slv
+		.new_int_decision(0..=1)
+		.order_literals(LiteralStrategy::Eager)
+		.view();
+	let b = slv
+		.new_int_decision(0..=1)
+		.order_literals(LiteralStrategy::Eager)
+		.view();
 	IntLinearLessEqBounds::post(
 		&mut slv,
 		[
@@ -214,7 +209,7 @@ fn test_unify_int_impossible() {
 fn test_unify_int_lin_view_domains() {
 	let mut prb = Model::default();
 	let a = prb.new_int_decision(IntSet::from_iter([1..=1, 3..=3, 5..=5]));
-	let b = prb.new_int_decision(IntSet::from(1..=3));
+	let b = prb.new_int_decision(1..=3);
 
 	prb.linear(a * 6).eq(b * 2).post().unwrap();
 

--- a/docs/src/modelling/search-branching.md
+++ b/docs/src/modelling/search-branching.md
@@ -55,7 +55,7 @@ A `Brancher` is an object that directs the search.
 Huub provides two pre-built branchers for common use cases: `IntBrancher` for integer decisions and `BoolBrancher` for Boolean decisions.
 You can also implement custom branchers for specialized problems.
 
-### Decision and value selection strategies
+### Decision and domain selection strategies
 
 The built-in branchers use two independent strategies to make decisions:
 
@@ -70,7 +70,7 @@ The built-in branchers use two independent strategies to make decisions:
   Useful when you want to explore small values first.
 - `Largest`: Choose the decision with the largest upper bound. Useful when you want to explore large values first.
 
-**Value selection** — how to limit the chosen decision:
+**Domain selection** — how to limit the chosen decision:
 
 - `IndomainMin`: Assign the decision to its **lower bound** (smallest possible value). This explores small values first.
 - `IndomainMax`: Assign the decision to its **upper bound** (largest possible value). This explores large values first.
@@ -79,12 +79,12 @@ The built-in branchers use two independent strategies to make decisions:
 
 ### Using branchers in the solver
 
-To use a brancher, create it with a list of decisions, a decision selection strategy, and a value selection strategy, then add it to the solver:
+To use a brancher, create it with a list of decisions, a decision selection strategy, and a domain selection strategy, then add it to the solver:
 
 ```rust
 # extern crate huub;
 # use huub::solver::{
-# 	branchers::{IntBrancher, ValueSelection, VariableSelection},
+# 	branchers::{DecisionSelection, DomainSelection, IntBrancher},
 # 	Solver, Valuation,
 # };
 # let mut solver: Solver = Solver::default();
@@ -95,8 +95,8 @@ To use a brancher, create it with a list of decisions, a decision selection stra
 IntBrancher::new_in(
 	&mut solver,
 	vec![x, y],
-	VariableSelection::FirstFail,
-	ValueSelection::IndomainMin,
+	DecisionSelection::FirstFail,
+	DomainSelection::IndomainMin,
 );
 
 solver

--- a/docs/src/modelling/search-branching.md
+++ b/docs/src/modelling/search-branching.md
@@ -83,19 +83,13 @@ To use a brancher, create it with a list of decisions, a decision selection stra
 
 ```rust
 # extern crate huub;
-# use huub::{
-# 	model::Model,
-# 	solver::{
-# 		branchers::{IntBrancher, ValueSelection, VariableSelection},
-# 		Solver, Valuation,
-# 	},
+# use huub::solver::{
+# 	branchers::{IntBrancher, ValueSelection, VariableSelection},
+# 	Solver, Valuation,
 # };
-# let mut model = Model::default();
-# let x = model.new_int_decision(0..=100);
-# let y = model.new_int_decision(0..=100);
-# let (mut solver, map): (Solver, _) = model.lower().to_solver().unwrap();
-# let x = map.get(&mut solver, x);
-# let y = map.get(&mut solver, y);
+# let mut solver: Solver = Solver::default();
+# let x = solver.new_int_decision(0..=100).view();
+# let y = solver.new_int_decision(0..=100).view();
 // Use an IntBrancher to branch on decisions [x, y] using FirstFail and
 // IndomainMin
 IntBrancher::new_in(
@@ -127,15 +121,11 @@ This makes warm-starting robust: if your partial solution turns out to be incomp
 # extern crate huub;
 # use huub::{
 # 	actions::IntDecisionActions,
-# 	model::Model,
-# 	solver::{branchers::WarmStartBrancher, IntLitMeaning, Solver},
+# 	solver::{branchers::WarmStartBrancher, IntLitMeaning, Solver, View},
 # };
-# let mut model = Model::default();
-# let b = model.new_bool_decision();
-# let x = model.new_int_decision(1..=10);
-# let (mut solver, map): (Solver, _) = model.lower().to_solver().unwrap();
-# let b = map.get(&mut solver, b);
-# let x = map.get(&mut solver, x);
+# let mut solver: Solver = Solver::default();
+# let b: View<bool> = solver.new_bool_decision().into();
+# let x = solver.new_int_decision(1..=10).view();
 // Warm start by suggesting certain boolean decisions should be true
 let warm_start_decisions = vec![b, x.lit(&mut solver, IntLitMeaning::Eq(5))];
 
@@ -158,13 +148,9 @@ Once you have created a solver, you can search for solutions using the `solve()`
 
 ```rust
 # extern crate huub;
-# use huub::{
-# 	model::Model,
-# 	solver::{Solver, Status},
-# };
-# let mut model = Model::default();
-# let x = model.new_int_decision(1..=9);
-# let (mut solver, _): (Solver, _) = model.lower().to_solver().unwrap();
+# use huub::solver::{Solver, Status};
+# let mut solver: Solver = Solver::default();
+# let _x = solver.new_int_decision(1..=9).view();
 let status = solver
 	.solve()
 	.on_solution(|solution| {
@@ -195,12 +181,8 @@ The `set_terminate_callback` method allows you to provide a closure that returns
 # extern crate huub;
 # use std::time::Instant;
 #
-# use huub::{
-# 	model::Model,
-# 	solver::{Solver, Status, TerminationSignal},
-# };
-# let mut model = Model::default();
-# let (mut solver, map): (Solver, _) = model.lower().to_solver().unwrap();
+# use huub::solver::{Solver, Status, TerminationSignal};
+# let mut solver: Solver = Solver::default();
 let start_time = Instant::now();
 let time_limit = std::time::Duration::from_secs(10);
 
@@ -345,9 +327,8 @@ You can retrieve statistics about the search process to understand solver behavi
 
 ```rust
 # extern crate huub;
-# use huub::{model::Model, solver::Solver};
-# let mut model = Model::default();
-# let (mut solver, _): (Solver, _) = model.lower().to_solver().unwrap();
+# use huub::solver::Solver;
+# let mut solver: Solver = Solver::default();
 # let _ = solver.solve().on_solution(|_| {}).satisfy();
 let stats = solver.solver_statistics();
 


### PR DESCRIPTION
Expose integer decision creation on `Solver` through a public `new_int_decision` builder API.

This change makes it possible to create integer decisions directly in solver-space, without
requiring model lowering for solver-only workflows. The builder accepts the domain at
construction time, supports optional literal strategy configuration, and provides finalizers
for returning either a `View<IntVal>` or a `Decision<IntVal>` (with documented constraints).

It also updates internal and test call sites from `IntDecision::new_in` to the new builder
API, and simplifies docs/examples to use direct solver creation where that is now clearer
and appropriate.
