### PR TITLE
feat: bias search using decision variable polarity

### DIFF
--- a/crates/huub/src/actions.rs
+++ b/crates/huub/src/actions.rs
@@ -1,6 +1,7 @@
 //! Traits that encapsulate different sets of actions that can be performed at
 //! different phases and by different objects in the solving process.
 
+mod analyze;
 mod boolean;
 mod initialization;
 mod integer;
@@ -8,6 +9,7 @@ mod integer;
 use std::{marker::PhantomData, ops::Not};
 
 pub use crate::actions::{
+	analyze::{BoolAnalyzeActions, IntAnalyzeActions},
 	boolean::{
 		BoolInspectionActions, BoolOperations, BoolPropagationActions, BoolSimplificationActions,
 	},

--- a/crates/huub/src/actions/analyze.rs
+++ b/crates/huub/src/actions/analyze.rs
@@ -1,0 +1,68 @@
+//! Actions available to [`Constraint`](crate::constraints::Constraint)
+//! implementations during the
+//! [`analyze`](crate::constraints::Constraint::analyze) stage.
+
+use crate::{IntVal, actions::ReasoningContext, solver::Polarity};
+
+/// Actions available to [`Constraint`](crate::constraints::Constraint)
+/// implementations in the
+/// [`analyze`](crate::constraints::Constraint::analyze) stage for Boolean
+/// decision variables.
+pub trait BoolAnalyzeActions<Context>
+where
+	Context: ReasoningContext + ?Sized,
+{
+	/// Record a unit of constraint-level polarity evidence stating that this
+	/// Boolean view should be pushed in direction `polarity` (where
+	/// [`Positive`](Polarity::Positive) means "prefer true") to make the
+	/// constraint easier to satisfy.
+	fn polarity(&self, ctx: &mut Context, polarity: Polarity);
+}
+
+/// Actions available to [`Constraint`](crate::constraints::Constraint)
+/// implementations in the
+/// [`analyze`](crate::constraints::Constraint::analyze) stage for integer
+/// decision variables.
+pub trait IntAnalyzeActions<Context>
+where
+	Context: ReasoningContext + ?Sized,
+{
+	/// Record a unit of constraint-level polarity evidence stating that this
+	/// integer view should be pushed in direction `polarity` to make the
+	/// constraint easier to satisfy.
+	fn polarity(&self, ctx: &mut Context, polarity: Polarity);
+
+	/// Request that the direct encoding (the literals for the equality
+	/// conditions `x = i`) of this integer view be created eagerly.
+	fn request_direct_eager(&self, ctx: &mut Context);
+
+	/// Request that the order encoding (the literals for the inequality
+	/// conditions `x < i`) of this integer view be created eagerly.
+	fn request_order_eager(&self, ctx: &mut Context);
+}
+
+impl<Context> IntAnalyzeActions<Context> for IntVal
+where
+	Context: ReasoningContext + ?Sized,
+{
+	fn polarity(&self, _: &mut Context, _: Polarity) {
+		// A constant has no decision to record evidence on.
+	}
+
+	fn request_direct_eager(&self, _: &mut Context) {
+		// A constant has no literals to create.
+	}
+
+	fn request_order_eager(&self, _: &mut Context) {
+		// A constant has no literals to create.
+	}
+}
+
+impl<Context> BoolAnalyzeActions<Context> for bool
+where
+	Context: ReasoningContext + ?Sized,
+{
+	fn polarity(&self, _: &mut Context, _: Polarity) {
+		// A constant has no decision to record evidence on.
+	}
+}

--- a/crates/huub/src/constraints.rs
+++ b/crates/huub/src/constraints.rs
@@ -32,9 +32,10 @@ use tracing::warn;
 use crate::{
 	Conjunction, IntVal,
 	actions::{
-		BoolInitActions, BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions,
-		IntEvent, IntExplanationActions, IntInitActions, IntInspectionActions,
-		IntPropagationActions, IntSimplificationActions, ReasoningContext, ReasoningEngine,
+		BoolAnalyzeActions, BoolInitActions, BoolInspectionActions, BoolPropagationActions,
+		BoolSimplificationActions, IntAnalyzeActions, IntEvent, IntExplanationActions,
+		IntInitActions, IntInspectionActions, IntPropagationActions, IntSimplificationActions,
+		ReasoningContext, ReasoningEngine,
 	},
 	lower::{LoweringContext, LoweringError},
 	model::{self, Model},
@@ -50,6 +51,7 @@ pub trait BoolModelActions<E>
 where
 	E: ReasoningEngine,
 	Self: BoolSolverActions<E>
+		+ for<'a> BoolAnalyzeActions<E::InitializationContext<'a>>
 		+ for<'a> BoolSimplificationActions<E::PropagationContext<'a>>
 		+ Into<model::View<bool>>,
 {
@@ -106,6 +108,15 @@ pub struct Conflict<Atom> {
 /// their explicit type in an enumerated type to allow for global model
 /// analysis.
 pub trait Constraint<E: ReasoningEngine + ?Sized>: Any + Debug + DynClone + Propagator<E> {
+	/// Analyze the constraint to declare the literal encoding it requires, and
+	/// to contribute polarity evidence for the decision variables it involves.
+	///
+	/// This stage runs once on the [`Model`] before lowering. The default
+	/// implementation contributes nothing.
+	fn analyze(&self, context: &mut E::InitializationContext<'_>) {
+		let _ = context;
+	}
+
 	/// Simplify the [`Model`] given the current constraint.
 	///
 	/// This method is expected to reduce the domains of decision variables,
@@ -139,6 +150,7 @@ pub trait IntModelActions<E>
 where
 	E: ReasoningEngine,
 	Self: IntSolverActions<E>
+		+ for<'a> IntAnalyzeActions<E::InitializationContext<'a>>
 		+ for<'a> IntSimplificationActions<E::PropagationContext<'a>>
 		+ Into<model::View<IntVal>>,
 {
@@ -276,6 +288,7 @@ impl<E, B> BoolModelActions<E> for B
 where
 	E: ReasoningEngine,
 	B: BoolSolverActions<E>
+		+ for<'a> BoolAnalyzeActions<E::InitializationContext<'a>>
 		+ for<'a> BoolSimplificationActions<E::PropagationContext<'a>>
 		+ Into<model::View<bool>>,
 {
@@ -422,6 +435,7 @@ impl<E, I> IntModelActions<E> for I
 where
 	E: ReasoningEngine,
 	I: IntSolverActions<E>
+		+ for<'a> IntAnalyzeActions<E::InitializationContext<'a>>
 		+ for<'a> IntSimplificationActions<E::PropagationContext<'a>>
 		+ Into<model::View<IntVal>>,
 {

--- a/crates/huub/src/constraints/bool_array_element.rs
+++ b/crates/huub/src/constraints/bool_array_element.rs
@@ -7,8 +7,8 @@ use std::iter::once;
 use crate::{
 	IntVal,
 	actions::{
-		BoolInitActions, BoolSimplificationActions, IntDecisionActions, IntInitActions,
-		IntInspectionActions, IntPropCond, IntPropagationActions, ReasoningEngine,
+		BoolInitActions, BoolSimplificationActions, IntAnalyzeActions, IntDecisionActions,
+		IntInitActions, IntInspectionActions, IntPropCond, IntPropagationActions, ReasoningEngine,
 	},
 	constraints::{
 		BoolModelActions, Constraint, IntModelActions, Propagator, SimplificationStatus,
@@ -40,6 +40,11 @@ where
 	View<IntVal>: IntModelActions<E>,
 	View<bool>: BoolModelActions<E>,
 {
+	fn analyze(&self, ctx: &mut E::InitializationContext<'_>) {
+		// The element propagator requires the direct encoding of the index.
+		self.index.request_direct_eager(ctx);
+	}
+
 	fn simplify(
 		&mut self,
 		ctx: &mut E::PropagationContext<'_>,

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -20,7 +20,7 @@ use crate::{
 		SimplificationStatus,
 	},
 	lower::{LoweringContext, LoweringError},
-	solver::{IntLitMeaning, engine::Engine, queue::PriorityLevel},
+	solver::{IntLitMeaning, Polarity, engine::Engine, queue::PriorityLevel},
 };
 
 /// The propagation rules for the `cumulative` constraint. This enum is
@@ -817,6 +817,18 @@ where
 	I3: IntModelActions<E>,
 	I4: IntModelActions<E>,
 {
+	fn analyze(&self, ctx: &mut E::InitializationContext<'_>) {
+		// The constraint is easier to satisfy with a larger resource capacity,
+		// and with tasks that use less of the resource for a shorter time.
+		self.capacity.polarity(ctx, Polarity::Positive);
+		for usage in &self.usages {
+			usage.polarity(ctx, Polarity::Negative);
+		}
+		for duration in &self.durations {
+			duration.polarity(ctx, Polarity::Negative);
+		}
+	}
+
 	fn simplify(
 		&mut self,
 		ctx: &mut E::PropagationContext<'_>,

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -11,9 +11,9 @@ use rustc_hash::FxHashMap;
 use crate::{
 	IntSet, IntVal,
 	actions::{
-		ConstructionActions, InitActions, IntDecisionActions, IntInspectionActions, IntPropCond,
-		IntSimplificationActions, PostingActions, ReasoningContext, ReasoningEngine,
-		SimplificationActions, Trailed, TrailingActions,
+		ConstructionActions, InitActions, IntAnalyzeActions, IntDecisionActions,
+		IntInspectionActions, IntPropCond, IntSimplificationActions, PostingActions,
+		ReasoningContext, ReasoningEngine, SimplificationActions, Trailed, TrailingActions,
 	},
 	constraints::{
 		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
@@ -128,6 +128,13 @@ where
 	View<IntVal>: IntModelActions<E>,
 	IntVal: IntModelActions<E>,
 {
+	fn analyze(&self, ctx: &mut E::InitializationContext<'_>) {
+		// The element propagator requires the direct encoding of the index. A
+		// constant index resolves to no decision and is a no-op.
+		let index: View<IntVal> = self.index.clone().into();
+		index.request_direct_eager(ctx);
+	}
+
 	fn simplify(
 		&mut self,
 		ctx: &mut E::PropagationContext<'_>,
@@ -389,6 +396,13 @@ where
 	IntVal: IntModelActions<E>,
 	View<IntVal>: IntModelActions<E>,
 {
+	fn analyze(&self, ctx: &mut E::InitializationContext<'_>) {
+		// The element propagator requires the direct encoding of the index. A
+		// constant index resolves to no decision and is a no-op.
+		let index: View<IntVal> = self.0.index.clone().into();
+		index.request_direct_eager(ctx);
+	}
+
 	fn simplify(
 		&mut self,
 		ctx: &mut E::PropagationContext<'_>,

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -14,11 +14,11 @@ use pindakaas::{
 use crate::{
 	Conjunction, IntVal,
 	actions::{
-		BoolInitActions, BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions,
-		InitActions, IntDecisionActions, IntEvent, IntInitActions, IntInspectionActions,
-		IntPropCond, IntPropagationActions, IntSimplificationActions, PostingActions,
-		PropagationActions, ReasoningContext, ReasoningEngine, SimplificationActions, Trailed,
-		TrailingActions,
+		BoolAnalyzeActions, BoolInitActions, BoolInspectionActions, BoolPropagationActions,
+		BoolSimplificationActions, InitActions, IntAnalyzeActions, IntDecisionActions, IntEvent,
+		IntInitActions, IntInspectionActions, IntPropCond, IntPropagationActions,
+		IntSimplificationActions, PostingActions, PropagationActions, ReasoningContext,
+		ReasoningEngine, SimplificationActions, Trailed, TrailingActions,
 	},
 	constraints::{
 		BoolModelActions, BoolSolverActions, Constraint, IntModelActions, IntSolverActions,
@@ -31,7 +31,8 @@ use crate::{
 	lower::{LoweringContext, LoweringError},
 	model::{self, expressions::bool_formula::BoolFormula},
 	solver::{
-		self, BoolView, Decision, IntLitMeaning, queue::PriorityLevel, view::integer::IntView,
+		self, BoolView, Decision, IntLitMeaning, Polarity, queue::PriorityLevel,
+		view::integer::IntView,
 	},
 	views::LinearBoolView,
 };
@@ -294,6 +295,22 @@ where
 	model::View<bool>: BoolModelActions<E>,
 	OF: OverflowMode,
 {
+	fn analyze(&self, ctx: &mut E::InitializationContext<'_>) {
+		match self.reif {
+			// A half-reified constraint is vacuously satisfied when the
+			// implication literal is false.
+			Some(Reification::ImpliedBy(r)) => r.polarity(ctx, Polarity::Negative),
+			// For an `int_lin_le` constraint (sum <= rhs), making each term
+			// smaller makes the constraint easier to satisfy.
+			None if self.comparator == LinComparator::LessEq => {
+				for t in &self.terms {
+					t.polarity(ctx, Polarity::Negative);
+				}
+			}
+			_ => {}
+		}
+	}
+
 	fn simplify(
 		&mut self,
 		ctx: &mut E::PropagationContext<'_>,

--- a/crates/huub/src/constraints/int_no_overlap.rs
+++ b/crates/huub/src/constraints/int_no_overlap.rs
@@ -21,7 +21,7 @@ use crate::{
 	},
 	helpers::matrix::Matrix,
 	lower::{LoweringContext, LoweringError},
-	solver::{IntLitMeaning, engine::Engine, queue::PriorityLevel},
+	solver::{IntLitMeaning, Polarity, engine::Engine, queue::PriorityLevel},
 };
 
 /// The [`IntNoOverlapSweep`] propagator ensures that a set of k-dimensional
@@ -595,6 +595,13 @@ where
 	I1: IntModelActions<E>,
 	I2: IntModelActions<E>,
 {
+	fn analyze(&self, ctx: &mut E::InitializationContext<'_>) {
+		// Smaller objects are easier to place without overlap.
+		for size in self.size.iter_elem() {
+			size.polarity(ctx, Polarity::Negative);
+		}
+	}
+
 	fn simplify(
 		&mut self,
 		ctx: &mut E::PropagationContext<'_>,

--- a/crates/huub/src/constraints/int_table.rs
+++ b/crates/huub/src/constraints/int_table.rs
@@ -9,8 +9,9 @@ use itertools::Itertools;
 use crate::{
 	IntVal,
 	actions::{
-		InitActions, IntDecisionActions, IntInitActions, IntInspectionActions, IntPropCond,
-		IntPropagationActions, IntSimplificationActions, PropagationActions, ReasoningEngine,
+		InitActions, IntAnalyzeActions, IntDecisionActions, IntInitActions, IntInspectionActions,
+		IntPropCond, IntPropagationActions, IntSimplificationActions, PropagationActions,
+		ReasoningEngine,
 	},
 	constraints::{
 		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
@@ -37,6 +38,14 @@ where
 	E: ReasoningEngine,
 	View<IntVal>: IntModelActions<E>,
 {
+	fn analyze(&self, ctx: &mut E::InitializationContext<'_>) {
+		// The table constraint is encoded using the direct encoding of all its
+		// variables.
+		for v in &self.vars {
+			v.request_direct_eager(ctx);
+		}
+	}
+
 	fn simplify(
 		&mut self,
 		ctx: &mut E::PropagationContext<'_>,

--- a/crates/huub/src/constraints/int_unique.rs
+++ b/crates/huub/src/constraints/int_unique.rs
@@ -13,14 +13,15 @@ mod domain;
 mod value;
 
 use itertools::{Either, Itertools};
+use rangelist::IntervalIterator;
 use tracing::warn;
 
 pub use crate::constraints::int_unique::{
 	bounds::IntUniqueBounds, domain::IntUniqueDomain, value::IntUniqueValue,
 };
 use crate::{
-	IntVal,
-	actions::{IntEvent, IntInspectionActions, ReasoningEngine},
+	IntSet, IntVal,
+	actions::{IntAnalyzeActions, IntEvent, IntInspectionActions, ReasoningEngine},
 	constraints::{
 		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
 	},
@@ -77,6 +78,35 @@ where
 	E: ReasoningEngine,
 	View<IntVal>: IntModelActions<E>,
 {
+	fn analyze(&self, ctx: &mut E::InitializationContext<'_>) {
+		// The direct encoding is only used by the value- and domain-consistency
+		// propagators.
+		if !(self.value_propagation() || self.domain_propagation()) {
+			return;
+		}
+
+		// The eager value encoding pays off when the decisions jointly range over
+		// few values relative to their number. Use the cardinality of the union of
+		// all the decision variable domains.
+		let dcns = &self.bounds_prop.vars;
+		let mut union: Option<IntSet> = None;
+		for d in dcns {
+			let dom = d.domain(ctx);
+			union = Some(match union {
+				None => dom,
+				Some(u) => u.union(&dom),
+			});
+		}
+		let tight = union
+			.and_then(|u| u.card())
+			.is_some_and(|card| card <= dcns.len() * 100 / 80);
+		if tight {
+			for d in dcns {
+				d.request_direct_eager(ctx);
+			}
+		}
+	}
+
 	fn simplify(
 		&mut self,
 		ctx: &mut E::PropagationContext<'_>,

--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -3,6 +3,7 @@
 
 use std::{
 	any::Any,
+	collections::VecDeque,
 	error::Error,
 	fmt::{self, Debug, Display},
 	marker::PhantomData,
@@ -20,9 +21,8 @@ use rustc_hash::FxHashSet;
 use tracing::warn;
 
 #[cfg(feature = "flatzinc")]
-use crate::model::deserialize::{
-	Goal,
-	flatzinc::{FlatZincError, FlatZincLowerData, FlatZincModelMeta, FlatZincSolverMeta},
+use crate::model::deserialize::flatzinc::{
+	FlatZincError, FlatZincLowerData, FlatZincModelMeta, FlatZincSolverMeta,
 };
 use crate::{
 	IntSet, IntVal,
@@ -31,19 +31,45 @@ use crate::{
 		PostingActions, ReasoningContext, ReasoningEngine, Trailed,
 	},
 	constraints::{
-		BoxedPropagator, Conflict, Constraint, ReasonBuilder,
-		bool_array_element::BoolDecisionArrayElement,
-		int_array_element::{IntArrayElementBounds, IntValArrayElement},
-		int_table::IntTable,
-		int_unique::IntUnique,
+		BoxedConstraint, BoxedPropagator, Conflict, Constraint, ReasonBuilder,
+		int_array_minimum::IntArrayMinimumBounds,
+		int_div::IntDivBounds,
+		int_linear::{IntEq, IntLinear, LinComparator},
+		int_mul::IntMulBounds,
+		int_pow::IntPowBounds,
 	},
-	helpers::bytes::Bytes,
-	model::{self, Model, decision::integer::Domain, resolved::Resolved},
+	helpers::{
+		bytes::Bytes,
+		overflow::{OverflowImpossible, OverflowMode, OverflowPossible},
+	},
+	model::{
+		self, ConRef, Model,
+		decision::{Tier, integer::Domain},
+		deserialize::Goal,
+		initilization_context::ModelInitContext,
+		resolved::Resolved,
+		view::integer::IntView,
+	},
 	solver::{
-		self, IntLitMeaning, LiteralStrategy, Solver, engine::Engine, view::boolean::BoolView,
+		self, IntLitMeaning, LiteralStrategy, Polarity, Solver, engine::Engine,
+		view::boolean::BoolView,
 	},
 	views::LinearBoolView,
 };
+
+/// State of the breadth-first walk used to reconstruct the goal polarity in
+/// [`GoalPolarity::process`].
+#[derive(Debug, Default)]
+struct GoalPolarity {
+	/// The constraint currently being processed.
+	current_con: Option<ConRef>,
+	/// The queue of decisions still to be processed: the decision, the desired
+	/// direction, and the constraint that enqueued it or `None` for the goal
+	/// itself.
+	queue: VecDeque<(Resolved<model::Decision<IntVal>>, Polarity, Option<ConRef>)>,
+	/// The (decision, direction) pairs already enqueued.
+	visited: FxHashSet<(Resolved<model::Decision<IntVal>>, Polarity)>,
+}
 
 /// Internal type to represent a complete [`Lowerer`] builder.
 #[derive(Builder)]
@@ -114,6 +140,13 @@ pub(crate) struct LowererComplete<Origin = ()> {
 	/// Whether to enable the vivification in the SAT solver.
 	#[builder(default = Lowerer::DEFAULT_VIVIFICATION)]
 	vivification: bool,
+	/// The (optional) intended objective, used to bias the polarity of the
+	/// decision variables that compose it.
+	///
+	/// Use the [`positive_polarity`](Lowerer::positive_polarity) and
+	/// [`negative_polarity`](Lowerer::negative_polarity) builder setters rather
+	/// than setting this directly.
+	objective: Option<Goal<model::View<IntVal>>>,
 }
 
 /// Actions that can be performed when reformulating a [`Model`] object into a
@@ -232,15 +265,9 @@ pub struct LoweringMap {
 pub(crate) struct LoweringMapBuilder {
 	/// Map of Boolean decisions to Boolean views.
 	pub(crate) bool_map: Vec<Option<solver::View<bool>>>,
-	/// Set of integer decisions for which the direct encoding should be created
-	/// eagerly.
-	pub(crate) int_eager_direct: FxHashSet<Resolved<model::Decision<IntVal>>>,
 	/// The (default) maximum cardinality of the domain of an integer variable
 	/// before its order encoding is created lazily.
 	pub(crate) int_eager_limit: usize,
-	/// Set of integer decisions for which the order encoding should be created
-	/// eagerly.
-	pub(crate) int_eager_order: FxHashSet<Resolved<model::Decision<IntVal>>>,
 	/// Map of integer decisions to integer views.
 	pub(crate) int_map: Vec<Option<solver::View<IntVal>>>,
 }
@@ -258,6 +285,256 @@ pub enum ReduceType {
 	Sqrt = 1,
 	/// Logarithmic reduction target (CaDiCaL `reduceopt` value `2`).
 	Log = 2,
+}
+
+impl GoalPolarity {
+	/// Reconstruct the goal polarity (best-effort) from the intended
+	/// optimization `goal`, recording objective-level evidence on the
+	/// decisions that compose it.
+	///
+	/// Starting from the goal decision, it walks breadth-first over the
+	/// constraints each visited decision is subscribed to (via
+	/// [`Model::subscribed_constraints`]), recording the desired direction onto
+	/// the other variables those constraints relate, which are in turn
+	/// enqueued.
+	///
+	/// The relations considered are the (non-reified) linear (in)equalities and
+	/// the monotone/antitone relationships of arithmetic constraints such as
+	/// multiplication, division, exponentiation, and array minimum.
+	fn process(
+		model: &mut Model,
+		constraints: &[Option<BoxedConstraint>],
+		goal: Goal<model::View<IntVal>>,
+	) {
+		// Record the polarity of the objective itself, and seed the walk from
+		// its underlying integer decision.
+		let (obj, dir) = match goal {
+			Goal::Maximize(obj) => (obj, Polarity::Positive),
+			Goal::Minimize(obj) => (obj, Polarity::Negative),
+		};
+		model.observe_int_polarity(obj, Tier::Objective, dir);
+		let IntView::Linear(lin) = obj.resolve_alias(model).into_inner().0 else {
+			return;
+		};
+		let start = Resolved(lin.var);
+		let start_dir = if lin.scale.get() < 0 { !dir } else { dir };
+		let mut walk = GoalPolarity::default();
+		let _ = walk.visited.insert((start.clone(), start_dir));
+		walk.queue.push_back((start, start_dir, None));
+
+		let mut con_refs: Vec<ConRef> = Vec::new();
+		while let Some((input, input_polarity, discovering)) = walk.queue.pop_front() {
+			// Collect the constraints the decision is involved in
+			con_refs.clear();
+			model.subscribed_constraints(input.0, |con| con_refs.push(con));
+			con_refs.sort_unstable_by_key(|con| con.index());
+			con_refs.dedup();
+			for &con in &con_refs {
+				// Never enqueue decisions from the constraint that enqueued this
+				// decision
+				if discovering == Some(con) {
+					continue;
+				}
+				let Some(c) = constraints[con.index()].as_ref() else {
+					continue;
+				};
+				let c: &dyn Constraint<Model> = c.as_ref();
+				let c: &dyn Any = c;
+				walk.current_con = Some(con);
+				walk.process_constraint(model, c, &input, input_polarity);
+			}
+		}
+	}
+
+	/// Process the constraint `con` during the objective walk: derive the
+	/// relations it implies and record the direction `input_polarity` of the
+	/// visited decision `input` onto the other variables of those relations.
+	fn process_constraint(
+		&mut self,
+		model: &mut Model,
+		con: &dyn Any,
+		input: &Resolved<model::Decision<IntVal>>,
+		input_polarity: Polarity,
+	) {
+		/// Type alias to abbreviate the integer view type in the downcasts.
+		type V = model::View<IntVal>;
+
+		if let Some(lin) = con.downcast_ref::<IntLinear<OverflowImpossible>>() {
+			if lin.reif.is_none() && lin.comparator != LinComparator::NotEqual {
+				self.record_relation(model, &lin.terms, input, input_polarity);
+			}
+		} else if let Some(lin) = con.downcast_ref::<IntLinear<OverflowPossible>>() {
+			if lin.reif.is_none() && lin.comparator != LinComparator::NotEqual {
+				self.record_relation(model, &lin.terms, input, input_polarity);
+			}
+		} else if let Some(eq) = con.downcast_ref::<IntEq>() {
+			// `a = b` expressed as the linear equality `a - b = 0`.
+			self.record_relation(model, &[eq.vars[0], -eq.vars[1]], input, input_polarity);
+		} else if let Some(mul) = con.downcast_ref::<IntMulBounds<OverflowImpossible, V, V, V>>() {
+			self.record_mul(model, mul, input, input_polarity);
+		} else if let Some(mul) = con.downcast_ref::<IntMulBounds<OverflowPossible, V, V, V>>() {
+			self.record_mul(model, mul, input, input_polarity);
+		} else if let Some(pow) = con.downcast_ref::<IntPowBounds<OverflowImpossible, V, V, V>>() {
+			self.record_pow(model, pow, input, input_polarity);
+		} else if let Some(pow) = con.downcast_ref::<IntPowBounds<OverflowPossible, V, V, V>>() {
+			self.record_pow(model, pow, input, input_polarity);
+		} else if let Some(div) = con.downcast_ref::<IntDivBounds<V, V, V>>() {
+			self.record_div(model, div, input, input_polarity);
+		} else if let Some(min) = con.downcast_ref::<IntArrayMinimumBounds<V, V>>() {
+			// The minimum is monotone in every element of the array.
+			for &el in &min.vars {
+				self.record_relation(model, &[min.min, -el], input, input_polarity);
+			}
+		}
+	}
+
+	/// Record the polarity implied by `result = numerator / denominator` for
+	/// the related variables of the visited decision.
+	fn record_div(
+		&mut self,
+		model: &mut Model,
+		div: &IntDivBounds<model::View<IntVal>, model::View<IntVal>, model::View<IntVal>>,
+		input: &Resolved<model::Decision<IntVal>>,
+		input_polarity: Polarity,
+	) {
+		// The denominator must be strictly positive or strictly negative for the
+		// division to be monotone in either argument. The result follows the
+		// numerator when the denominator is positive, and opposes it when the
+		// denominator is negative.
+		let (den_lb, den_ub) = div.denominator.bounds(model);
+		if den_lb >= 1 {
+			self.record_relation(model, &[div.result, -div.numerator], input, input_polarity);
+		} else if den_ub <= -1 {
+			self.record_relation(model, &[div.result, div.numerator], input, input_polarity);
+		} else {
+			return;
+		}
+		// Increasing the denominator moves the result toward zero, i.e. against
+		// the sign of the numerator.
+		let (num_lb, num_ub) = div.numerator.bounds(model);
+		if num_lb >= 0 {
+			self.record_relation(model, &[div.result, div.denominator], input, input_polarity);
+		} else if num_ub <= 0 {
+			self.record_relation(
+				model,
+				&[div.result, -div.denominator],
+				input,
+				input_polarity,
+			);
+		}
+	}
+
+	/// Record the polarity implied by `product = factor1 * factor2` for the
+	/// related variables of the visited decision.
+	///
+	/// The product is monotone in a factor when the other factor is
+	/// non-negative, and antitone when it is non-positive.
+	fn record_mul<OM: OverflowMode>(
+		&mut self,
+		model: &mut Model,
+		mul: &IntMulBounds<OM, model::View<IntVal>, model::View<IntVal>, model::View<IntVal>>,
+		input: &Resolved<model::Decision<IntVal>>,
+		input_polarity: Polarity,
+	) {
+		let (f2_lb, f2_ub) = mul.factor2.bounds(model);
+		if f2_lb >= 0 {
+			self.record_relation(model, &[mul.product, -mul.factor1], input, input_polarity);
+		} else if f2_ub <= 0 {
+			self.record_relation(model, &[mul.product, mul.factor1], input, input_polarity);
+		}
+		let (f1_lb, f1_ub) = mul.factor1.bounds(model);
+		if f1_lb >= 0 {
+			self.record_relation(model, &[mul.product, -mul.factor2], input, input_polarity);
+		} else if f1_ub <= 0 {
+			self.record_relation(model, &[mul.product, mul.factor2], input, input_polarity);
+		}
+	}
+
+	/// Record the polarity implied by `result = base ^ exponent` for the
+	/// related variables of the visited decision.
+	fn record_pow<OM: OverflowMode>(
+		&mut self,
+		model: &mut Model,
+		pow: &IntPowBounds<OM, model::View<IntVal>, model::View<IntVal>, model::View<IntVal>>,
+		input: &Resolved<model::Decision<IntVal>>,
+		input_polarity: Polarity,
+	) {
+		let (base_lb, base_ub) = pow.base.bounds(model);
+		let (exp_lb, exp_ub) = pow.exponent.bounds(model);
+		let fixed_exp = (exp_lb == exp_ub).then_some(exp_lb);
+
+		// The result is monotone in the base for non-negative bases with
+		// positive exponents, and for any fixed odd exponent; it is antitone in
+		// the base for non-positive bases with a fixed even exponent.
+		if (exp_lb >= 1 && base_lb >= 0) || fixed_exp.is_some_and(|k| k >= 1 && k % 2 == 1) {
+			self.record_relation(model, &[pow.result, -pow.base], input, input_polarity);
+		} else if base_ub <= 0 && fixed_exp.is_some_and(|k| k >= 2 && k % 2 == 0) {
+			self.record_relation(model, &[pow.result, pow.base], input, input_polarity);
+		}
+		// The result is monotone in the exponent when the base is at least one.
+		if base_lb >= 1 {
+			self.record_relation(model, &[pow.result, -pow.exponent], input, input_polarity);
+		}
+	}
+
+	/// Record the direction `input_polarity` of the visited decision `input`
+	/// onto the other terms of a single relation, given as the terms of a
+	/// linear equality (views with opposite coefficient signs are monotone,
+	/// views with the same coefficient sign are antitone).
+	///
+	/// Every (non-`input`) term has a push recorded, so the score accumulates
+	/// across all the relations that mention a decision. Integer decisions are
+	/// additionally enqueued (once) so the walk continues through them.
+	fn record_relation(
+		&mut self,
+		model: &mut Model,
+		terms: &[model::View<IntVal>],
+		input: &Resolved<model::Decision<IntVal>>,
+		input_polarity: Polarity,
+	) {
+		// Whether `input`'s coefficient in this relation is negative.
+		let Some(input_neg) =
+			terms
+				.iter()
+				.find_map(|t| match t.resolve_alias(model).into_inner().0 {
+					IntView::Linear(lin) if &Resolved(lin.var) == input => {
+						Some(lin.scale.get() < 0)
+					}
+					_ => None,
+				})
+		else {
+			return;
+		};
+		// To push `input` in `input_polarity`, the other terms must be pushed in
+		// the opposite direction.
+		let term_dir = if input_neg {
+			input_polarity
+		} else {
+			!input_polarity
+		};
+		for &t in terms {
+			match t.resolve_alias(model).into_inner().0 {
+				IntView::Linear(lin) => {
+					let w = Resolved(lin.var);
+					if &w == input {
+						continue;
+					}
+					model.observe_int_polarity(t, Tier::Objective, term_dir);
+					// The direction wanted for `w` is `term_dir` folded by `w`'s scale.
+					let w_dir = if lin.scale.get() < 0 {
+						!term_dir
+					} else {
+						term_dir
+					};
+					if self.visited.insert((w.clone(), w_dir)) {
+						self.queue.push_back((w, w_dir, self.current_con));
+					}
+				}
+				// Boolean- and constant-backed terms are leaves of the walk.
+				_ => model.observe_int_polarity(t, Tier::Objective, term_dir),
+			}
+		}
+	}
 }
 
 impl Lowerer {
@@ -320,6 +597,44 @@ impl<State: lowerer::State> Lowerer<&mut Model, State> {
 	}
 }
 
+impl<Origin, State: lowerer::State> Lowerer<Origin, State> {
+	/// Indicate that the search should prefer smaller values for the given
+	/// objective view (e.g. a minimization objective), biasing the polarity of
+	/// the decision variables that compose it toward smaller values at
+	/// objective priority.
+	///
+	/// This is mutually exclusive with
+	/// [`positive_polarity`](Lowerer::positive_polarity): both set the same
+	/// intended objective.
+	pub fn negative_polarity(
+		self,
+		objective: model::View<IntVal>,
+	) -> Lowerer<Origin, lowerer::SetObjective<State>>
+	where
+		State::Objective: lowerer::IsUnset,
+	{
+		self.objective(Goal::Minimize(objective))
+	}
+
+	/// Indicate that the search should prefer larger values for the given
+	/// objective view (e.g. a maximization objective), biasing the polarity of
+	/// the decision variables that compose it toward larger values at objective
+	/// priority.
+	///
+	/// This is mutually exclusive with
+	/// [`negative_polarity`](Lowerer::negative_polarity): both set the same
+	/// intended objective.
+	pub fn positive_polarity(
+		self,
+		objective: model::View<IntVal>,
+	) -> Lowerer<Origin, lowerer::SetObjective<State>>
+	where
+		State::Objective: lowerer::IsUnset,
+	{
+		self.objective(Goal::Maximize(objective))
+	}
+}
+
 #[cfg(feature = "flatzinc")]
 impl<State: lowerer::State> Lowerer<Result<FlatZincLowerData, FlatZincError>, State> {
 	/// Lower the [`FlatZinc`](flatzinc_serde::FlatZinc) instance to a
@@ -350,6 +665,9 @@ impl<State: lowerer::State> Lowerer<Result<FlatZincLowerData, FlatZincError>, St
 			reason_eager: complete.reason_eager,
 			variable_elimination: complete.variable_elimination,
 			vivification: complete.vivification,
+			// Use the parsed optimization goal to bias polarity, unless an
+			// explicit objective was set on the builder.
+			objective: complete.objective.or(meta.goal),
 		}
 		.into_solver_internal()?;
 		if let Some(branching) = meta.branching {
@@ -412,6 +730,7 @@ impl LowererComplete<&mut Model> {
 			reason_eager,
 			variable_elimination,
 			vivification,
+			objective,
 		} = self;
 
 		let mut slv = Solver::<Sat>::default();
@@ -443,62 +762,27 @@ impl LowererComplete<&mut Model> {
 
 		model.propagate()?;
 
-		// Determine encoding types for integer variables
-		let mut int_eager_direct = FxHashSet::<Resolved<model::Decision<IntVal>>>::default();
-		let int_eager_order = FxHashSet::<Resolved<model::Decision<IntVal>>>::default();
-
-		for c in model.constraints.iter().flatten() {
-			let c: &dyn Constraint<Model> = c.as_ref();
-			let c: &dyn Any = c;
-			if let Some(c) = c.downcast_ref::<BoolDecisionArrayElement>() {
-				let index = c.index.resolve_alias(model);
-				if let Some(var) = index.integer_decision() {
-					int_eager_direct.insert(var);
-				}
-			} else if let Some(c) = c.downcast_ref::<IntUnique>() {
-				for v in &c.bounds_prop.vars {
-					let v = v.resolve_alias(model);
-					if let Some(var) = v.integer_decision() {
-						let Domain::Domain(dom) = &model.int_vars[var.idx()].domain else {
-							unreachable!()
-						};
-						if dom.card() <= Some(c.bounds_prop.vars.len() * 100 / 80) {
-							int_eager_direct.insert(var);
-						}
-					}
-				}
-			} else if let Some(c) = c.downcast_ref::<IntArrayElementBounds<
-				model::View<IntVal>,
-				model::View<IntVal>,
-				model::View<IntVal>,
-			>>() {
-				let index = c.index.resolve_alias(model);
-				if let Some(var) = index.integer_decision() {
-					int_eager_direct.insert(var);
-				}
-			} else if let Some(c) = c.downcast_ref::<IntTable>() {
-				for &v in &c.vars {
-					let v = v.resolve_alias(model);
-					if let Some(var) = v.integer_decision() {
-						int_eager_direct.insert(var);
-					}
-				}
-			} else if let Some(c) =
-				c.downcast_ref::<IntValArrayElement<model::View<IntVal>, model::View<IntVal>>>()
-			{
-				let index = c.0.index.resolve_alias(model);
-				if let Some(var) = index.integer_decision() {
-					int_eager_direct.insert(var);
-				}
+		// Analyze each constraint to record its literal-encoding requirements
+		// and polarity evidence onto the model's decision definitions, then
+		// reconstruct the objective polarity. The constraints are temporarily
+		// taken out of the model so the analyze stage can mutate the decision
+		// definitions while iterating.
+		let constraints = std::mem::take(&mut model.constraints);
+		for (idx, c) in constraints.iter().enumerate() {
+			if let Some(c) = c {
+				let mut ctx = ModelInitContext::new(model, ConRef::new(idx));
+				c.analyze(&mut ctx);
 			}
 		}
+		if let Some(obj) = objective {
+			GoalPolarity::process(model, &constraints, obj);
+		}
+		model.constraints = constraints;
 
 		// Create the mapping between model decisions and solver views.
 		let mut map_builder = LoweringMapBuilder {
 			bool_map: vec![None; model.bool_vars.len()],
-			int_eager_direct,
 			int_eager_limit,
-			int_eager_order,
 			int_map: vec![None; model.int_vars.len()],
 		};
 
@@ -780,10 +1064,7 @@ impl LoweringMap {
 		use crate::model::view::boolean::BoolView::*;
 
 		let int_lit = |slv: &mut Ctx, iv: model::Decision<IntVal>, lit_meaning: IntLitMeaning| {
-			let iv = self.get_int(
-				slv,
-				model::View(model::view::integer::IntView::Linear(iv.into())),
-			);
+			let iv = self.get_int(slv, model::View(IntView::Linear(iv.into())));
 			iv.lit(slv, lit_meaning)
 		};
 
@@ -863,7 +1144,15 @@ impl LoweringMapBuilder {
 				let def = &model.bool_vars[idx];
 				let view = match def.alias {
 					Some(alias) => self.get_or_create_bool(model, slv, alias),
-					None => slv.new_bool_decision().into(),
+					None => {
+						let dcn = slv.new_bool_decision();
+						match def.polarity.resolve() {
+							Some(Polarity::Positive) => slv.sat.phase(dcn.0),
+							Some(Polarity::Negative) => slv.sat.phase(!dcn.0),
+							None => {}
+						};
+						dcn.into()
+					}
 				};
 				self.bool_map[idx] = Some(view);
 				if lit.is_negated() { !view } else { view }
@@ -917,15 +1206,15 @@ impl LoweringMapBuilder {
 						let Domain::Domain(dom) = &def.domain else {
 							unreachable!()
 						};
-						let direct_enc = if self.int_eager_direct.contains(&var) {
+						let direct_enc = if def.eager_direct {
 							LiteralStrategy::Eager
 						} else {
 							LiteralStrategy::Lazy
 						};
 						let card = dom.card();
-						let order_enc = if self.int_eager_order.contains(&var)
-							|| self.int_eager_direct.contains(&var)
-							|| card.is_some() && card.unwrap() <= self.int_eager_limit
+						let order_enc = if def.eager_order
+							|| def.eager_direct || card.is_some()
+							&& card.unwrap() <= self.int_eager_limit
 						{
 							LiteralStrategy::Eager
 						} else {
@@ -935,6 +1224,7 @@ impl LoweringMapBuilder {
 							.new_int_decision(dom.clone())
 							.order_literals(order_enc)
 							.direct_literals(direct_enc)
+							.maybe_polarity(def.polarity.resolve())
 							.view();
 						self.int_map[var.idx()] = Some(view);
 						view
@@ -1162,5 +1452,155 @@ impl IntInspectionActions<dyn LoweringActions + '_> for solver::Decision<IntVal>
 	fn val(&self, ctx: &dyn LoweringActions) -> Option<IntVal> {
 		let (lb, ub) = self.bounds(ctx);
 		if lb == ub { Some(lb) } else { None }
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{
+		IntVal,
+		model::{
+			Model, View,
+			view::{boolean::BoolView, integer::IntView},
+		},
+		solver::{Polarity, Solver, Status, Valuation},
+		views::LinearView,
+	};
+
+	/// Helper to find the model storage index of the integer decision backing
+	/// the given (unscaled) model view.
+	fn int_decision_index(v: View<IntVal>) -> usize {
+		let IntView::Linear(LinearView { var, .. }) = v.0 else {
+			panic!("expected a linear view")
+		};
+		var.idx()
+	}
+
+	/// `r -> (a + b <= 1)` is vacuously satisfied when `r` is false, so the
+	/// constraint analysis prefers `r` to be false.
+	#[test]
+	fn polarity_halfreified_prefers_false() {
+		let mut model = Model::default();
+		let a = model.new_int_decision(0..=5);
+		let b = model.new_int_decision(0..=5);
+		let r = model.new_bool_decision();
+		model.linear(a + b).le(1).implied_by(r).post().unwrap();
+
+		let BoolView::Decision(l) = r.0 else {
+			panic!("expected a Boolean decision view")
+		};
+		let ri = l.idx();
+		let (_slv, _map): (Solver, _) = model.lower().to_solver().unwrap();
+		assert_eq!(
+			model.bool_vars[ri].polarity.resolve(),
+			Some(Polarity::Negative)
+		);
+	}
+
+	/// Minimizing `-x` should prefer larger `x`; the negative scale of the
+	/// objective view must be folded so that `x` receives a positive polarity.
+	#[test]
+	fn polarity_objective_negative_scale() {
+		let mut model = Model::default();
+		let x = model.new_int_decision(1..=10);
+		let (mut slv, map): (Solver, _) = model.lower().negative_polarity(-x).to_solver().unwrap();
+		let sx = map.get(&mut slv, x);
+		let mut found = None;
+		let status = slv
+			.solve()
+			.on_solution(|sol| {
+				found = Some(Valuation::val(&sx, sol));
+			})
+			.satisfy();
+		assert_eq!(status, Status::Satisfied);
+		assert_eq!(found, Some(10));
+	}
+
+	/// `a - b + c - x = 0` (relates x to a, b, c) and `d + e - c = 0` (relates
+	/// c to d, e). Maximizing x (positive polarity) should prefer a, c, d and
+	/// e large and b small, walking from x through c into d and e, and folding
+	/// the negative coefficient of b. Posted as plain equalities (no
+	/// `defines_var` / `.define()`) to exercise the variable-to-linear map on
+	/// a user-built model.
+	#[test]
+	fn polarity_objective_recursive_reconstruction() {
+		let mut model = Model::default();
+		let a = model.new_int_decision(1..=5);
+		let b = model.new_int_decision(1..=5);
+		let c = model.new_int_decision(1..=8);
+		let d = model.new_int_decision(1..=5);
+		let e = model.new_int_decision(1..=5);
+		let x = model.new_int_decision(-100..=100);
+		model.linear(a - b + c - x).eq(0).post().unwrap();
+		model.linear(d + e - c).eq(0).post().unwrap();
+
+		// Resolve each view to its decision index before lowering borrows `model`.
+		let idx = int_decision_index;
+		let (ai, bi, ci, di, ei) = (idx(a), idx(b), idx(c), idx(d), idx(e));
+
+		let (_slv, _map): (Solver, _) = model.lower().positive_polarity(x).to_solver().unwrap();
+
+		let pol = |i: usize| model.int_vars[i].polarity.resolve();
+		assert_eq!(pol(ai), Some(Polarity::Positive), "a");
+		assert_eq!(pol(bi), Some(Polarity::Negative), "b");
+		assert_eq!(pol(ci), Some(Polarity::Positive), "c");
+		assert_eq!(pol(di), Some(Polarity::Positive), "d");
+		assert_eq!(pol(ei), Some(Polarity::Positive), "e");
+	}
+
+	/// `a + b - z <= 0` (i.e. `a + b <= z`): increasing `a` or `b` forces
+	/// `z` upward, so maximizing `z` prefers `a` and `b` large. Note that
+	/// the objective-level signal dominates the constraint-level preference
+	/// for smaller terms in the inequality.
+	#[test]
+	fn polarity_objective_through_leq() {
+		let mut model = Model::default();
+		let a = model.new_int_decision(1..=5);
+		let b = model.new_int_decision(1..=5);
+		let z = model.new_int_decision(1..=20);
+		model.linear(a + b - z).le(0).post().unwrap();
+
+		let (ai, bi) = (int_decision_index(a), int_decision_index(b));
+		let (_slv, _map): (Solver, _) = model.lower().positive_polarity(z).to_solver().unwrap();
+
+		let pol = |i: usize| model.int_vars[i].polarity.resolve();
+		assert_eq!(pol(ai), Some(Polarity::Positive), "a");
+		assert_eq!(pol(bi), Some(Polarity::Positive), "b");
+	}
+
+	/// `z = min(a, b)` is monotone in both elements of the array, so
+	/// maximizing `z` prefers `a` and `b` large.
+	#[test]
+	fn polarity_objective_through_minimum() {
+		let mut model = Model::default();
+		let a = model.new_int_decision(1..=5);
+		let b = model.new_int_decision(1..=5);
+		let z = model.new_int_decision(1..=5);
+		model.minimum(vec![a, b]).result(z).post().unwrap();
+
+		let (ai, bi) = (int_decision_index(a), int_decision_index(b));
+		let (_slv, _map): (Solver, _) = model.lower().positive_polarity(z).to_solver().unwrap();
+
+		let pol = |i: usize| model.int_vars[i].polarity.resolve();
+		assert_eq!(pol(ai), Some(Polarity::Positive), "a");
+		assert_eq!(pol(bi), Some(Polarity::Positive), "b");
+	}
+
+	/// `m = a * b` with non-negative factors is monotone in both factors,
+	/// so maximizing `m` prefers `a` and `b` large.
+	#[test]
+	fn polarity_objective_through_mul() {
+		let mut model = Model::default();
+		let a = model.new_int_decision(1..=5);
+		let b = model.new_int_decision(1..=5);
+		let m = model.new_int_decision(1..=25);
+		model.mul(a, b).result(m).post().unwrap();
+
+		let (ai, bi) = (int_decision_index(a), int_decision_index(b));
+		let (_slv, _map): (Solver, _) = model.lower().positive_polarity(m).to_solver().unwrap();
+
+		let pol = |i: usize| model.int_vars[i].polarity.resolve();
+		assert_eq!(pol(ai), Some(Polarity::Positive), "a");
+		assert_eq!(pol(bi), Some(Polarity::Positive), "b");
 	}
 }

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -4,7 +4,7 @@
 pub(crate) mod decision;
 pub mod deserialize;
 pub mod expressions;
-mod initilization_context;
+pub(crate) mod initilization_context;
 pub(crate) mod resolved;
 pub(crate) mod view;
 
@@ -37,11 +37,12 @@ use crate::{
 	helpers::bytes::Bytes,
 	lower::{Lowerer, LowererComplete},
 	model::{
-		decision::{boolean::BoolDecision, integer::IntDecision},
+		decision::{PolarityScore, Tier, boolean::BoolDecision, integer::IntDecision},
 		initilization_context::ModelInitContext,
+		view::{boolean::BoolView, integer::IntView},
 	},
 	solver::{
-		IntLitMeaning,
+		IntLitMeaning, Polarity,
 		activation_list::ActivationAction,
 		queue::{PropagatorInfo, PropagatorQueue},
 	},
@@ -282,6 +283,7 @@ impl Model {
 		self.bool_vars.push(BoolDecision {
 			alias: None,
 			constraints: Vec::new(),
+			polarity: PolarityScore::default(),
 		});
 		debug_assert_eq!(var.idx(), self.bool_vars.len() - 1);
 		var.into()
@@ -429,6 +431,58 @@ impl Model {
 		self.int_vars[i as usize].constraints = constraints;
 	}
 
+	/// Record one unit of polarity evidence at the given `tier` stating that
+	/// the Boolean `view` should be pushed in direction `polarity` (where
+	/// [`Positive`](Polarity::Positive) means "prefer true").
+	///
+	/// Evidence is only recorded for views backed by a pure Boolean decision;
+	/// the literal's negation is folded into the sign.
+	pub(crate) fn observe_bool_polarity(
+		&mut self,
+		view: View<bool>,
+		tier: Tier,
+		polarity: Polarity,
+	) {
+		if let BoolView::Decision(l) = view.resolve_alias(self).into_inner().0 {
+			// A negated literal flips the desired direction onto the variable.
+			let polarity = if l.is_negated() { !polarity } else { polarity };
+			self.bool_vars[l.idx()].polarity.observe(tier, polarity);
+		}
+	}
+
+	/// Record one unit of polarity evidence at the given `tier` stating that
+	/// the integer `view` should be pushed in direction `polarity`. The view's
+	/// scale sign (and any Boolean negation) is folded onto the underlying
+	/// decision.
+	pub(crate) fn observe_int_polarity(
+		&mut self,
+		view: View<IntVal>,
+		tier: Tier,
+		polarity: Polarity,
+	) {
+		match view.resolve_alias(self).into_inner().0 {
+			IntView::Linear(lin) => {
+				let polarity = if lin.scale.get() < 0 {
+					!polarity
+				} else {
+					polarity
+				};
+				self.int_vars[lin.var.idx()]
+					.polarity
+					.observe(tier, polarity);
+			}
+			IntView::Bool(lin) => {
+				let polarity = if lin.scale.get() < 0 {
+					!polarity
+				} else {
+					polarity
+				};
+				self.observe_bool_polarity(lin.var, tier, polarity);
+			}
+			IntView::Const(_) => {}
+		}
+	}
+
 	/// Post a constraint to the model.
 	///
 	/// The constraint is added to the model. It will be enforced during
@@ -509,6 +563,22 @@ impl Model {
 		}
 		self.notify_advisors();
 		Ok(())
+	}
+
+	/// Invoke `f` with a [`ConRef`] for each constraint that the given integer
+	/// decision is subscribed to (i.e. that may involve it). The same
+	/// constraint may be reported more than once.
+	pub(crate) fn subscribed_constraints(&self, dec: Decision<IntVal>, mut f: impl FnMut(ConRef)) {
+		self.int_vars[dec.idx()].constraints.for_each_activated_by(
+			IntEvent::Fixed,
+			|act: ActivationAction<AdvRef, ConRef>| {
+				let con = match act {
+					ActivationAction::Enqueue(con) => con,
+					ActivationAction::Advise(adv) => self.advisors[adv.index()].con,
+				};
+				f(con);
+			},
+		);
 	}
 }
 

--- a/crates/huub/src/model/decision.rs
+++ b/crates/huub/src/model/decision.rs
@@ -3,6 +3,8 @@
 pub(crate) mod boolean;
 pub(crate) mod integer;
 
+use crate::solver::Polarity;
+
 /// A typed handle to a decision variable in a model.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Decision<T: DecisionReference>(pub(crate) T::Ref);
@@ -11,6 +13,66 @@ pub struct Decision<T: DecisionReference>(pub(crate) T::Ref);
 pub trait DecisionReference: private::Sealed + 'static {
 	/// The underlying reference type stored in [`Decision`].
 	type Ref;
+}
+
+/// Accumulated, signed polarity evidence for a single decision variable.
+///
+/// Positive weights indicate a preference for larger values, negative weights a
+/// preference for smaller values. The magnitude captures the quantity of
+/// evidence (e.g. the number of constraints, or a coefficient).
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub(crate) struct PolarityScore {
+	/// Signed evidence collected from the objective.
+	objective: i32,
+	/// Signed evidence collected from constraints.
+	constraint: i32,
+}
+
+/// The priority tier of a piece of polarity evidence collected during the
+/// [`analyze`](crate::constraints::Constraint::analyze) stage.
+///
+/// Evidence from the objective strictly dominates evidence from constraints:
+/// any nonzero objective signal decides the polarity on its own, and constraint
+/// evidence is only consulted when the objective tier is silent.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Tier {
+	/// Evidence derived from a constraint (lower priority).
+	Constraint,
+	/// Evidence derived from the objective (higher priority).
+	Objective,
+}
+
+impl PolarityScore {
+	/// Record one unit of evidence in the given `tier` for the given direction.
+	pub(crate) fn observe(&mut self, tier: Tier, polarity: Polarity) {
+		let field = match tier {
+			Tier::Objective => &mut self.objective,
+			Tier::Constraint => &mut self.constraint,
+		};
+		let weight = match polarity {
+			Polarity::Positive => 1,
+			Polarity::Negative => -1,
+		};
+		*field = field.saturating_add(weight);
+	}
+
+	/// Collapse the accumulated evidence into a single preferred direction, or
+	/// `None` if the evidence is balanced.
+	///
+	/// Objective evidence strictly dominates: the constraint tier is only
+	/// consulted when the objective tier is silent.
+	pub(crate) fn resolve(&self) -> Option<Polarity> {
+		let decisive = if self.objective != 0 {
+			self.objective
+		} else {
+			self.constraint
+		};
+		match decisive.signum() {
+			1 => Some(Polarity::Positive),
+			-1 => Some(Polarity::Negative),
+			_ => None,
+		}
+	}
 }
 
 /// Sealing helpers for model decision reference traits.

--- a/crates/huub/src/model/decision/boolean.rs
+++ b/crates/huub/src/model/decision/boolean.rs
@@ -11,7 +11,7 @@ use crate::{
 	constraints::ReasonBuilder,
 	model::{
 		Model,
-		decision::{Decision, DecisionReference, private},
+		decision::{Decision, DecisionReference, PolarityScore, private},
 		view::View,
 	},
 	solver::activation_list::ActivationActionS,
@@ -28,6 +28,8 @@ pub(crate) struct BoolDecision {
 	/// This list is used to enqueue the constraints for propagation when the
 	/// domain of the variable changes.
 	pub(crate) constraints: Vec<ActivationActionS>,
+	/// Accumulated polarity evidence collected during the analyze stage.
+	pub(crate) polarity: PolarityScore,
 }
 
 impl Decision<bool> {

--- a/crates/huub/src/model/decision/integer.rs
+++ b/crates/huub/src/model/decision/integer.rs
@@ -13,7 +13,7 @@ use crate::{
 	constraints::ReasonBuilder,
 	model::{
 		AdvRef, ConRef, Decision, Model,
-		decision::{DecisionReference, private},
+		decision::{DecisionReference, PolarityScore, private},
 		resolved::Resolved,
 		view::{View, boolean::BoolView, integer::IntView},
 	},
@@ -43,6 +43,14 @@ pub(crate) struct IntDecision {
 	/// This list is used to enqueue the constraints for propagation when the
 	/// domain of the variable changes.
 	pub(crate) constraints: ActivationList,
+	/// Whether the analyze stage requested the direct encoding (the `x = i`
+	/// equality literals) to be created eagerly.
+	pub(crate) eager_direct: bool,
+	/// Whether the analyze stage requested the order encoding (the `x < i`
+	/// inequality literals) to be created eagerly.
+	pub(crate) eager_order: bool,
+	/// Accumulated polarity evidence collected during the analyze stage.
+	pub(crate) polarity: PolarityScore,
 }
 
 impl Decision<IntVal> {
@@ -187,6 +195,9 @@ impl IntDecision {
 		Self {
 			domain: Domain::Domain(dom),
 			constraints: Default::default(),
+			eager_direct: false,
+			eager_order: false,
+			polarity: PolarityScore::default(),
 		}
 	}
 }

--- a/crates/huub/src/model/initilization_context.rs
+++ b/crates/huub/src/model/initilization_context.rs
@@ -3,15 +3,16 @@
 use crate::{
 	IntSet, IntVal,
 	actions::{
-		BoolInitActions, BoolInspectionActions, InitActions, IntInitActions, IntInspectionActions,
-		IntPropCond, ReasoningContext, ReasoningEngine,
+		BoolAnalyzeActions, BoolInitActions, BoolInspectionActions, InitActions, IntAnalyzeActions,
+		IntInitActions, IntInspectionActions, IntPropCond, ReasoningContext, ReasoningEngine,
 	},
 	model::{
 		AdvRef, Advisor, ConRef, Decision, Model,
+		decision::Tier,
 		resolved::Resolved,
 		view::{View, boolean::BoolView, integer::IntView},
 	},
-	solver::{IntLitMeaning, activation_list::ActivationAction, queue::PriorityLevel},
+	solver::{IntLitMeaning, Polarity, activation_list::ActivationAction, queue::PriorityLevel},
 };
 
 /// Wrapper around [`Model`] that knows the constraint being
@@ -32,6 +33,13 @@ pub struct ModelInitContext<'a> {
 	decision_enqueue: Option<bool>,
 }
 
+impl BoolAnalyzeActions<ModelInitContext<'_>> for Decision<bool> {
+	fn polarity(&self, ctx: &mut ModelInitContext<'_>, polarity: Polarity) {
+		ctx.model
+			.observe_bool_polarity((*self).into(), Tier::Constraint, polarity);
+	}
+}
+
 impl BoolInitActions<ModelInitContext<'_>> for Decision<bool> {
 	fn advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
 		self.resolve_alias(ctx.model).advise_when_fixed(ctx, data);
@@ -45,6 +53,25 @@ impl BoolInitActions<ModelInitContext<'_>> for Decision<bool> {
 impl BoolInspectionActions<ModelInitContext<'_>> for Decision<bool> {
 	fn val(&self, ctx: &ModelInitContext<'_>) -> Option<bool> {
 		self.val(ctx.model)
+	}
+}
+
+impl IntAnalyzeActions<ModelInitContext<'_>> for Decision<IntVal> {
+	fn polarity(&self, ctx: &mut ModelInitContext<'_>, polarity: Polarity) {
+		ctx.model
+			.observe_int_polarity((*self).into(), Tier::Constraint, polarity);
+	}
+
+	fn request_direct_eager(&self, ctx: &mut ModelInitContext<'_>) {
+		if let Some(dec) = self.resolve_alias(ctx.model).integer_decision() {
+			ctx.model.int_vars[dec.idx()].eager_direct = true;
+		}
+	}
+
+	fn request_order_eager(&self, ctx: &mut ModelInitContext<'_>) {
+		if let Some(dec) = self.resolve_alias(ctx.model).integer_decision() {
+			ctx.model.int_vars[dec.idx()].eager_order = true;
+		}
 	}
 }
 

--- a/crates/huub/src/model/view/boolean.rs
+++ b/crates/huub/src/model/view/boolean.rs
@@ -10,8 +10,8 @@ use std::{
 use crate::{
 	IntVal,
 	actions::{
-		BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions, IntPropCond,
-		PropagationActions,
+		BoolAnalyzeActions, BoolInspectionActions, BoolPropagationActions,
+		BoolSimplificationActions, IntPropCond, PropagationActions, ReasoningContext,
 	},
 	constraints::{Conflict, ReasonBuilder},
 	model::{
@@ -21,7 +21,7 @@ use crate::{
 		resolved::Resolved,
 		view::{DefaultView, View, private},
 	},
-	solver::{IntLitMeaning, activation_list::ActivationAction},
+	solver::{IntLitMeaning, Polarity, activation_list::ActivationAction},
 };
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -180,6 +180,20 @@ impl Add<IntVal> for View<bool> {
 	fn add(self, rhs: IntVal) -> Self::Output {
 		let me: View<IntVal> = self.into();
 		me + rhs
+	}
+}
+
+impl<Ctx> BoolAnalyzeActions<Ctx> for View<bool>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Decision<bool>: BoolAnalyzeActions<Ctx>,
+{
+	fn polarity(&self, ctx: &mut Ctx, polarity: Polarity) {
+		// Only views backed by a pure Boolean decision carry recordable
+		// evidence; the decision resolves any alias and folds its negation.
+		if let BoolView::Decision(l) = self.0 {
+			l.polarity(ctx, polarity);
+		}
 	}
 }
 

--- a/crates/huub/src/model/view/integer.rs
+++ b/crates/huub/src/model/view/integer.rs
@@ -10,8 +10,9 @@ use std::{
 use crate::{
 	IntSet, IntVal,
 	actions::{
-		BoolPropagationActions, IntDecisionActions, IntExplanationActions, IntInspectionActions,
-		IntPropagationActions, IntSimplificationActions, PropagationActions, ReasoningContext,
+		BoolPropagationActions, IntAnalyzeActions, IntDecisionActions, IntExplanationActions,
+		IntInspectionActions, IntPropagationActions, IntSimplificationActions, PropagationActions,
+		ReasoningContext,
 	},
 	constraints::{Conflict, ReasonBuilder, int_linear::IntEq},
 	model::{
@@ -20,7 +21,7 @@ use crate::{
 		resolved::Resolved,
 		view::{DefaultView, boolean::BoolView, private},
 	},
-	solver::IntLitMeaning,
+	solver::{IntLitMeaning, Polarity},
 	views::{LinearBoolView, LinearView},
 };
 
@@ -619,6 +620,37 @@ impl From<View<bool>> for View<IntVal> {
 impl From<i64> for View<IntVal> {
 	fn from(value: i64) -> Self {
 		View(IntView::Const(value))
+	}
+}
+
+impl<Ctx> IntAnalyzeActions<Ctx> for View<IntVal>
+where
+	Ctx: ReasoningContext + ?Sized,
+	LinearView<NonZero<IntVal>, IntVal, Decision<IntVal>>: IntAnalyzeActions<Ctx>,
+	LinearBoolView<NonZero<IntVal>, IntVal, View<bool>>: IntAnalyzeActions<Ctx>,
+{
+	fn polarity(&self, ctx: &mut Ctx, polarity: Polarity) {
+		match self.0 {
+			IntView::Const(c) => c.polarity(ctx, polarity),
+			IntView::Linear(lin) => lin.polarity(ctx, polarity),
+			IntView::Bool(lin) => lin.polarity(ctx, polarity),
+		}
+	}
+
+	fn request_direct_eager(&self, ctx: &mut Ctx) {
+		match self.0 {
+			IntView::Const(c) => c.request_direct_eager(ctx),
+			IntView::Linear(lin) => lin.request_direct_eager(ctx),
+			IntView::Bool(lin) => lin.request_direct_eager(ctx),
+		}
+	}
+
+	fn request_order_eager(&self, ctx: &mut Ctx) {
+		match self.0 {
+			IntView::Const(c) => c.request_order_eager(ctx),
+			IntView::Linear(lin) => lin.request_order_eager(ctx),
+			IntView::Bool(lin) => lin.request_order_eager(ctx),
+		}
 	}
 }
 

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -123,6 +123,23 @@ pub enum LiteralStrategy {
 /// Note that this checker will always return false.
 pub(crate) struct NoAssumptions;
 
+/// Preferred search direction for an integer decision variable.
+///
+/// The polarity is used to set the phase of the underlying Boolean literals so
+/// that the SAT solver tries the preferred direction first, and to decide to
+/// which bound an unfixed integer variable is fixed during solution checking.
+///
+/// The absence of a preferred direction is represented by `Option<Polarity>`'s
+/// `None`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum Polarity {
+	/// Prefer larger values (push the variable toward its upper bound).
+	Positive,
+	/// Prefer smaller values (push the variable toward its lower bound).
+	Negative,
+}
+
 /// The overarching search strategy used by the solver.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[non_exhaustive]
@@ -426,6 +443,17 @@ impl Not for IntLitMeaning {
 impl AssumptionChecker for NoAssumptions {
 	fn fail(&self, bv: View<bool>) -> bool {
 		matches!(bv.0, BoolView::Const(false))
+	}
+}
+
+impl Not for Polarity {
+	type Output = Self;
+
+	fn not(self) -> Self {
+		match self {
+			Polarity::Positive => Polarity::Negative,
+			Polarity::Negative => Polarity::Positive,
+		}
 	}
 }
 
@@ -1162,6 +1190,7 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 		#[builder(start_fn, into)] domain: IntSet,
 		#[builder(default)] mut order_literals: LiteralStrategy,
 		#[builder(default)] direct_literals: LiteralStrategy,
+		polarity: Option<Polarity>,
 	) -> View<IntVal> {
 		let orig_domain_len = domain.card();
 		assert_ne!(
@@ -1245,6 +1274,7 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 			domain,
 			order_encoding,
 			upper_bound,
+			polarity,
 		});
 		let iv = Decision((engine.state.int_vars.len() - 1) as u32);
 		// Create propagator activation list
@@ -1257,6 +1287,22 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 		// Setup the boolean to integer mapping
 		if let OrderStorage::Eager { storage, .. } = engine.state.int_vars[iv.idx()].order_encoding
 		{
+			// Apply phase hints to the (eager) order literals according to the
+			// polarity. Note that the positive literal represents `x < val`, so a
+			// positive polarity (prefer large values) phases the negation.
+			match polarity {
+				Some(Polarity::Positive) => {
+					for l in storage {
+						self.sat.phase(!Into::<RawLit>::into(l));
+					}
+				}
+				Some(Polarity::Negative) => {
+					for l in storage {
+						self.sat.phase(Into::<RawLit>::into(l));
+					}
+				}
+				None => {}
+			}
 			let mut vars = storage;
 			if let DirectStorage::Eager(vars2) = &engine.state.int_vars[iv.idx()].direct_encoding {
 				debug_assert_eq!(Into::<i32>::into(vars.end()) + 1, vars2.start().into());

--- a/crates/huub/src/solver/decision/integer.rs
+++ b/crates/huub/src/solver/decision/integer.rs
@@ -18,7 +18,7 @@ use crate::{
 		Trailed, TrailingActions,
 	},
 	solver::{
-		IntLitMeaning, Solver,
+		IntLitMeaning, Polarity, Solver,
 		decision::{Decision, DecisionReference, private},
 		engine::State,
 		solving_context::SolvingContext,
@@ -89,6 +89,11 @@ pub(crate) struct IntDecision {
 	///
 	/// Note that the lower bound is tracked within [`Self::order_encoding`].
 	pub(crate) upper_bound: Trailed<IntVal>,
+	/// The preferred search direction for the integer variable, if any.
+	///
+	/// This drives the phase of lazily-created order literals and the bound to
+	/// which the variable is fixed in `check_solution`.
+	pub(crate) polarity: Option<Polarity>,
 }
 
 /// The definition given to a lazily created literal.
@@ -1459,7 +1464,7 @@ mod tests {
 		IntSet, IntVal,
 		actions::{IntDecisionActions, IntInspectionActions},
 		solver::{
-			IntLitMeaning, LiteralStrategy, Solver,
+			IntLitMeaning, LiteralStrategy, Polarity, Solver, Status, Valuation,
 			decision::{Decision, integer::IntDecision},
 			view::{View, boolean::BoolView, integer::IntView},
 		},
@@ -1784,5 +1789,47 @@ mod tests {
 				.chain((2..=9).map(NotEq))
 				.chain(once(Less(10))),
 		);
+	}
+
+	/// An otherwise-unfixed lazy integer variable is fixed to the bound
+	/// preferred by its polarity during solution checking.
+	#[test]
+	fn polarity_check_solution_fixes_to_bound() {
+		for (polarity, expected) in [(Polarity::Positive, 10), (Polarity::Negative, 1)] {
+			let mut slv: Solver = Solver::default();
+			let x = slv.new_int_decision(1..=10).polarity(polarity).view();
+			let mut found = None;
+			let status = slv
+				.solve()
+				.on_solution(|sol| {
+					found = Some(Valuation::val(&x, sol));
+				})
+				.satisfy();
+			assert_eq!(status, Status::Satisfied);
+			assert_eq!(found, Some(expected), "polarity {polarity:?}");
+		}
+	}
+
+	/// With an eager order encoding, the phase hints make the first solution
+	/// take the bound preferred by the polarity.
+	#[test]
+	fn polarity_eager_phase_prefers_bound() {
+		for (polarity, expected) in [(Polarity::Positive, 4), (Polarity::Negative, 1)] {
+			let mut slv: Solver = Solver::default();
+			let x = slv
+				.new_int_decision(1..=4)
+				.order_literals(LiteralStrategy::Eager)
+				.polarity(polarity)
+				.view();
+			let mut found = None;
+			let status = slv
+				.solve()
+				.on_solution(|sol| {
+					found = Some(Valuation::val(&x, sol));
+				})
+				.satisfy();
+			assert_eq!(status, Status::Satisfied);
+			assert_eq!(found, Some(expected), "polarity {polarity:?}");
+		}
 	}
 }

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -40,7 +40,7 @@ use crate::{
 	constraints::{BoxedPropagator, Conflict, DeferredReason, Reason},
 	helpers::bytes::Bytes,
 	solver::{
-		IntLitMeaning, SearchStrategy, SwitchTrigger,
+		IntLitMeaning, Polarity, SearchStrategy, SwitchTrigger,
 		activation_list::{ActivationAction, ActivationActionS, ActivationList},
 		bool_to_int::BoolToIntMap,
 		branchers::{BoxedBrancher, Directive},
@@ -432,13 +432,28 @@ impl PropagatorExtension for Engine {
 					OrderStorage::Lazy(_)
 				));
 
-				// Ensure the lazy literal for the upper bound exists
-				let ub_lit = r.lit(&mut ctx, IntLitMeaning::Less(lb + 1));
-				if let BoolView::Lit(ub_lit) = ub_lit.0 {
-					let prev = ctx.state.trail.assign_lit(ub_lit.0);
-					debug_assert_eq!(prev, None);
+				// Fix the unfixed variable to the bound preferred by its polarity:
+				// a positive polarity fixes to the upper bound (by raising the
+				// lower bound), otherwise to the lower bound (by lowering the upper
+				// bound). Either way the required lazy literal is created.
+				match ctx.state.int_vars[r.idx()].polarity {
+					Some(Polarity::Positive) => {
+						let lb_lit = r.lit(&mut ctx, IntLitMeaning::GreaterEq(ub));
+						if let BoolView::Lit(lb_lit) = lb_lit.0 {
+							let prev = ctx.state.trail.assign_lit(lb_lit.0);
+							debug_assert_eq!(prev, None);
+						}
+						ctx.state.int_vars[r.idx()].notify_lower_bound(&mut ctx.state.trail, ub);
+					}
+					Some(Polarity::Negative) | None => {
+						let ub_lit = r.lit(&mut ctx, IntLitMeaning::Less(lb + 1));
+						if let BoolView::Lit(ub_lit) = ub_lit.0 {
+							let prev = ctx.state.trail.assign_lit(ub_lit.0);
+							debug_assert_eq!(prev, None);
+						}
+						ctx.state.int_vars[r.idx()].notify_upper_bound(&mut ctx.state.trail, lb);
+					}
 				}
-				ctx.state.int_vars[r.idx()].notify_upper_bound(&mut ctx.state.trail, lb);
 
 				let activation = mem::take(&mut ctx.state.int_activation[r.idx()]);
 				activation.for_each_activated_by(IntEvent::Fixed, |action| {

--- a/crates/huub/src/solver/solving_context.rs
+++ b/crates/huub/src/solver/solving_context.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::{self, Debug, Formatter};
 
-use pindakaas::solver::propagation::SolvingActions;
+use pindakaas::{Lit as RawLit, solver::propagation::SolvingActions};
 use tracing::trace;
 
 use crate::{
@@ -19,7 +19,7 @@ use crate::{
 	constraints::{Conflict, DeferredReason, Reason, ReasonBuilder},
 	helpers::bytes::Bytes,
 	solver::{
-		BoxedPropagator, IntLitMeaning,
+		BoxedPropagator, IntLitMeaning, Polarity,
 		decision::{Decision, integer::LazyLitDef},
 		engine::{Engine, LitPropagation, PropRef, State, trace_new_lit},
 		view::{View, boolean::BoolView},
@@ -112,9 +112,21 @@ impl<'a> BoolPropagationActions<SolvingContext<'a>> for Decision<bool> {
 impl IntDecisionActions<SolvingContext<'_>> for Decision<IntVal> {
 	fn lit(&self, ctx: &mut SolvingContext<'_>, meaning: IntLitMeaning) -> View<bool> {
 		let var = &mut ctx.state.int_vars[self.idx()];
+		let polarity = var.polarity;
 		let new_var = |def: LazyLitDef| {
 			// Create new variable
 			let v = ctx.slv.new_observed_var();
+			// Apply a phase hint to newly created (lazy) order literals according
+			// to the variable's polarity. The positive literal represents
+			// `x < val`, so a positive polarity (prefer large values) phases the
+			// negation. Direct (equality) literals are left unphased.
+			if matches!(def.meaning, IntLitMeaning::Less(_)) {
+				match polarity {
+					Some(Polarity::Positive) => ctx.slv.phase(!Into::<RawLit>::into(v)),
+					Some(Polarity::Negative) => ctx.slv.phase(v.into()),
+					None => {}
+				}
+			}
 			ctx.state.statistics.lazy_literals += 1;
 			ctx.state.trail.grow_to_boolvar(v);
 			trace_new_lit!(*self, def, v);

--- a/crates/huub/src/views/linear_bool_view.rs
+++ b/crates/huub/src/views/linear_bool_view.rs
@@ -15,14 +15,15 @@ use rangelist::IntervalIterator;
 use crate::{
 	IntSet, IntVal,
 	actions::{
-		BoolInspectionActions, BoolOperations, BoolPropagationActions, BoolSimplificationActions,
-		IntDecisionActions, IntExplanationActions, IntInspectionActions, IntPropagationActions,
-		IntSimplificationActions, PropagationActions, ReasoningContext,
+		BoolAnalyzeActions, BoolInspectionActions, BoolOperations, BoolPropagationActions,
+		BoolSimplificationActions, IntAnalyzeActions, IntDecisionActions, IntExplanationActions,
+		IntInspectionActions, IntPropagationActions, IntSimplificationActions, PropagationActions,
+		ReasoningContext,
 	},
 	constraints::ReasonBuilder,
 	helpers::{div_ceil, div_floor},
 	solver::{
-		IntLitMeaning,
+		IntLitMeaning, Polarity,
 		solution::{Solution, Valuation},
 	},
 	views::offset_view::OffsetView,
@@ -171,6 +172,32 @@ impl<Var> From<Var> for LinearBoolView<NonZero<IntVal>, IntVal, Var> {
 			offset: 0,
 			var,
 		}
+	}
+}
+
+impl<Ctx, Var> IntAnalyzeActions<Ctx> for LinearBoolView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Var: BoolAnalyzeActions<Ctx>,
+{
+	fn polarity(&self, ctx: &mut Ctx, polarity: Polarity) {
+		// The integer view is backed by a Boolean; a negative scale would flip
+		// the direction (the stored scale is kept positive, so this is a no-op
+		// in practice).
+		let polarity = if self.scale.is_negative() {
+			!polarity
+		} else {
+			polarity
+		};
+		self.var.polarity(ctx, polarity);
+	}
+
+	fn request_direct_eager(&self, _ctx: &mut Ctx) {
+		// Backed by a Boolean: there are no integer literals to create eagerly.
+	}
+
+	fn request_order_eager(&self, _ctx: &mut Ctx) {
+		// Backed by a Boolean: there are no integer literals to create eagerly.
 	}
 }
 

--- a/crates/huub/src/views/linear_view.rs
+++ b/crates/huub/src/views/linear_view.rs
@@ -13,13 +13,13 @@ use std::{
 use crate::{
 	IntSet, IntVal,
 	actions::{
-		IntDecisionActions, IntExplanationActions, IntInspectionActions, IntPropagationActions,
-		IntSimplificationActions, PropagationActions, ReasoningContext,
+		IntAnalyzeActions, IntDecisionActions, IntExplanationActions, IntInspectionActions,
+		IntPropagationActions, IntSimplificationActions, PropagationActions, ReasoningContext,
 	},
 	constraints::ReasonBuilder,
 	helpers::{div_ceil, div_floor},
 	solver::{
-		IntLitMeaning,
+		IntLitMeaning, Polarity,
 		solution::{Solution, Valuation},
 	},
 	views::offset_view::OffsetView,
@@ -175,6 +175,30 @@ impl<Var> From<OffsetView<IntVal, Var>> for LinearView<NonZero<IntVal>, IntVal, 
 impl<Var> From<Var> for LinearView<NonZero<IntVal>, IntVal, Var> {
 	fn from(var: Var) -> Self {
 		Self::new(NonZero::new(1).unwrap(), 0, var)
+	}
+}
+
+impl<Ctx, Var> IntAnalyzeActions<Ctx> for LinearView<NonZero<IntVal>, IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Var: IntAnalyzeActions<Ctx>,
+{
+	fn polarity(&self, ctx: &mut Ctx, polarity: Polarity) {
+		// A negative scale flips the desired direction onto the variable.
+		let polarity = if self.scale.is_negative() {
+			!polarity
+		} else {
+			polarity
+		};
+		self.var.polarity(ctx, polarity);
+	}
+
+	fn request_direct_eager(&self, ctx: &mut Ctx) {
+		self.var.request_direct_eager(ctx);
+	}
+
+	fn request_order_eager(&self, ctx: &mut Ctx) {
+		self.var.request_order_eager(ctx);
 	}
 }
 

--- a/crates/huub/src/views/offset_view.rs
+++ b/crates/huub/src/views/offset_view.rs
@@ -10,12 +10,12 @@ use std::{
 use crate::{
 	IntSet, IntVal,
 	actions::{
-		IntDecisionActions, IntExplanationActions, IntInspectionActions, IntPropagationActions,
-		ReasoningContext,
+		IntAnalyzeActions, IntDecisionActions, IntExplanationActions, IntInspectionActions,
+		IntPropagationActions, ReasoningContext,
 	},
 	constraints::ReasonBuilder,
 	solver::{
-		IntLitMeaning,
+		IntLitMeaning, Polarity,
 		solution::{Solution, Valuation},
 	},
 	views::linear_view::LinearView,
@@ -107,6 +107,25 @@ impl<Offset: Default, Var> From<Var> for OffsetView<Offset, Var> {
 			offset: Offset::default(),
 			var: value,
 		}
+	}
+}
+
+impl<Ctx, Var> IntAnalyzeActions<Ctx> for OffsetView<IntVal, Var>
+where
+	Ctx: ReasoningContext + ?Sized,
+	Var: IntAnalyzeActions<Ctx>,
+{
+	fn polarity(&self, ctx: &mut Ctx, polarity: Polarity) {
+		// The offset does not affect the desired direction.
+		self.var.polarity(ctx, polarity);
+	}
+
+	fn request_direct_eager(&self, ctx: &mut Ctx) {
+		self.var.request_direct_eager(ctx);
+	}
+
+	fn request_order_eager(&self, ctx: &mut Ctx) {
+		self.var.request_order_eager(ctx);
 	}
 }
 


### PR DESCRIPTION
Add an analysis that derives, per decision variable, whether the search
should prefer larger or smaller values, and use it to guide the SAT
solver's phase and the fixing of unfixed integer variables.
