### PR TITLE
feat: MiniZinc assumption interface for UNSAT core reporting

### DIFF
--- a/crates/huub-cli/corpus/assume_basic_unsat.fzn.json
+++ b/crates/huub-cli/corpus/assume_basic_unsat.fzn.json
@@ -1,0 +1,14 @@
+{
+  "variables": {
+    "a" : { "type" : "bool" },
+    "neg_a" : { "type" : "bool", "defined" : true }
+  },
+  "arrays": {},
+  "constraints": [
+    { "id" : "bool_not", "args" : ["a", "neg_a"], "defines" : "neg_a" },
+    { "id" : "huub_assume", "args" : [["a", "neg_a"]] }
+  ],
+  "output": ["a"],
+  "solve": { "method" : "satisfy" },
+  "version": "1.0"
+}

--- a/crates/huub-cli/corpus/assume_minimize_boundary.fzn.json
+++ b/crates/huub-cli/corpus/assume_minimize_boundary.fzn.json
@@ -1,0 +1,16 @@
+{
+  "variables": {
+    "a" : { "type" : "bool" },
+    "ai" : { "type" : "int", "domain" : [[0, 1]], "defined" : true },
+    "x" : { "type" : "int", "domain" : [[0, 3]] }
+  },
+  "arrays": {},
+  "constraints": [
+    { "id" : "bool2int", "args" : ["a", "ai"], "defines" : "ai" },
+    { "id" : "int_lin_le", "args" : [[2, -1], ["ai", "x"], 0] },
+    { "id" : "huub_assume", "args" : [["a"]] }
+  ],
+  "output": ["a", "x"],
+  "solve": { "method" : "minimize", "objective" : "x" },
+  "version": "1.0"
+}

--- a/crates/huub-cli/corpus/assume_static_false.fzn.json
+++ b/crates/huub-cli/corpus/assume_static_false.fzn.json
@@ -1,0 +1,12 @@
+{
+  "variables": {
+    "a" : { "type" : "bool" }
+  },
+  "arrays": {},
+  "constraints": [
+    { "id" : "huub_assume", "args" : [["a", false]] }
+  ],
+  "output": ["a"],
+  "solve": { "method" : "satisfy" },
+  "version": "1.0"
+}

--- a/crates/huub-cli/src/lib.rs
+++ b/crates/huub-cli/src/lib.rs
@@ -25,6 +25,7 @@ mod cli;
 mod trace;
 
 use std::{
+	cell::RefCell,
 	fmt::{self, Debug, Display},
 	io,
 	num::NonZeroI32,
@@ -35,7 +36,7 @@ use std::{
 	time::Instant,
 };
 
-use flatzinc_serde::{FlatZinc, Literal, NamedRef, Variable, helpers::ArcKey};
+use flatzinc_serde::{FlatZinc, Literal, Method, NamedRef, Variable, helpers::ArcKey};
 use huub::{
 	lower::LoweringError,
 	model::deserialize::{
@@ -43,8 +44,8 @@ use huub::{
 		flatzinc::{FlatZincError, FznIdent, HuubFlatZinc},
 	},
 	solver::{
-		AnyView, SearchStrategy, Solution, Solver, Status, SwitchTrigger, TerminationSignal,
-		Valuation,
+		AnyView, AssumptionChecker, SearchStrategy, Solution, Solver, Status, SwitchTrigger,
+		TerminationSignal, Valuation, View,
 	},
 };
 use mimalloc::MiMalloc;
@@ -279,7 +280,43 @@ impl<'a> Cli<'a> {
 					.collect(),
 			})
 			.collect();
-		let res = match meta.goal {
+
+		// Assumption interface: every `huub_assume` constraint in the FlatZinc
+		// instance contributes its array elements to `meta.assumptions`. The
+		// CLI forwards them to the solver via `.assuming(...)` and prints the
+		// failing subset (the "core") as a `%%%mzn-core` line when the solver
+		// reports UNSAT or proves optimality.
+		let assumption_views: Vec<View<bool>> = meta.assumptions.iter().map(|(_, v)| *v).collect();
+		let has_assumptions = !assumption_views.is_empty();
+		// FlatZinc identifier of the objective decision, used to label the
+		// boundary literal that appears in the core on `Status::Complete`.
+		let obj_name: Option<&str> = match &fzn.solve.method {
+			Method::Minimize(Literal::Variable(v)) | Method::Maximize(Literal::Variable(v)) => {
+				Some(&v.name)
+			}
+			_ => None,
+		};
+		// Populated from inside the `on_failure` callback with the labels of
+		// the user assumptions that the solver attributed to the failure.
+		let unsat_core: RefCell<Option<Vec<String>>> = RefCell::default();
+		let make_on_failure = || {
+			|checker: &dyn AssumptionChecker| {
+				*unsat_core.borrow_mut() = Some(
+					meta.assumptions
+						.iter()
+						.filter_map(|(label, view)| {
+							if checker.fail(*view) {
+								Some(label.clone())
+							} else {
+								None
+							}
+						})
+						.collect(),
+				);
+			}
+		};
+
+		let (status, obj_val) = match meta.goal {
 			Some(goal) => {
 				if self.all_solutions {
 					warn!(
@@ -302,13 +339,14 @@ impl<'a> Cli<'a> {
 								}
 							);
 						})
+						.assuming(assumption_views)
+						.maybe_on_failure(has_assumptions.then(|| make_on_failure()))
 						.maybe_all_solutions(self.all_optimal.then(|| output_vars.clone()));
 					match goal {
 						Goal::Minimize(obj) => solve.minimize(obj),
 						Goal::Maximize(obj) => solve.maximize(obj),
 						_ => panic!("unknown optimization goal"),
 					}
-					.0
 				} else {
 					if let Err(err) = ctrlc::set_handler(move || {
 						interrupted.store(true, Ordering::SeqCst);
@@ -351,8 +389,10 @@ impl<'a> Cli<'a> {
 								last_obj = Some(obj_dcn.val(sol));
 							}
 						})
+						.assuming(assumption_views)
+						.maybe_on_failure(has_assumptions.then(|| make_on_failure()))
 						.maybe_all_solutions(self.all_optimal.then(|| output_vars.clone()));
-					let (status, _obj) = match goal {
+					let ret = match goal {
 						Goal::Minimize(obj) => solve.minimize(obj),
 						Goal::Maximize(obj) => solve.maximize(obj),
 						_ => panic!("unknown optimization goal"),
@@ -360,25 +400,30 @@ impl<'a> Cli<'a> {
 					if !last_sol.is_empty() {
 						output!(self.stdout, "{}", last_sol);
 					}
-					status
+					ret
 				}
 			}
-			None => slv
-				.solve()
-				.bind_using_clauses(true)
-				.on_solution(|sol| {
-					output!(
-						self.stdout,
-						"{}",
-						SolutionWrap {
-							sol,
-							fzn: &fzn,
-							var_map: &meta.names
-						}
-					);
-				})
-				.maybe_all_solutions(self.all_solutions.then(|| output_vars.clone()))
-				.satisfy(),
+			None => {
+				let status = slv
+					.solve()
+					.bind_using_clauses(true)
+					.on_solution(|sol| {
+						output!(
+							self.stdout,
+							"{}",
+							SolutionWrap {
+								sol,
+								fzn: &fzn,
+								var_map: &meta.names
+							}
+						);
+					})
+					.assuming(assumption_views)
+					.maybe_on_failure(has_assumptions.then(|| make_on_failure()))
+					.maybe_all_solutions(self.all_solutions.then(|| output_vars.clone()))
+					.satisfy();
+				(status, None)
+			}
 		};
 		if self.statistics {
 			let stats = slv.solver_statistics();
@@ -398,7 +443,21 @@ impl<'a> Cli<'a> {
 				],
 			);
 		}
-		match res {
+		if let Some(mut core) = unsat_core.into_inner() {
+			// If `Status::Complete` for an optimisation problem we annotate
+			// the core with the objective literal.
+			if status == Status::Complete {
+				let (name, val) = (obj_name.unwrap_or("objective"), obj_val.unwrap());
+				let bound_label = match &fzn.solve.method {
+					Method::Minimize(_) => format!("{name} < {val}"),
+					Method::Maximize(_) => format!("{name} >= {}", val + 1),
+					Method::Satisfy => unreachable!(),
+				};
+				core.push(bound_label);
+			}
+			outputln!(self.stdout, "%%%mzn-core: [{}]", core.join(", "));
+		}
+		match status {
 			Status::Satisfied => {}
 			Status::Unsatisfiable => outputln!(self.stdout, "{}", FZN_UNSATISFIABLE),
 			Status::Unknown => outputln!(self.stdout, "{}", FZN_UNKNOWN),

--- a/crates/huub-cli/tests/flatzinc_tests.rs
+++ b/crates/huub-cli/tests/flatzinc_tests.rs
@@ -6,8 +6,8 @@ mod helpers;
 #[cfg(test)]
 mod tests {
 	use crate::helpers::{
-		assert_all_optimal, assert_all_solutions, assert_first_solution, assert_optimal,
-		assert_search_order, assert_unsat,
+		FZN_COMPLETE, FZN_UNSATISFIABLE, assert_all_optimal, assert_all_solutions, assert_core,
+		assert_first_solution, assert_optimal, assert_search_order, assert_unsat,
 	};
 
 	assert_all_solutions!(array_var_int_element);
@@ -21,6 +21,10 @@ mod tests {
 	assert_all_solutions!(unify_with_view_3);
 
 	assert_all_optimal!(simple_sum);
+
+	assert_core!(assume_basic_unsat, FZN_UNSATISFIABLE, &["a", "neg_a"]);
+	assert_core!(assume_static_false, FZN_UNSATISFIABLE, &["false"]);
+	assert_core!(assume_minimize_boundary, FZN_COMPLETE, &["a", "x < 2"]);
 
 	assert_first_solution!(seq_search_1);
 	assert_first_solution!(seq_search_2);

--- a/crates/huub-cli/tests/helpers/mod.rs
+++ b/crates/huub-cli/tests/helpers/mod.rs
@@ -34,6 +34,20 @@ macro_rules! assert_all_solutions {
 	};
 }
 
+/// Define an integration test that checks the UNSAT core emitted by the solver.
+macro_rules! assert_core {
+	($file:ident, $status:expr, $core:expr) => {
+		#[test]
+		fn $file() {
+			$crate::helpers::check_core(
+				&std::path::PathBuf::from(format!("./corpus/{}.fzn.json", stringify!($file))),
+				$status,
+				$core,
+			)
+		}
+	};
+}
+
 /// Define an integration test that checks only the first solution emitted by
 /// the solver.
 macro_rules! assert_first_solution {
@@ -102,6 +116,7 @@ use std::{
 
 pub(crate) use assert_all_optimal;
 pub(crate) use assert_all_solutions;
+pub(crate) use assert_core;
 pub(crate) use assert_first_solution;
 pub(crate) use assert_optimal;
 pub(crate) use assert_search_order;
@@ -110,13 +125,13 @@ use expect_test::ExpectFile;
 use huub_cli::Cli;
 
 /// The FlatZinc marker that terminates a complete search.
-const FZN_COMPLETE: &str = "==========\n";
+pub(crate) const FZN_COMPLETE: &str = "==========\n";
 
 /// The FlatZinc marker that separates consecutive solutions.
 const FZN_SEPARATOR: &str = "----------\n";
 
 /// The FlatZinc marker that reports an unsatisfiable instance.
-const FZN_UNSATISFIABLE: &str = "=====UNSATISFIABLE=====\n";
+pub(crate) const FZN_UNSATISFIABLE: &str = "=====UNSATISFIABLE=====\n";
 
 /// Run the solver in all-optimal mode and compare the emitted solutions against
 /// an expectation.
@@ -150,6 +165,44 @@ pub(crate) fn check_all_solutions(file: &Path, sort: bool, solns: ExpectFile) {
 	stdout.push(marker);
 	let stdout = stdout.join(FZN_SEPARATOR);
 	solns.assert_eq(&stdout);
+}
+
+/// Run the solver once and assert that the FlatZinc output contains a
+/// `%%%mzn-core: [<expected>]` line. The check is order-insensitive: the
+/// reported core is split on `, ` and compared to `expected` as multisets.
+///
+/// `expected_status_marker` must equal one of [`FZN_UNSATISFIABLE`] or
+/// [`FZN_COMPLETE`]; the solver's final line is verified to match it so the
+/// test fails loudly if the model becomes satisfiable for an unrelated reason.
+pub(crate) fn check_core(file: &Path, expected_status_marker: &str, expected_core: &[&str]) {
+	let output = run_solver(vec![file.as_os_str()]);
+	let stdout = String::from_utf8(output).unwrap();
+	let core_line = stdout
+		.lines()
+		.find(|l| l.starts_with("%%%mzn-core: "))
+		.unwrap_or_else(|| panic!("solver did not emit a `%%%mzn-core:` line:\n{stdout}"));
+	let body = core_line
+		.trim_start_matches("%%%mzn-core: ")
+		.trim_start_matches('[')
+		.trim_end_matches(']');
+	let mut actual: Vec<&str> = if body.is_empty() {
+		Vec::new()
+	} else {
+		body.split(", ").collect()
+	};
+	actual.sort();
+	let mut expected: Vec<&str> = expected_core.to_vec();
+	expected.sort();
+	assert_eq!(
+		actual, expected,
+		"unexpected `%%%mzn-core` contents:\n{stdout}"
+	);
+	assert!(
+		stdout
+			.trim_end()
+			.ends_with(expected_status_marker.trim_end()),
+		"solver did not finish with expected marker `{expected_status_marker}`:\n{stdout}"
+	);
 }
 
 /// Run the solver once and compare the final reported solution against an

--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -364,12 +364,18 @@ impl<State: lowerer::State> Lowerer<Result<FlatZincLowerData, FlatZincError>, St
 			Goal::Minimize(v) => Goal::Minimize(map.get(&mut slv, v)),
 			Goal::Maximize(v) => Goal::Maximize(map.get(&mut slv, v)),
 		});
+		let assumptions = meta
+			.assumptions
+			.into_iter()
+			.map(|(label, view)| (label, map.get(&mut slv, view)))
+			.collect();
 		Ok((
 			slv,
 			FlatZincSolverMeta {
 				names,
 				stats: meta.stats,
 				goal,
+				assumptions,
 			},
 		))
 	}

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -119,6 +119,8 @@ pub enum ConstraintIdent {
 	ArrayVarBoolElement,
 	/// "array_var_int_element"
 	ArrayVarIntElement,
+	/// "huub_assume"
+	Assume,
 	/// "bool2int"
 	Bool2Int,
 	/// "bool_clause"
@@ -266,6 +268,14 @@ pub struct FlatZincModelMeta {
 	pub branching: Option<Branching>,
 	/// Optional optimization goal extracted from the instance.
 	pub goal: Option<Goal<View<IntVal>>>,
+	/// Boolean assumptions collected from `huub_assume` constraints.
+	///
+	/// Each entry pairs a human-readable label (the FlatZinc identifier of the
+	/// variable, or the literal string `"false"` for static constants) with the
+	/// model-level Boolean view that the solver should treat as an assumption.
+	/// The list preserves the order in which the `huub_assume` constraints (and
+	/// elements within each constraint) appeared in the FlatZinc instance.
+	pub assumptions: Vec<(String, View<bool>)>,
 }
 
 /// Metadata produced when building a solver from a FlatZinc instance.
@@ -278,6 +288,12 @@ pub struct FlatZincSolverMeta {
 	pub stats: FlatZincStatistics,
 	/// Optional optimization goal extracted from the instance.
 	pub goal: Option<Goal<solver::View<IntVal>>>,
+	/// Boolean assumptions collected from `huub_assume` constraints, lowered
+	/// to solver-level Boolean views.
+	///
+	/// See [`FlatZincModelMeta::assumptions`] for the semantics of the label
+	/// associated with each view.
+	pub assumptions: Vec<(String, solver::View<bool>)>,
 }
 
 /// Statistical information about the extraction process that creates a
@@ -323,6 +339,9 @@ pub(crate) struct FznModelBuilder<'a> {
 	processed: Vec<bool>,
 	/// Statistics about the extraction process
 	stats: FlatZincStatistics,
+	/// Boolean assumptions collected from `huub_assume` constraints, in the
+	/// order in which they were encountered in the FlatZinc instance.
+	assumptions: Vec<(String, View<bool>)>,
 }
 
 /// Trait that extends [`FlatZinc`] with Huub-specific functionality.
@@ -442,6 +461,7 @@ impl ConstraintIdent {
 			Self::ArrayIntMinimum => "huub_array_int_minimum",
 			Self::ArrayVarBoolElement => "array_var_bool_element",
 			Self::ArrayVarIntElement => "array_var_int_element",
+			Self::Assume => "huub_assume",
 			Self::Bool2Int => "bool2int",
 			Self::BoolClause => "bool_clause",
 			Self::BoolClauseReif => "huub_bool_clause_reif",
@@ -517,6 +537,7 @@ impl TryFrom<&str> for ConstraintIdent {
 			"huub_all_different_int" => Ok(Self::AllDifferentInt),
 			"huub_array_int_maximum" => Ok(Self::ArrayIntMaximum),
 			"huub_array_int_minimum" => Ok(Self::ArrayIntMinimum),
+			"huub_assume" => Ok(Self::Assume),
 			"huub_bool_clause_reif" => Ok(Self::BoolClauseReif),
 			"huub_cumulative" => Ok(Self::Cumulative),
 			"huub_diffn_int" => Ok(Self::DiffnInt { strict: true }),
@@ -1325,6 +1346,7 @@ impl<'a> FznModelBuilder<'a> {
 				stats: self.stats,
 				branching,
 				goal,
+				assumptions: self.assumptions,
 			},
 		))
 	}
@@ -1408,6 +1430,7 @@ impl<'a> FznModelBuilder<'a> {
 			prb: Model::default(),
 			processed: vec![false; fzn.constraints.len()],
 			stats: FlatZincStatistics::default(),
+			assumptions: Vec::new(),
 		}
 	}
 
@@ -1558,6 +1581,35 @@ impl<'a> FznModelBuilder<'a> {
 					let val = self.arg_int(val)?;
 
 					self.prb.element(arr).index(idx).result(val).post()?;
+				}
+				ConstraintIdent::Assume => {
+					let [arr] = c.args.as_slice() else {
+						return num_args_err(1);
+					};
+					// Resolve every element to a model-level Boolean view, pairing
+					// each view with a human-readable label that the CLI can print
+					// when the assumption ends up in an UNSAT core.
+					//
+					// For variables we use the FlatZinc identifier. For static `false`
+					// literals we keep the textual constant, so the user can see when a
+					// static `false` was passed in. `true` literals are ignored.
+					let arr = self.arg_array(arr)?;
+					self.assumptions.reserve(arr.len());
+					for l in arr {
+						let label = match l {
+							Literal::Variable(v) => v.name.clone(),
+							Literal::Bool(true) => continue,
+							Literal::Bool(false) => "false".to_owned(),
+							l => {
+								return Err(FlatZincError::InvalidArgumentType {
+									expected: "bool",
+									found: format!("{:?}", l),
+								});
+							}
+						};
+						let view = self.lit_bool(l)?;
+						self.assumptions.push((label, view));
+					}
 				}
 				ConstraintIdent::Bool2Int => {
 					let [b, i] = c.args.as_slice() else {

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -535,6 +535,37 @@ where
 		self.maybe_all_solutions_internal(views.map(|v| v.into_iter().map(|v| v.into()).collect()))
 	}
 
+	/// Conditionally register a failure callback.
+	///
+	/// Behaves like [`on_failure`](Self::on_failure) when given `Some`, and
+	/// leaves the callback unset when given `None`.
+	pub fn maybe_on_failure<NewF>(
+		self,
+		on_failure: Option<NewF>,
+	) -> SolveArgs<'a, Sat, S, NewF, solve_args::SetOnFailure<State>>
+	where
+		State::OnFailure: solve_args::IsUnset,
+		NewF: FnOnce(&dyn AssumptionChecker),
+	{
+		self.with_f::<NewF>().maybe_on_failure_internal(on_failure)
+	}
+
+	/// Conditionally register a solution callback.
+	///
+	/// Behaves like [`on_solution`](Self::on_solution) when given `Some`, and
+	/// leaves the callback unset when given `None`.
+	pub fn maybe_on_solution<NewS>(
+		self,
+		on_solution: Option<NewS>,
+	) -> SolveArgs<'a, Sat, NewS, F, solve_args::SetOnSolution<State>>
+	where
+		State::OnSolution: solve_args::IsUnset,
+		NewS: for<'b> FnMut(Solution<'b>),
+	{
+		self.with_s::<NewS>()
+			.maybe_on_solution_internal(on_solution)
+	}
+
 	/// Find a solution that minimizes the given objective expression.
 	/// Implements branch-and-bound search, iteratively improving the solution
 	/// until proven optimal.
@@ -623,10 +654,10 @@ where
 				// - If a previous solution was found, then the current bound is the best solution
 				//   under the current constraints and assumptions.
 				SatSolveResult::Unsatisfiable(fail) => {
+					if let Some(on_failure) = on_failure {
+						on_failure(&fail);
+					}
 					break if obj_curr.is_none() {
-						if let Some(on_failure) = on_failure {
-							on_failure(&fail);
-						}
 						(Unsatisfiable, None)
 					} else {
 						(Complete, obj_curr)
@@ -647,6 +678,9 @@ where
 			drop(result);
 
 			if obj_curr == Some(obj_bound) {
+				if let Some(on_failure) = on_failure {
+					on_failure(&NoAssumptions);
+				}
 				break (Complete, obj_curr);
 			} else {
 				let bound_lit = objective.lit(solver, IntLitMeaning::Less(obj_curr.unwrap()));

--- a/share/minizinc/huub/experimental/assume/fzn_assume.mzn
+++ b/share/minizinc/huub/experimental/assume/fzn_assume.mzn
@@ -1,0 +1,2 @@
+predicate huub_assume(array [int] of var bool: b ::promise_ctx_monotone);
+predicate fzn_assume(array [int] of var bool: b ::promise_ctx_monotone) = huub_assume(b);


### PR DESCRIPTION
Add an `assume([x])` predicate so MiniZinc users can mark Boolean
literals as assumptions for a solve. On unsatisfiability, or when
optimality is proven, Huub reports the subset of those literals that
the solver attributed to the failure as a `%%%mzn-core: [...]` line.