### PR TITLE
fix: avoid RefCell double-borrow in flatzinc decision unification

### DIFF
--- a/crates/huub-cli/corpus/github_323.fzn.json
+++ b/crates/huub-cli/corpus/github_323.fzn.json
@@ -1,0 +1,14 @@
+{
+  "variables": {
+    "x": { "type": "bool" },
+    "y": { "type": "bool", "defined": true }
+  },
+  "arrays": {},
+  "constraints": [
+    { "id": "array_var_bool_element", "args": [1, ["x"], "y"], "defines": "y" },
+    { "id": "bool_clause", "args": [["x"], []] }
+  ],
+  "output": ["x", "y"],
+  "solve": { "method": "satisfy" },
+  "version": "1.0"
+}

--- a/crates/huub-cli/corpus/github_323.sol
+++ b/crates/huub-cli/corpus/github_323.sol
@@ -1,0 +1,2 @@
+x = true;
+y = true;

--- a/crates/huub-cli/tests/flatzinc_tests.rs
+++ b/crates/huub-cli/tests/flatzinc_tests.rs
@@ -26,6 +26,7 @@ mod tests {
 	assert_first_solution!(seq_search_2);
 	assert_first_solution!(seq_search_3);
 	assert_first_solution!(seq_search_4);
+	assert_first_solution!(github_323);
 	assert_first_solution!(warm_start_fail);
 	assert_first_solution!(warm_start_in_seq_search);
 	assert_first_solution!(warm_start_success);

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -2208,6 +2208,9 @@ impl<'a> FznModelBuilder<'a> {
 			let b_set = unify_map_find(map, b);
 			match (a_set, b_set) {
 				(Some(a_set), Some(b_set)) => {
+					if Rc::ptr_eq(&a_set, &b_set) {
+						return;
+					}
 					let mut members = (*a_set).borrow_mut();
 					members.extend(b_set.take());
 					for b in members.iter() {


### PR DESCRIPTION
Prevent a panic in `FznModelBuilder::unify_variables` when two literals
already belong to the same unification set. The `(Some(a_set), Some(b_set))`
merge path could try to merge a set with itself, causing a `RefCell
already borrowed` panic via `borrow_mut` + `take`. This change
short-circuits self-merges using `Rc::ptr_eq`.
