### PR TITLE
fix: correctly propagate `ARTIFICIAL` flag during backtrack

### DIFF
--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -290,7 +290,8 @@ impl Engine {
 	/// backtracking from an artificial decision level
 	fn notify_backtrack<const ARTIFICIAL: bool>(&mut self, new_level: usize, restart: bool) {
 		// Revert value changes to previous decision level
-		self.state.notify_backtrack::<false>(new_level, restart);
+		self.state
+			.notify_backtrack::<ARTIFICIAL>(new_level, restart);
 
 		// Notify subscribed propagators of backtracking
 		let notify = mem::take(&mut self.state.notify_of_backtrack);


### PR DESCRIPTION
The `Engine::notify_backtrack` method was hardcoding `false` when calling
`self.state.notify_backtrack`, effectively ignoring its own `ARTIFICIAL`
const generic parameter. This change ensures the flag is correctly passed
down so state is restored properly when backtracking from artificial
decision levels.
