### PR TITLE
fix: sound Hall-set explanation for domain-consistent alldifferent

### DIFF
--- a/crates/huub/src/constraints/int_unique/domain.rs
+++ b/crates/huub/src/constraints/int_unique/domain.rs
@@ -3,7 +3,7 @@
 //! [`IntUniqueDomain`]; this module file contains the propagator and its
 //! private graph/matching/Tarjan helpers.
 
-use std::cmp;
+use std::{cmp, mem, ops::Range};
 
 use rangelist::IntervalIterator;
 use rustc_hash::FxHashSet;
@@ -34,26 +34,48 @@ struct AugmentingPathScratch {
 /// rebuilt in [`IntUniqueDomain::compute_scc_closure_for_explain`].
 #[derive(Clone, Debug)]
 struct ClosureScratch {
-	/// Variable members `H` of the tight Hall set. Membership is marked in
-	/// [`Self::var_in`]; the list lets the marks be cleared in O(closure).
-	vars: Vec<usize>,
+	/// Decision members `H` of the tight Hall set. Membership is marked in
+	/// [`Self::dcn_in`]; the list lets the marks be cleared in O(closure).
+	dcns: Vec<usize>,
 	/// Value set `V` of the tight Hall set (marked in [`Self::val_in`]).
 	vals: Vec<usize>,
-	/// `var_in[v]` is `true` while variable `v` is in the down-closure being
+	/// `dcn_in[v]` is `true` while decision `v` is in the down-closure being
 	/// built (a re-entrancy-free dedup bitset).
-	var_in: Vec<bool>,
+	dcn_in: Vec<bool>,
 	/// `val_in[i]` is `true` while value index `i` is in the down-closure.
 	val_in: Vec<bool>,
+}
+
+/// The bipartite "decision <-> value" graph that Régin's algorithm operates on,
+/// together with the current maximum matching between the two sides.
+///
+/// All decision/value bookkeeping lives here: the decision list, the
+/// union-domain origin used to translate between integer values and right-side
+/// indices, and the matching tables. Algorithms (augmenting-path search,
+/// Tarjan, Hall-set reasoning) operate on this struct from the outside.
+#[derive(Clone, Debug)]
+struct DecisionValueMatching<I> {
+	/// Left side: the integer decision variables.
+	dcns: Vec<I>,
+	/// Lower bound of the union of all initial decision domains. The
+	/// right-side index `r` represents the integer value
+	/// `union_domain_lb + r`, for `r` in `0..n_values()`.
+	union_domain_lb: IntVal,
+	/// Matching: decision index -> value index.
+	dcn_to_val: Vec<Option<usize>>,
+	/// Matching: value index -> decision index. Sized at construction time to
+	/// the size of the union of initial decision domains.
+	val_to_dcn: Vec<Option<usize>>,
 }
 
 /// Domain-consistent propagator for the integer `unique` constraint.
 ///
 /// Implements Régin's bipartite-matching + Tarjan SCC algorithm (AAAI 1994):
-/// maintain a maximum matching from variables to values, repair it with
+/// maintain a maximum matching from decisions to values, repair it with
 /// BFS-augmenting paths after domain changes, then run Tarjan's SCC on the
 /// residual bipartite graph (with a single dummy node fanning out free
 /// values so the residual graph stays linear in size) and remove any value
-/// from a variable's domain whenever the variable and value land in
+/// from a decision's domain whenever the decision and value land in
 /// different SCCs.
 ///
 /// **References**
@@ -68,12 +90,12 @@ struct ClosureScratch {
 ///   Conference (ACSC 2012), CRPIT Volume 122, pages 115--124, 2012.
 #[derive(Clone, Debug)]
 pub struct IntUniqueDomain<I> {
-	/// Variables, values, and their current matching.
-	graph: VariableValueMatching<I>,
-	/// Set of variable indices whose domain has changed since the last
+	/// Decisions, values, and their current matching.
+	graph: DecisionValueMatching<I>,
+	/// Set of decision indices whose domain has changed since the last
 	/// propagation pass; cleared by `propagate` and `advise_of_backtrack`.
-	dirty_vars: FxHashSet<usize>,
-	/// Backtrackable partition of variable indices into current SCCs.
+	dirty_dcns: FxHashSet<usize>,
+	/// Backtrackable partition of decision indices into current SCCs.
 	partition: TrailedPartition,
 	/// Per-call scratch for augmenting-path search.
 	bfs: AugmentingPathScratch,
@@ -100,7 +122,7 @@ struct TarjanFrame {
 }
 
 /// Reusable scratch for Tarjan's SCC algorithm over a graph with `n` total
-/// nodes. `vars_buf` / `vals_buf` are sized for the bipartite use-case (one
+/// nodes. `dcns_buf` / `vals_buf` are sized for the bipartite use-case (one
 /// buffer per side); a single-bucket variant would suit a non-bipartite
 /// consumer.
 #[derive(Clone, Debug)]
@@ -124,31 +146,9 @@ struct TarjanScratch {
 	/// back on pop. Reuses one allocation across all DFS frames.
 	neighbours: Vec<usize>,
 	/// Scratch list of left nodes in the SCC currently being popped.
-	vars_buf: Vec<usize>,
+	dcns_buf: Vec<usize>,
 	/// Scratch list of right nodes in the SCC currently being popped.
 	vals_buf: Vec<usize>,
-}
-
-/// The bipartite "variable <-> value" graph that Régin's algorithm operates on,
-/// together with the current maximum matching between the two sides.
-///
-/// All variable/value bookkeeping lives here: the variable list, the
-/// union-domain origin used to translate between integer values and right-side
-/// indices, and the matching tables. Algorithms (augmenting-path search,
-/// Tarjan, Hall-set reasoning) operate on this struct from the outside.
-#[derive(Clone, Debug)]
-struct VariableValueMatching<I> {
-	/// Left side: the integer decision variables.
-	vars: Vec<I>,
-	/// Lower bound of the union of all initial variable domains. The
-	/// right-side index `r` represents the integer value
-	/// `union_domain_lb + r`, for `r` in `0..n_values()`.
-	union_domain_lb: IntVal,
-	/// Matching: variable index -> value index.
-	var_to_val: Vec<Option<usize>>,
-	/// Matching: value index -> variable index. Sized at construction time to
-	/// the size of the union of initial variable domains.
-	val_to_var: Vec<Option<usize>>,
 }
 
 impl AugmentingPathScratch {
@@ -162,92 +162,175 @@ impl AugmentingPathScratch {
 }
 
 impl ClosureScratch {
-	/// Create scratch for `n_vars` variables and `n_values` values.
-	fn new(n_vars: usize, n_values: usize) -> Self {
+	/// Clear the membership marks left by a down-closure computation, walking
+	/// the `dcns` and `vals` lists so only O(closure) entries are touched. The
+	/// `dcns` list is left populated (the caller still needs the member set);
+	/// `vals` is emptied. Afterwards both bitsets are all `false` again, ready
+	/// for the next [`IntUniqueDomain::compute_scc_closure_for_explain`].
+	fn clear_marks(&mut self) {
+		for &u in &self.dcns {
+			self.dcn_in[u] = false;
+		}
+		for &vi in &self.vals {
+			self.val_in[vi] = false;
+		}
+		self.vals.clear();
+	}
+
+	/// Create scratch for `n_dcns` decisions and `n_values` values.
+	fn new(n_dcns: usize, n_values: usize) -> Self {
 		Self {
-			vars: Vec::new(),
+			dcns: Vec::new(),
 			vals: Vec::new(),
-			var_in: vec![false; n_vars],
+			dcn_in: vec![false; n_dcns],
 			val_in: vec![false; n_values],
 		}
 	}
 }
 
+impl<I> DecisionValueMatching<I> {
+	/// Rewire the matching along a freshly discovered BFS-augmenting path
+	/// ending at `(end_dcn, end_val)`. Walks backwards through
+	/// `bfs_parent`, flipping each edge until it reaches the path's root
+	/// (a decision whose previous match was `None`).
+	fn augment_along_path(&mut self, end_dcn: usize, end_val: usize, bfs_parent: &[usize]) {
+		let mut cur_dcn = end_dcn;
+		let mut cur_val = end_val;
+		loop {
+			let prev_val = self.dcn_to_val[cur_dcn];
+			self.val_to_dcn[cur_val] = Some(cur_dcn);
+			self.dcn_to_val[cur_dcn] = Some(cur_val);
+			let Some(pv) = prev_val else {
+				break;
+			};
+			cur_val = pv;
+			let parent = bfs_parent[cur_dcn];
+			debug_assert_ne!(parent, usize::MAX, "BFS parent missing");
+			cur_dcn = parent;
+		}
+	}
+
+	/// Number of left-side nodes (decisions).
+	fn n_dcns(&self) -> usize {
+		self.dcns.len()
+	}
+
+	/// Number of right-side nodes (values in the union of initial domains).
+	fn n_values(&self) -> usize {
+		self.val_to_dcn.len()
+	}
+
+	/// Build an initially empty matching for the given decisions, probing each
+	/// one's bounds through `ctx` to size the value-side tables to the union of
+	/// initial decision domains.
+	fn new<C: ReasoningContext + ?Sized>(ctx: &mut C, dcns: Vec<I>) -> Self
+	where
+		I: IntInspectionActions<C>,
+	{
+		let n = dcns.len();
+		let mut lb = IntVal::MAX;
+		let mut ub = IntVal::MIN;
+		for v in &dcns {
+			let (l, u) = v.bounds(ctx);
+			lb = cmp::min(lb, l);
+			ub = cmp::max(ub, u);
+		}
+		debug_assert!(lb <= ub);
+		Self {
+			dcns,
+			union_domain_lb: lb,
+			dcn_to_val: vec![None; n],
+			val_to_dcn: vec![None; (ub - lb + 1) as usize],
+		}
+	}
+
+	/// Integer value at the given right-side index.
+	fn value_at(&self, right_idx: usize) -> IntVal {
+		self.union_domain_lb + right_idx as IntVal
+	}
+
+	/// Right-side index for a value already known to lie in
+	/// `[union_domain_lb, union_domain_lb + n_values())`.
+	fn value_index(&self, val: IntVal) -> usize {
+		(val - self.union_domain_lb) as usize
+	}
+}
+
 impl<I> IntUniqueDomain<I> {
-	/// Attempt to repair the matching for `start_var` (whose previously matched
+	/// Attempt to repair the matching for `start_dcn` (whose previously matched
 	/// value is no longer in its domain) by finding a BFS-augmenting path.
 	///
 	/// On success, rewires the matching along the discovered path and returns
 	/// `Ok(())`. On failure, restores the previous matching and returns
 	/// `Err(conflict)`. The conflict closure constructs a Hall-set explanation
-	/// from the BFS-visited variables, whose domain union has strictly fewer
-	/// values than variables.
+	/// from the BFS-visited decisions, whose domain union has strictly fewer
+	/// values than decisions.
 	fn find_augmenting_path<E>(
 		&mut self,
-		start_var: usize,
+		start_dcn: usize,
 		ctx: &mut E::PropagationContext<'_>,
 	) -> Result<(), E::Conflict>
 	where
 		E: ReasoningEngine,
 		I: IntSolverActions<E>,
 	{
-		let matched_val_idx = self.graph.var_to_val[start_var];
+		let matched_val_idx = self.graph.dcn_to_val[start_dcn];
 		if let Some(val_idx) = matched_val_idx {
-			self.graph.val_to_var[val_idx] = None;
-			self.graph.var_to_val[start_var] = None;
+			self.graph.val_to_dcn[val_idx] = None;
+			self.graph.dcn_to_val[start_dcn] = None;
 		}
 
 		self.bfs.queue.clear();
-		self.bfs.queue.push(start_var);
+		self.bfs.queue.push(start_dcn);
 		self.bfs.parent.fill(usize::MAX);
 		let mut queue_head = 0;
 		while queue_head < self.bfs.queue.len() {
-			let var_idx = self.bfs.queue[queue_head];
+			let dcn_idx = self.bfs.queue[queue_head];
 			queue_head += 1;
-			for val in self.graph.vars[var_idx].domain(ctx).iter().flatten() {
+			for val in self.graph.dcns[dcn_idx].domain(ctx).iter().flatten() {
 				let val_idx = self.graph.value_index(val);
-				if let Some(matched_var) = self.graph.val_to_var[val_idx] {
-					if self.bfs.parent[matched_var] == usize::MAX {
-						self.bfs.queue.push(matched_var);
-						self.bfs.parent[matched_var] = var_idx;
+				if let Some(matched_dcn) = self.graph.val_to_dcn[val_idx] {
+					if self.bfs.parent[matched_dcn] == usize::MAX {
+						self.bfs.queue.push(matched_dcn);
+						self.bfs.parent[matched_dcn] = dcn_idx;
 					}
 				} else {
 					self.graph
-						.augment_along_path(var_idx, val_idx, &self.bfs.parent);
+						.augment_along_path(dcn_idx, val_idx, &self.bfs.parent);
 					return Ok(());
 				}
 			}
 		}
 
 		// No augmenting path: restore the previous matching and signal conflict
-		// with a Hall-set explanation built from the BFS-visited variables.
+		// with a Hall-set explanation built from the BFS-visited decisions.
 		if let Some(val_idx) = matched_val_idx {
-			self.graph.val_to_var[val_idx] = Some(start_var);
-			self.graph.var_to_val[start_var] = Some(val_idx);
+			self.graph.val_to_dcn[val_idx] = Some(start_dcn);
+			self.graph.dcn_to_val[start_dcn] = Some(val_idx);
 		}
 
 		Err(ctx.declare_conflict(
 			move |ctx: &mut E::PropagationContext<'_>| -> Vec<<E as ReasoningEngine>::Atom> {
-				self.build_hall_set_reason(ctx, &self.bfs.queue, |var, ctx, meaning| {
-					var.lit(ctx, meaning)
+				self.build_hall_set_reason(ctx, &self.bfs.queue, |dcn, ctx, meaning| {
+					dcn.lit(ctx, meaning)
 				})
 			},
 		))
 	}
 
 	/// Create a new [`IntUniqueDomain`] propagator and post it in the solver.
-	pub fn post<E>(solver: &mut E, vars: Vec<I>)
+	pub fn post<E>(solver: &mut E, dcns: Vec<I>)
 	where
 		E: PostingActions + ?Sized,
 		I: IntSolverActions<Engine> + IntInspectionActions<E>,
 	{
-		let graph = VariableValueMatching::new(solver, vars);
-		let n = graph.n_vars();
+		let graph = DecisionValueMatching::new(solver, dcns);
+		let n = graph.n_dcns();
 		let n_values = graph.n_values();
 		let partition = TrailedPartition::new(solver, n);
 		solver.add_propagator(Box::new(Self {
 			graph,
-			dirty_vars: FxHashSet::default(),
+			dirty_dcns: FxHashSet::default(),
 			partition,
 			bfs: AugmentingPathScratch::new(n),
 			tarjan: TarjanScratch::new(n, n_values),
@@ -256,8 +339,8 @@ impl<I> IntUniqueDomain<I> {
 	}
 
 	/// Process the SCC rooted at `start_idx`: pop nodes off the DFS stack into
-	/// `tarjan.vars_buf` / `vals_buf`, partition the variables out of the live
-	/// SCC, and remove the SCC's values from any variable outside it.
+	/// `tarjan.dcns_buf` / `vals_buf`, partition the decisions out of the live
+	/// SCC, and remove the SCC's values from any decision outside it.
 	fn process_scc_root<E>(
 		&mut self,
 		start_idx: usize,
@@ -267,9 +350,9 @@ impl<I> IntUniqueDomain<I> {
 		E: ReasoningEngine,
 		I: IntSolverActions<E>,
 	{
-		let n_vars = self.graph.n_vars();
+		let n_dcns = self.graph.n_dcns();
 		let dummy = self.tarjan.dummy_node();
-		self.tarjan.vars_buf.clear();
+		self.tarjan.dcns_buf.clear();
 		self.tarjan.vals_buf.clear();
 
 		// Pop the SCC off the DFS stack into the two bitsets. The dummy node is
@@ -278,72 +361,72 @@ impl<I> IntUniqueDomain<I> {
 		loop {
 			let node = self.tarjan.dfs_stack.pop().expect("non-empty DFS stack");
 			self.tarjan.dfs_on_stack[node] = false;
-			if node < n_vars {
-				self.tarjan.vars_buf.push(node);
+			if node < n_dcns {
+				self.tarjan.dcns_buf.push(node);
 			} else if node != dummy {
-				self.tarjan.vals_buf.push(node - n_vars);
+				self.tarjan.vals_buf.push(node - n_dcns);
 			}
 			if node == start_idx {
 				break;
 			}
 		}
 
-		// Every popped SCC must contain at least one variable, because the
-		// 2-cycle construction makes every matched value share its variable's SCC.
-		// This is to avoid value-only SCC in classic Régin's algorithm,
-		// which would require a separate pass to filter out
+		// Every popped SCC must contain at least one decision, because the
+		// 2-cycle construction makes every matched value share its decision's SCC.
+		// This is to avoid value-only SCCs in classic Régin's algorithm,
+		// which would require a separate pass to filter out.
 		debug_assert!(
-			!self.tarjan.vars_buf.is_empty(),
-			"2-cycle construction guarantees every SCC contains a variable"
+			!self.tarjan.dcns_buf.is_empty(),
+			"2-cycle construction guarantees every SCC contains a decision"
 		);
 
-		// Move the SCC's variables into their own block. `split_off` keeps the
-		// SCC's vars in positions [new_root..orig_end); the *other* vars from
+		// Move the SCC's decisions into their own block. `split_off` keeps the
+		// SCC's decisions in positions [new_root..orig_end); the *other* decisions from
 		// the same original block now occupy [orig_root..new_root) — exactly
-		// the variables that still need this SCC's values stripped from them.
-		let (orig_root, new_scc_root) = self.partition.split_off(&self.tarjan.vars_buf, ctx);
+		// the decisions that still need this SCC's values stripped from them.
+		let (orig_root, new_scc_root) = self.partition.split_off(&self.tarjan.dcns_buf, ctx);
 		let Some(new_root) = new_scc_root else {
 			// The new SCC absorbed the entire original block — no outside
-			// variables to strip values from.
+			// decisions to strip values from.
 			return Ok(());
 		};
 
 		// `new_root` is the SCC's block root for both matched and unmatched
-		// values (a matched val's matched_var is in this SCC; for an unmatched
-		// val, any in-SCC var serves as the SCC representative). One scc_id
+		// values (a matched val's matched_dcn is in this SCC; for an unmatched
+		// val, any in-SCC decision serves as the SCC representative). One scc_id
 		// covers every value in the SCC.
 		let scc_id = new_root;
 		let val_reason = ctx.deferred_reason(scc_id as u64);
 		for &val_idx in self.tarjan.vals_buf.iter() {
 			let val = self.graph.value_at(val_idx);
 			for pos in orig_root..new_root {
-				let var_idx = self.partition.elements()[pos];
-				let var = self.graph.vars[var_idx].clone();
-				if !var.in_domain(ctx, val) {
+				let dcn_idx = self.partition.elements()[pos];
+				let dcn = self.graph.dcns[dcn_idx].clone();
+				if !dcn.in_domain(ctx, val) {
 					continue;
 				}
-				var.remove_val(ctx, val, val_reason)?;
+				dcn.remove_val(ctx, val, val_reason)?;
 			}
 		}
 		Ok(())
 	}
 
-	/// Iterative Tarjan DFS on the bipartite var/value residual graph, rooted
-	/// at `start_idx`. Uses an explicit heap work-stack ([`TarjanFrame`])
-	/// instead of native recursion, so the maximum DFS depth (up to `2 *
-	/// n_vars`) does not consume the call stack. When the root of a
-	/// non-trivial SCC is popped and the run already detected an SCC split,
+	/// Iterative Tarjan DFS on the bipartite decision/value residual graph,
+	/// rooted at `start_idx`. Uses an explicit heap work-stack
+	/// ([`TarjanFrame`]) instead of native recursion, so the maximum DFS depth
+	/// (up to `2 * n_dcns`) does not consume the call stack. When the root of
+	/// a non-trivial SCC is popped and the run already detected an SCC split,
 	/// delegates filtering to [`Self::process_scc_root`].
 	///
-	/// The implicit graph is constructed such that each variables and values
+	/// The implicit graph is constructed such that each decision and value
 	/// has a node together with a dummy node. There are three types of edges:
-	/// (1) If a variable is matched to a value, there is an arc from the
-	/// variable  node to the value node, and also a value node to a variable
+	/// (1) If a decision is matched to a value, there is an arc from the
+	/// decision node to the value node, and also a value node to a decision
 	/// node. (2) For each matched value, there is an arc from the dummy node
 	/// to the value node. (3) For each unmatched value, there is an arc from
 	/// the value node to the dummy node. Note that this construction is
 	/// slightly different from classical Regin's algorithm, but it guarantees
-	/// that every SCC contains at least one variable, so no value-only SCC can
+	/// that every SCC contains at least one decision, so no value-only SCC can
 	/// arise, and thus avoids the need for a separate SCC pass to filter out
 	/// value-only SCCs.
 	fn tarjan_dfs<E>(
@@ -366,8 +449,8 @@ impl<I> IntUniqueDomain<I> {
 		                  next_dfs_index: &mut usize,
 		                  n_left_visited: &mut usize,
 		                  ctx: &mut E::PropagationContext<'_>| {
-			let n_vars = this.graph.n_vars();
-			if node < n_vars {
+			let n_dncs = this.graph.n_dcns();
+			if node < n_dncs {
 				*n_left_visited += 1;
 			}
 			this.tarjan.dfs_stack.push(node);
@@ -378,26 +461,26 @@ impl<I> IntUniqueDomain<I> {
 
 			let frame_start = this.tarjan.neighbours.len();
 			let dummy = this.tarjan.dummy_node();
-			if node < n_vars {
+			if node < n_dncs {
 				// 2-cycle: edges to ALL domain values incl. the matched one, so
 				// every matched pair shares an SCC and no value-only SCC arises.
-				for val in this.graph.vars[node].domain(ctx).iter().flatten() {
+				for val in this.graph.dcns[node].domain(ctx).iter().flatten() {
 					let val_idx = this.graph.value_index(val);
-					this.tarjan.neighbours.push(n_vars + val_idx);
+					this.tarjan.neighbours.push(n_dncs + val_idx);
 				}
 			} else if node == dummy {
 				// Dummy: forwards every free value to all matched values. Built
 				// once per run (the dummy is visited at most once).
 				for vi in 0..this.graph.n_values() {
-					if this.graph.val_to_var[vi].is_some() {
-						this.tarjan.neighbours.push(n_vars + vi);
+					if this.graph.val_to_dcn[vi].is_some() {
+						this.tarjan.neighbours.push(n_dncs + vi);
 					}
 				}
 			} else {
-				let val_idx = node - n_vars;
-				if let Some(var_idx) = this.graph.val_to_var[val_idx] {
-					// Matched value: matching edge back to its variable.
-					this.tarjan.neighbours.push(var_idx);
+				let val_idx = node - n_dncs;
+				if let Some(dcn_idx) = this.graph.val_to_dcn[val_idx] {
+					// Matched value: matching edge back to its decision.
+					this.tarjan.neighbours.push(dcn_idx);
 				} else {
 					// Free value: a single edge to the shared dummy node, which
 					// fans out to every matched value on its behalf.
@@ -413,7 +496,7 @@ impl<I> IntUniqueDomain<I> {
 			});
 		};
 
-		let n_vars = self.graph.n_vars();
+		let n_dcns = self.graph.n_dcns();
 		push_frame(self, start_idx, next_dfs_index, n_left_visited, ctx);
 
 		while let Some(&TarjanFrame {
@@ -450,7 +533,7 @@ impl<I> IntUniqueDomain<I> {
 				// left nodes weren't reached from this root -> graph is not one
 				// single SCC. The counter avoids re-scanning `dfs_index` on every
 				// SCC-root pop.
-				if self.tarjan.low_link[frame.node] > 1 || *n_left_visited < n_vars {
+				if self.tarjan.low_link[frame.node] > 1 || *n_left_visited < n_dcns {
 					*scc_split_detected = true;
 				}
 				if *scc_split_detected {
@@ -487,9 +570,9 @@ impl<I> IntUniqueDomain<I> {
 	///
 	/// where each per-member group is exactly `dom(v) subseteq V`, for
 	/// `V = [dom_lb, dom_ub] \ holes` (the union of the member domains).
-	/// Because `|S|` distinct variables are pinned into the `|V| == |S|`
+	/// Because `|S|` distinct decisions are pinned into the `|V| == |S|`
 	/// values of `V` they exhaust it, so `R(S)` entails the explained literal:
-	/// `w != d` for any outside variable `w` and `d in V` (value removal), or
+	/// `w != d` for any outside decision `w` and `d in V` (value removal), or
 	/// `false` when `S` itself is the over-tight Hall set (UNSAT conflict).
 	///
 	/// This is the form Régin's algorithm requires for both UNSAT conflicts
@@ -514,7 +597,7 @@ impl<I> IntUniqueDomain<I> {
 		let mut dom_lb = IntVal::MAX;
 		let mut dom_ub = IntVal::MIN;
 		for &vid in members {
-			let (lb, ub) = self.graph.vars[vid].bounds(ctx);
+			let (lb, ub) = self.graph.dcns[vid].bounds(ctx);
 			dom_lb = cmp::min(dom_lb, lb);
 			dom_ub = cmp::max(dom_ub, ub);
 		}
@@ -523,7 +606,7 @@ impl<I> IntUniqueDomain<I> {
 		// Pass 2: union of member domains, window-indexed.
 		let mut union_bits = FxHashSet::default();
 		for &vid in members {
-			for val in self.graph.vars[vid].domain(ctx).iter().flatten() {
+			for val in self.graph.dcns[vid].domain(ctx).iter().flatten() {
 				union_bits.insert((val - dom_lb) as usize);
 			}
 		}
@@ -532,84 +615,86 @@ impl<I> IntUniqueDomain<I> {
 		// bitset's zero positions (no separate holes Vec).
 		let n_holes = window - union_bits.len();
 		let mut reason: Vec<A> = Vec::with_capacity(members.len() * (2 + n_holes));
-		for &vid in members {
-			let var = &self.graph.vars[vid];
-			reason.push(get_lit(var, ctx, IntLitMeaning::GreaterEq(dom_lb)));
-			reason.push(get_lit(var, ctx, IntLitMeaning::Less(dom_ub + 1)));
+		for &did in members {
+			let dcn = &self.graph.dcns[did];
+			reason.push(get_lit(dcn, ctx, IntLitMeaning::GreaterEq(dom_lb)));
+			reason.push(get_lit(dcn, ctx, IntLitMeaning::Less(dom_ub + 1)));
 			for i in dom_lb..=dom_ub {
 				if !union_bits.contains(&((i - dom_lb) as usize)) {
-					reason.push(get_lit(var, ctx, IntLitMeaning::NotEq(i)));
+					reason.push(get_lit(dcn, ctx, IntLitMeaning::NotEq(i)));
 				}
 			}
 		}
 		reason
 	}
 
-	/// Rebuild the down-closure of the SCC whose variable members occupy the
-	/// partition positions `block`, leaving the closed variable set `H` in
-	/// `closure.vars` and the value set `V` in `closure.vals`.
+	/// Rebuild the down-closure of the SCC whose decision members occupy the
+	/// partition positions `block`, leaving the closed decision set `H` in
+	/// `closure.dcns` and the value set `V` in `closure.vals`.
 	/// The closure is the tight Hall set used for explanation:
 	/// ```text
 	///   V := U_{h in H} dom(h)              // values any member can still take
-	///   H := H_scc U { match(v) : v in V }  // variables matched to those values
+	///   H := H_scc U { match(v) : v in V }  // decisions matched to those values
 	/// ```
-	/// computed to a least fixpoint from `H = {SCC variables}`. The matching is
+	/// computed to a least fixpoint from `H = {SCC decisions}`. The matching is
 	/// a bijection between `H` and `V`, so `|H| == |V|`. With `dom(h) subseteq
 	/// V` for every `h in H` (the first line at fixpoint) this makes the Hall
 	/// set tight: `|U_{h in H} dom(h)| == |H|`.
 	///
-	/// Seeding from the SCC's variables suffices: the 2-cycle graph keeps every
-	/// matched value inside its variable's SCC, and the shared dummy node fans
+	/// Seeding from the SCC's decisions suffices: the 2-cycle graph keeps every
+	/// matched value inside its decision's SCC, and the shared dummy node fans
 	/// out to every matched value, so neither an out-of-closure value nor a
 	/// free (unmatched) value is reachable without leaving the SCC.
-	fn compute_scc_closure_for_explain<C>(&mut self, ctx: &mut C, block: std::ops::Range<usize>)
+	fn compute_scc_closure_for_explain<C>(&mut self, ctx: &mut C, block: Range<usize>)
 	where
 		C: ReasoningContext,
 		I: IntInspectionActions<C>,
 	{
-		self.closure.vars.clear();
+		self.closure.dcns.clear();
 		self.closure.vals.clear();
 		for pos in block {
 			let u = self.partition.elements()[pos];
-			if !self.closure.var_in[u] {
-				self.closure.var_in[u] = true;
-				self.closure.vars.push(u);
+			if !self.closure.dcn_in[u] {
+				self.closure.dcn_in[u] = true;
+				self.closure.dcns.push(u);
 			}
 		}
 
 		let mut head = 0;
-		while head < self.closure.vars.len() {
-			let u = self.closure.vars[head];
+		while head < self.closure.dcns.len() {
+			let u = self.closure.dcns[head];
 			head += 1;
-			for val in self.graph.vars[u].domain(ctx).iter().flatten() {
+			for val in self.graph.dcns[u].domain(ctx).iter().flatten() {
 				let vi = self.graph.value_index(val);
 				if self.closure.val_in[vi] {
 					continue;
 				}
 				self.closure.val_in[vi] = true;
 				self.closure.vals.push(vi);
-				match self.graph.val_to_var[vi] {
-					Some(w) => {
-						if !self.closure.var_in[w] {
-							self.closure.var_in[w] = true;
-							self.closure.vars.push(w);
-						}
-					}
-					None => {
-						debug_assert!(false, "free value reachable from a proper SCC down-closure");
-					}
+				// Every value reachable in the down-closure is matched (see the
+				// method doc); a free value would make the Hall set non-tight.
+				let matched = self.graph.val_to_dcn[vi];
+				debug_assert!(
+					matched.is_some(),
+					"reached free value from a proper SCC down-closure"
+				);
+				if let Some(w) = matched
+					&& !self.closure.dcn_in[w]
+				{
+					self.closure.dcn_in[w] = true;
+					self.closure.dcns.push(w);
 				}
 			}
 		}
 	}
 
-	/// Phase 1 of `propagate`. For each dirty variable: repair its matching
+	/// Phase 1 of `propagate`. For each dirty decision: repair its matching
 	/// entry if its previous match left the domain, then either propagate the
 	/// "newly fixed" case (singleton domain -> strip its value from the rest of
 	/// its SCC) or mark the surrounding SCC as needing a Tarjan re-run.
 	///
 	/// Returns the set of SCC roots that need to be revisited in phase 2. Takes
-	/// the dirty set by reference (rather than reading `self.dirty_vars`) so
+	/// the dirty set by reference (rather than reading `self.dirty_dcns`) so
 	/// the caller can own the take/restore and guarantee the set is put back
 	/// on every exit path.
 	fn repair_matching_and_propagate_fixed<E>(
@@ -624,25 +709,25 @@ impl<I> IntUniqueDomain<I> {
 		let mut changed_scc = FxHashSet::default();
 		for &i in dirty.iter() {
 			let scc_id = self.partition.block_root(i, ctx);
-			let needs_augment = match self.graph.var_to_val[i] {
+			let needs_augment = match self.graph.dcn_to_val[i] {
 				None => true,
-				Some(val_idx) => !self.graph.vars[i].in_domain(ctx, self.graph.value_at(val_idx)),
+				Some(val_idx) => !self.graph.dcns[i].in_domain(ctx, self.graph.value_at(val_idx)),
 			};
 			if needs_augment {
 				self.find_augmenting_path::<E>(i, ctx)?;
 			}
 
-			// If the variable is now fixed, propagate the newly fixed event.
+			// If the decision is now fixed, propagate the newly fixed event.
 			// Otherwise, mark its involved SCC as dirty for phase 2.
-			if let Some(val) = self.graph.vars[i].val(ctx) {
+			if let Some(val) = self.graph.dcns[i].val(ctx) {
 				changed_scc.insert(scc_id);
 				let (orig_scc, new_scc) = self.partition.split_off(&[i], ctx);
 				if new_scc.is_some() {
 					let orig_scc_end = self.partition.block_end(orig_scc, ctx);
-					let reason_lit = self.graph.vars[i].lit(ctx, IntLitMeaning::Eq(val));
+					let reason_lit = self.graph.dcns[i].lit(ctx, IntLitMeaning::Eq(val));
 					for pos in orig_scc..orig_scc_end {
 						let idx = self.partition.elements()[pos];
-						let v = self.graph.vars[idx].clone();
+						let v = self.graph.dcns[idx].clone();
 						v.remove_val(ctx, val, [reason_lit.clone()].as_slice())?;
 					}
 					if orig_scc_end - orig_scc > 1 {
@@ -661,8 +746,8 @@ impl<I> IntUniqueDomain<I> {
 
 	/// Phase 2 of `propagate`. Runs Tarjan on every SCC root flagged in
 	/// `changed_scc`. Tarjan walks the residual bipartite graph and, for each
-	/// non-trivial SCC discovered, partitions the variables out and removes
-	/// the SCC's values from variables outside it.
+	/// non-trivial SCC discovered, partitions the decisions out and removes
+	/// the SCC's values from decisions outside it.
 	fn run_tarjan_on_changed_sccs<E>(
 		&mut self,
 		changed_scc: &FxHashSet<usize>,
@@ -678,10 +763,10 @@ impl<I> IntUniqueDomain<I> {
 		let mut scc_split_detected = false;
 		for &i in changed_scc.iter() {
 			let scc_end = self.partition.block_end(i, ctx);
-			for var_idx in i..scc_end {
-				if self.tarjan.dfs_index[var_idx] == 0 {
+			for dcn_idx in i..scc_end {
+				if self.tarjan.dfs_index[dcn_idx] == 0 {
 					self.tarjan_dfs::<E>(
-						var_idx,
+						dcn_idx,
 						&mut next_dfs_index,
 						&mut n_left_visited,
 						&mut scc_split_detected,
@@ -700,11 +785,11 @@ where
 	I: IntSolverActions<E>,
 {
 	fn advise_of_backtrack(&mut self, _: &mut E::NotificationContext<'_>) {
-		self.dirty_vars.clear();
+		self.dirty_dcns.clear();
 	}
 
-	/// When a variable's domain changes, mark it as dirty and only enqueue
-	/// propagation if its domain size is now less than the number of variables.
+	/// When a decision's domain changes, mark it as dirty and only enqueue
+	/// propagation if its domain size is now less than the number of decisions.
 	/// Larger domains cannot participate in any non-trivial Hall set, so there
 	/// is nothing to propagate.
 	fn advise_of_int_change(
@@ -715,9 +800,9 @@ where
 	) -> bool {
 		// safe to unwrap: `card()` only returns `None` if the number of steps would
 		// overflow `usize`
-		let domain_size = self.graph.vars[data as usize].domain(ctx).card().unwrap();
-		self.dirty_vars.insert(data as usize);
-		domain_size < self.graph.n_vars()
+		let domain_size = self.graph.dcns[data as usize].domain(ctx).card().unwrap();
+		self.dirty_dcns.insert(data as usize);
+		domain_size < self.graph.n_dcns()
 	}
 
 	fn explain(
@@ -730,7 +815,7 @@ where
 		let scc_end = self.partition.block_end(scc_id, ctx);
 
 		// Rebuild the SCC's down-closure from the restored partition block: a
-		// variable set `H` provably confined to an equal-sized value set `V` in
+		// decision set `H` provably confined to an equal-sized value set `V` in
 		// the current domains. Note that the raw SCC members alone are unsound:
 		// a member can still hold an out-of-SCC value (a cross-SCC edge that a
 		// downstream prune/backtrack left behind), making the Hall set non-tight and
@@ -738,35 +823,27 @@ where
 		// `|H| == |V|` by construction.
 		self.compute_scc_closure_for_explain(ctx, scc_id..scc_end);
 		debug_assert_eq!(
-			self.closure.vars.len(),
+			self.closure.dcns.len(),
 			self.closure.vals.len(),
 			"down-closure Hall set is not tight"
 		);
-
-		let members = std::mem::take(&mut self.closure.vars);
-		let reason = self.build_hall_set_reason(ctx, &members, |var, ctx, meaning| {
-			let (atom, _) = var.lit_relaxed(ctx, meaning);
+		let reason = self.build_hall_set_reason(ctx, &self.closure.dcns, |dcn, ctx, meaning| {
+			let (atom, _) = dcn.lit_relaxed(ctx, meaning);
 			atom
 		});
-
-		// Clear the closure marks (O(closure)) and hand the scratch vec back.
-		for &u in &members {
-			self.closure.var_in[u] = false;
-		}
-		for &vi in &self.closure.vals {
-			self.closure.val_in[vi] = false;
-		}
-		self.closure.vals.clear();
-		self.closure.vars = members;
+		// Reset the membership marks (O(closure)) so the bitsets are clean for
+		// the next explain. The `dcns`/`vals` lists are the only record of which
+		// entries were marked, so this must run after the reason is built.
+		self.closure.clear_marks();
 		reason
 	}
 
 	fn initialize(&mut self, ctx: &mut E::InitializationContext<'_>) {
-		for i in 0..self.graph.n_vars() {
-			self.dirty_vars.insert(i);
+		for i in 0..self.graph.n_dcns() {
+			self.dirty_dcns.insert(i);
 		}
 		ctx.set_priority(PriorityLevel::Low);
-		for (i, v) in self.graph.vars.iter().enumerate() {
+		for (i, v) in self.graph.dcns.iter().enumerate() {
 			v.advise_when(ctx, IntPropCond::Domain, i as u64);
 		}
 		ctx.advise_on_backtrack();
@@ -780,16 +857,16 @@ where
 		skip(self, ctx)
 	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationContext<'_>) -> Result<(), E::Conflict> {
-		// Phase 1: drain dirty variables, fix the matching, and collect the
+		// Phase 1: drain dirty decisions, fix the matching, and collect the
 		// set of SCC roots whose residual graph may have changed.
 		//
 		// Borrow the dirty set out so phase 1 can take `&mut self` while reading
 		// it. Put the emptied set back on every path, including on conflict from
 		// `?`, so its capacity is reused next round.
-		let mut dirty = std::mem::take(&mut self.dirty_vars);
+		let mut dirty = mem::take(&mut self.dirty_dcns);
 		let result = self.repair_matching_and_propagate_fixed(&dirty, ctx);
 		dirty.clear();
-		self.dirty_vars = dirty;
+		self.dirty_dcns = dirty;
 		let changed_scc = result?;
 
 		// Phase 2: re-run Tarjan on every SCC that changed in phase 1.
@@ -799,7 +876,7 @@ where
 
 impl TarjanScratch {
 	/// Index of the auxiliary "dummy" node in the residual graph: the single
-	/// slot immediately after the real (variable and value) nodes. Every free
+	/// slot immediately after the real (decision and value) nodes. Every free
 	/// (unmatched) value points at this node, which in turn points at every
 	/// matched value, keeping the free-value fanout linear in the number of
 	/// values rather than quadratic. It is not a real graph node: it is skipped
@@ -808,10 +885,10 @@ impl TarjanScratch {
 		self.dfs_on_stack.len() - 1
 	}
 
-	/// Create scratch sized to fit `n_vars` variable nodes and `n_values` value
+	/// Create scratch sized to fit `n_dcns` decision nodes and `n_values` value
 	/// nodes, plus the auxiliary dummy node (see [`Self::dummy_node`]).
-	fn new(n_vars: usize, n_values: usize) -> Self {
-		let n_slots = n_vars + n_values + 1;
+	fn new(n_dcns: usize, n_values: usize) -> Self {
+		let n_slots = n_dcns + n_values + 1;
 		Self {
 			dfs_stack: Vec::new(),
 			dfs_on_stack: vec![false; n_slots],
@@ -819,7 +896,7 @@ impl TarjanScratch {
 			low_link: vec![0; n_slots],
 			work_stack: Vec::new(),
 			neighbours: Vec::new(),
-			vars_buf: Vec::new(),
+			dcns_buf: Vec::new(),
 			vals_buf: Vec::new(),
 		}
 	}
@@ -837,74 +914,6 @@ impl TarjanScratch {
 	}
 }
 
-impl<I> VariableValueMatching<I> {
-	/// Rewire the matching along a freshly discovered BFS-augmenting path
-	/// ending at `(end_var, end_val)`. Walks backwards through
-	/// `bfs_parent`, flipping each edge until it reaches the path's root
-	/// (a variable whose previous match was `None`).
-	fn augment_along_path(&mut self, end_var: usize, end_val: usize, bfs_parent: &[usize]) {
-		let mut cur_var = end_var;
-		let mut cur_val = end_val;
-		loop {
-			let prev_val = self.var_to_val[cur_var];
-			self.val_to_var[cur_val] = Some(cur_var);
-			self.var_to_val[cur_var] = Some(cur_val);
-			let Some(pv) = prev_val else {
-				break;
-			};
-			cur_val = pv;
-			let parent = bfs_parent[cur_var];
-			debug_assert_ne!(parent, usize::MAX, "BFS parent missing");
-			cur_var = parent;
-		}
-	}
-
-	/// Number of right-side nodes (values in the union of initial domains).
-	fn n_values(&self) -> usize {
-		self.val_to_var.len()
-	}
-
-	/// Number of left-side nodes (variables).
-	fn n_vars(&self) -> usize {
-		self.vars.len()
-	}
-
-	/// Build an initially empty matching for the given variables, probing each
-	/// one's bounds through `ctx` to size the value-side tables to the union of
-	/// initial variable domains.
-	fn new<C: ReasoningContext + ?Sized>(ctx: &mut C, vars: Vec<I>) -> Self
-	where
-		I: IntInspectionActions<C>,
-	{
-		let n = vars.len();
-		let mut lb = IntVal::MAX;
-		let mut ub = IntVal::MIN;
-		for v in &vars {
-			let (l, u) = v.bounds(ctx);
-			lb = cmp::min(lb, l);
-			ub = cmp::max(ub, u);
-		}
-		debug_assert!(lb <= ub);
-		Self {
-			vars,
-			union_domain_lb: lb,
-			var_to_val: vec![None; n],
-			val_to_var: vec![None; (ub - lb + 1) as usize],
-		}
-	}
-
-	/// Integer value at the given right-side index.
-	fn value_at(&self, right_idx: usize) -> IntVal {
-		self.union_domain_lb + right_idx as IntVal
-	}
-
-	/// Right-side index for a value already known to lie in
-	/// `[union_domain_lb, union_domain_lb + n_values())`.
-	fn value_index(&self, val: IntVal) -> usize {
-		(val - self.union_domain_lb) as usize
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use itertools::Itertools;
@@ -918,14 +927,14 @@ mod tests {
 
 	#[test]
 	#[traced_test]
-	fn test_all_different_domain_deep_chain() {
+	fn test_domain_deep_chain() {
 		// Staircase that forces a long DFS over the residual graph: `x_i in
 		// {i, i+1}` for `i < N`, with the top pinned to `x_N = N`. All-different
 		// forces a downward cascade `x_i = i`, but reaching that fixpoint walks
 		// a chain whose length is proportional to `N`.
 		const N: IntVal = 300;
 		let mut slv = Solver::default();
-		let vars: Vec<_> = (1..=N)
+		let dcns: Vec<_> = (1..=N)
 			.map(|i| {
 				let dom = if i == N { N..=N } else { i..=i + 1 };
 				slv.new_int_decision(dom)
@@ -934,8 +943,8 @@ mod tests {
 					.view()
 			})
 			.collect();
-		IntUniqueDomain::post(&mut slv, vars.clone());
-		slv.assert_all_solutions(&vars, |sol| {
+		IntUniqueDomain::post(&mut slv, dcns.clone());
+		slv.assert_all_solutions(&dcns, |sol| {
 			sol.iter()
 				.enumerate()
 				.all(|(i, v)| *v == crate::solver::Value::Int(i as IntVal + 1))
@@ -944,7 +953,7 @@ mod tests {
 
 	#[test]
 	#[traced_test]
-	fn test_all_different_domain_filtering() {
+	fn test_domain_filtering() {
 		// Régin-style example: {1,2}, {1,2}, {1,2,3}. The Hall set {a,b} on
 		// {1,2} should prune 1 and 2 from c, leaving c = 3.
 		let mut slv = Solver::default();
@@ -971,50 +980,10 @@ mod tests {
 
 	#[test]
 	#[traced_test]
-	fn test_all_different_domain_hall_set_reason_soundness() {
-		// Regression: the Hall-set explanation must stay sound. When an SCC's
-		// values are pruned from outside variables, the reason is only valid if
-		// every Hall-set member is confined to the SCC's value set `V`. If a
-		// member still holds an out-of-`V` value (a residual edge left behind by a
-		// prune/backtrack), the Hall set is non-tight and the nogood is too weak,
-		// wrongly cutting feasible assignments. Minimizing `x[0]` below, the true
-		// optimum is 2 (witness `[2, 1, 4, 3, 7, 5, 8]`, all-different); the buggy
-		// propagator excluded `x[0] = 2` and proved 3.
-		let mut slv: Solver = Solver::default();
-		let domains: [&[IntVal]; 7] = [
-			&[2, 3, 4, 5, 6],
-			&[1, 2, 5],
-			&[2, 4],
-			&[1, 3, 7],
-			&[7],
-			&[2, 5, 7],
-			&[1, 3, 8],
-		];
-		let views: Vec<_> = domains
-			.iter()
-			.map(|d| {
-				slv.new_int_decision(IntSet::from_iter(d.iter().map(|&v| v..=v)))
-					.order_literals(LiteralStrategy::Eager)
-					.direct_literals(LiteralStrategy::Eager)
-					.view()
-			})
-			.collect();
-		IntUniqueDomain::post(&mut slv, views.clone());
-		let (status, opt) = slv.solve().minimize(views[0]);
-		assert_eq!(status, crate::solver::Status::Complete);
-		assert_eq!(
-			opt,
-			Some(2),
-			"unsound Hall-set reason: domain propagator proved a wrong optimum"
-		);
-	}
-
-	#[test]
-	#[traced_test]
-	fn test_all_different_domain_interior_hole() {
+	fn test_domain_interior_hole() {
 		// One test covering the distinguishing behaviours of the domain
 		// propagator at once:
-		// - The universe (1..=6) exceeds the variable count, so the matching leaves
+		// - The universe (1..=6) exceeds the decision count, so the matching leaves
 		//   free values (2, 5, 6) and the residual graph routes through the dummy node.
 		// - The Hall set {a, b} occupies {3, 4}, so domain consistency must remove the
 		//   *interior* values 3 and 4 from `e`, leaving the disconnected set {1, 2, 5,
@@ -1067,7 +1036,7 @@ mod tests {
 
 	#[test]
 	#[traced_test]
-	fn test_all_different_domain_sat() {
+	fn test_domain_sat() {
 		let mut slv = Solver::default();
 		let a = slv
 			.new_int_decision(1..=3)
@@ -1090,8 +1059,8 @@ mod tests {
 
 	#[test]
 	#[traced_test]
-	fn test_all_different_domain_unsat() {
-		// Three variables on {1,2}: Hall set, no matching exists.
+	fn test_domain_unsat() {
+		// Three decisions on {1,2}: Hall set, no matching exists.
 		let mut slv = Solver::default();
 		let a = slv
 			.new_int_decision(1..=2)
@@ -1110,5 +1079,52 @@ mod tests {
 			.view();
 		IntUniqueDomain::post(&mut slv, vec![a, b, c]);
 		slv.assert_unsatisfiable();
+	}
+
+	/// Regression: the Hall-set explanation must stay sound. When an SCC's
+	/// values are pruned from outside decisions, the reason is only valid if
+	/// every Hall-set member is confined to the SCC's value set `V`. If a
+	/// member still holds an out-of-`V` value (a residual edge left behind by a
+	/// prune/backtrack), the Hall set is non-tight and the nogood is too weak,
+	/// wrongly cutting feasible assignments. Minimizing `x[0]` below, the true
+	/// optimum is 2 (witness `[2, 1, 4, 3, 7, 5, 8]`, all-different); the buggy
+	/// propagator excluded `x[0] = 2` and proved 3.
+	///
+	/// Minimization (rather than enumeration) is what exercises the bug:
+	/// proving the optimum forces conflict analysis to request the deferred
+	/// SCC-pruning reason via `explain`, which is where the unsound Hall set
+	/// was built.
+	#[test]
+	#[traced_test]
+	fn test_hall_set_soundness() {
+		// The explicit type pins the `Sat` parameter, which the `minimize` call
+		// below (unlike the propagate/enumerate helpers) does not constrain.
+		let mut slv: Solver = Solver::default();
+		let domains: [&[IntVal]; 7] = [
+			&[2, 3, 4, 5, 6],
+			&[1, 2, 5],
+			&[2, 4],
+			&[1, 3, 7],
+			&[7],
+			&[2, 5, 7],
+			&[1, 3, 8],
+		];
+		let views: Vec<_> = domains
+			.iter()
+			.map(|d| {
+				slv.new_int_decision(IntSet::from_iter(d.iter().map(|&v| v..=v)))
+					.order_literals(LiteralStrategy::Eager)
+					.direct_literals(LiteralStrategy::Eager)
+					.view()
+			})
+			.collect();
+		IntUniqueDomain::post(&mut slv, views.clone());
+		let (status, opt) = slv.solve().minimize(views[0]);
+		assert_eq!(status, crate::solver::Status::Complete);
+		assert_eq!(
+			opt,
+			Some(2),
+			"unsound Hall-set reason: domain propagator proved a wrong optimum"
+		);
 	}
 }

--- a/crates/huub/src/constraints/int_unique/domain.rs
+++ b/crates/huub/src/constraints/int_unique/domain.rs
@@ -30,6 +30,22 @@ struct AugmentingPathScratch {
 	parent: Vec<usize>,
 }
 
+/// Reusable scratch for the explain-time down-closure: the tight Hall set
+/// rebuilt in [`IntUniqueDomain::compute_scc_closure_for_explain`].
+#[derive(Clone, Debug)]
+struct ClosureScratch {
+	/// Variable members `H` of the tight Hall set. Membership is marked in
+	/// [`Self::var_in`]; the list lets the marks be cleared in O(closure).
+	vars: Vec<usize>,
+	/// Value set `V` of the tight Hall set (marked in [`Self::val_in`]).
+	vals: Vec<usize>,
+	/// `var_in[v]` is `true` while variable `v` is in the down-closure being
+	/// built (a re-entrancy-free dedup bitset).
+	var_in: Vec<bool>,
+	/// `val_in[i]` is `true` while value index `i` is in the down-closure.
+	val_in: Vec<bool>,
+}
+
 /// Domain-consistent propagator for the integer `unique` constraint.
 ///
 /// Implements Régin's bipartite-matching + Tarjan SCC algorithm (AAAI 1994):
@@ -63,6 +79,8 @@ pub struct IntUniqueDomain<I> {
 	bfs: AugmentingPathScratch,
 	/// Per-call scratch for Tarjan SCC.
 	tarjan: TarjanScratch,
+	/// Per-call scratch for the explain-time down-closure (Hall-set rebuild).
+	closure: ClosureScratch,
 }
 
 /// One pending node in the explicit (heap-allocated) Tarjan DFS work-stack.
@@ -143,6 +161,18 @@ impl AugmentingPathScratch {
 	}
 }
 
+impl ClosureScratch {
+	/// Create scratch for `n_vars` variables and `n_values` values.
+	fn new(n_vars: usize, n_values: usize) -> Self {
+		Self {
+			vars: Vec::new(),
+			vals: Vec::new(),
+			var_in: vec![false; n_vars],
+			val_in: vec![false; n_values],
+		}
+	}
+}
+
 impl<I> IntUniqueDomain<I> {
 	/// Attempt to repair the matching for `start_var` (whose previously matched
 	/// value is no longer in its domain) by finding a BFS-augmenting path.
@@ -213,14 +243,15 @@ impl<I> IntUniqueDomain<I> {
 	{
 		let graph = VariableValueMatching::new(solver, vars);
 		let n = graph.n_vars();
-		let n_nodes = n + graph.n_values();
+		let n_values = graph.n_values();
 		let partition = TrailedPartition::new(solver, n);
 		solver.add_propagator(Box::new(Self {
 			graph,
 			dirty_vars: FxHashSet::default(),
 			partition,
 			bfs: AugmentingPathScratch::new(n),
-			tarjan: TarjanScratch::new(n_nodes),
+			tarjan: TarjanScratch::new(n, n_values),
+			closure: ClosureScratch::new(n, n_values),
 		}));
 	}
 
@@ -244,13 +275,11 @@ impl<I> IntUniqueDomain<I> {
 		// Pop the SCC off the DFS stack into the two bitsets. The dummy node is
 		// not a real graph node, so it is dropped (but still terminates the loop
 		// if it happens to be the SCC root).
-		let mut has_var_in_scc = false;
 		loop {
 			let node = self.tarjan.dfs_stack.pop().expect("non-empty DFS stack");
 			self.tarjan.dfs_on_stack[node] = false;
 			if node < n_vars {
 				self.tarjan.vars_buf.push(node);
-				has_var_in_scc = true;
 			} else if node != dummy {
 				self.tarjan.vals_buf.push(node - n_vars);
 			}
@@ -259,13 +288,14 @@ impl<I> IntUniqueDomain<I> {
 			}
 		}
 
-		// An SCC with no variable nodes does nothing useful: any matched value
-		// in this SCC would force its matched var to be in the SCC too (the
-		// matching edge is in the residual graph), and an unmatched value with
-		// no adjacent var has no support to remove from anywhere.
-		if !has_var_in_scc {
-			return Ok(());
-		}
+		// Every popped SCC must contain at least one variable, because the
+		// 2-cycle construction makes every matched value share its variable's SCC.
+		// This is to avoid value-only SCC in classic Régin's algorithm,
+		// which would require a separate pass to filter out
+		debug_assert!(
+			!self.tarjan.vars_buf.is_empty(),
+			"2-cycle construction guarantees every SCC contains a variable"
+		);
 
 		// Move the SCC's variables into their own block. `split_off` keeps the
 		// SCC's vars in positions [new_root..orig_end); the *other* vars from
@@ -304,6 +334,18 @@ impl<I> IntUniqueDomain<I> {
 	/// n_vars`) does not consume the call stack. When the root of a
 	/// non-trivial SCC is popped and the run already detected an SCC split,
 	/// delegates filtering to [`Self::process_scc_root`].
+	///
+	/// The implicit graph is constructed such that each variables and values
+	/// has a node together with a dummy node. There are three types of edges:
+	/// (1) If a variable is matched to a value, there is an arc from the
+	/// variable  node to the value node, and also a value node to a variable
+	/// node. (2) For each matched value, there is an arc from the dummy node
+	/// to the value node. (3) For each unmatched value, there is an arc from
+	/// the value node to the dummy node. Note that this construction is
+	/// slightly different from classical Regin's algorithm, but it guarantees
+	/// that every SCC contains at least one variable, so no value-only SCC can
+	/// arise, and thus avoids the need for a separate SCC pass to filter out
+	/// value-only SCCs.
 	fn tarjan_dfs<E>(
 		&mut self,
 		start_idx: usize,
@@ -337,12 +379,10 @@ impl<I> IntUniqueDomain<I> {
 			let frame_start = this.tarjan.neighbours.len();
 			let dummy = this.tarjan.dummy_node();
 			if node < n_vars {
-				// Variable: non-matching edges to the other values in its domain.
+				// 2-cycle: edges to ALL domain values incl. the matched one, so
+				// every matched pair shares an SCC and no value-only SCC arises.
 				for val in this.graph.vars[node].domain(ctx).iter().flatten() {
 					let val_idx = this.graph.value_index(val);
-					if this.graph.var_to_val[node] == Some(val_idx) {
-						continue;
-					}
 					this.tarjan.neighbours.push(n_vars + val_idx);
 				}
 			} else if node == dummy {
@@ -439,9 +479,18 @@ impl<I> IntUniqueDomain<I> {
 	///   `dom_ub = max_{v in S} ub(v)`,
 	///   `holes  = { x in [dom_lb, dom_ub] : x not in dom(v) for any v in S }`,
 	/// and emits, for each `v in S`: `v >= dom_lb`, `v <= dom_ub`, and `v != x`
-	/// for every `x in holes`. The reason pins each member into the shared
-	/// window minus the union's complement, so a Hall set of size `|S|`
-	/// occupying `|S|` values can be reconstructed from the reason alone.
+	/// for every `x in holes`. Equivalently, the emitted reason is the clause
+	///
+	/// ```text
+	///   R(S) = AND_{v in S} ( v >= dom_lb /\ v <= dom_ub /\ AND_{x in holes} v != x )
+	/// ```
+	///
+	/// where each per-member group is exactly `dom(v) subseteq V`, for
+	/// `V = [dom_lb, dom_ub] \ holes` (the union of the member domains).
+	/// Because `|S|` distinct variables are pinned into the `|V| == |S|`
+	/// values of `V` they exhaust it, so `R(S)` entails the explained literal:
+	/// `w != d` for any outside variable `w` and `d in V` (value removal), or
+	/// `false` when `S` itself is the over-tight Hall set (UNSAT conflict).
 	///
 	/// This is the form Régin's algorithm requires for both UNSAT conflicts
 	/// (no augmenting path) and value-removal explanations (SCC pruning).
@@ -494,6 +543,64 @@ impl<I> IntUniqueDomain<I> {
 			}
 		}
 		reason
+	}
+
+	/// Rebuild the down-closure of the SCC whose variable members occupy the
+	/// partition positions `block`, leaving the closed variable set `H` in
+	/// `closure.vars` and the value set `V` in `closure.vals`.
+	/// The closure is the tight Hall set used for explanation:
+	/// ```text
+	///   V := U_{h in H} dom(h)              // values any member can still take
+	///   H := H_scc U { match(v) : v in V }  // variables matched to those values
+	/// ```
+	/// computed to a least fixpoint from `H = {SCC variables}`. The matching is
+	/// a bijection between `H` and `V`, so `|H| == |V|`. With `dom(h) subseteq
+	/// V` for every `h in H` (the first line at fixpoint) this makes the Hall
+	/// set tight: `|U_{h in H} dom(h)| == |H|`.
+	///
+	/// Seeding from the SCC's variables suffices: the 2-cycle graph keeps every
+	/// matched value inside its variable's SCC, and the shared dummy node fans
+	/// out to every matched value, so neither an out-of-closure value nor a
+	/// free (unmatched) value is reachable without leaving the SCC.
+	fn compute_scc_closure_for_explain<C>(&mut self, ctx: &mut C, block: std::ops::Range<usize>)
+	where
+		C: ReasoningContext,
+		I: IntInspectionActions<C>,
+	{
+		self.closure.vars.clear();
+		self.closure.vals.clear();
+		for pos in block {
+			let u = self.partition.elements()[pos];
+			if !self.closure.var_in[u] {
+				self.closure.var_in[u] = true;
+				self.closure.vars.push(u);
+			}
+		}
+
+		let mut head = 0;
+		while head < self.closure.vars.len() {
+			let u = self.closure.vars[head];
+			head += 1;
+			for val in self.graph.vars[u].domain(ctx).iter().flatten() {
+				let vi = self.graph.value_index(val);
+				if self.closure.val_in[vi] {
+					continue;
+				}
+				self.closure.val_in[vi] = true;
+				self.closure.vals.push(vi);
+				match self.graph.val_to_var[vi] {
+					Some(w) => {
+						if !self.closure.var_in[w] {
+							self.closure.var_in[w] = true;
+							self.closure.vars.push(w);
+						}
+					}
+					None => {
+						debug_assert!(false, "free value reachable from a proper SCC down-closure");
+					}
+				}
+			}
+		}
 	}
 
 	/// Phase 1 of `propagate`. For each dirty variable: repair its matching
@@ -621,14 +728,37 @@ where
 	) -> Conjunction<E::Atom> {
 		let scc_id = data as usize;
 		let scc_end = self.partition.block_end(scc_id, ctx);
-		self.build_hall_set_reason(
-			ctx,
-			&self.partition.elements()[scc_id..scc_end],
-			|var, ctx, meaning| {
-				let (atom, _) = var.lit_relaxed(ctx, meaning);
-				atom
-			},
-		)
+
+		// Rebuild the SCC's down-closure from the restored partition block: a
+		// variable set `H` provably confined to an equal-sized value set `V` in
+		// the current domains. Note that the raw SCC members alone are unsound:
+		// a member can still hold an out-of-SCC value (a cross-SCC edge that a
+		// downstream prune/backtrack left behind), making the Hall set non-tight and
+		// the nogood too weak. The closure absorbs every such escape so
+		// `|H| == |V|` by construction.
+		self.compute_scc_closure_for_explain(ctx, scc_id..scc_end);
+		debug_assert_eq!(
+			self.closure.vars.len(),
+			self.closure.vals.len(),
+			"down-closure Hall set is not tight"
+		);
+
+		let members = std::mem::take(&mut self.closure.vars);
+		let reason = self.build_hall_set_reason(ctx, &members, |var, ctx, meaning| {
+			let (atom, _) = var.lit_relaxed(ctx, meaning);
+			atom
+		});
+
+		// Clear the closure marks (O(closure)) and hand the scratch vec back.
+		for &u in &members {
+			self.closure.var_in[u] = false;
+		}
+		for &vi in &self.closure.vals {
+			self.closure.val_in[vi] = false;
+		}
+		self.closure.vals.clear();
+		self.closure.vars = members;
+		reason
 	}
 
 	fn initialize(&mut self, ctx: &mut E::InitializationContext<'_>) {
@@ -678,10 +808,10 @@ impl TarjanScratch {
 		self.dfs_on_stack.len() - 1
 	}
 
-	/// Create scratch sized to fit `n_nodes` real graph nodes plus the
-	/// auxiliary dummy node (see [`Self::dummy_node`]).
-	fn new(n_nodes: usize) -> Self {
-		let n_slots = n_nodes + 1;
+	/// Create scratch sized to fit `n_vars` variable nodes and `n_values` value
+	/// nodes, plus the auxiliary dummy node (see [`Self::dummy_node`]).
+	fn new(n_vars: usize, n_values: usize) -> Self {
+		let n_slots = n_vars + n_values + 1;
 		Self {
 			dfs_stack: Vec::new(),
 			dfs_on_stack: vec![false; n_slots],
@@ -837,6 +967,46 @@ mod tests {
 		slv.assert_all_solutions(&[a, b, c], |sol| {
 			sol.iter().all_unique() && sol[2] == crate::solver::Value::Int(3)
 		});
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_all_different_domain_hall_set_reason_soundness() {
+		// Regression: the Hall-set explanation must stay sound. When an SCC's
+		// values are pruned from outside variables, the reason is only valid if
+		// every Hall-set member is confined to the SCC's value set `V`. If a
+		// member still holds an out-of-`V` value (a residual edge left behind by a
+		// prune/backtrack), the Hall set is non-tight and the nogood is too weak,
+		// wrongly cutting feasible assignments. Minimizing `x[0]` below, the true
+		// optimum is 2 (witness `[2, 1, 4, 3, 7, 5, 8]`, all-different); the buggy
+		// propagator excluded `x[0] = 2` and proved 3.
+		let mut slv: Solver = Solver::default();
+		let domains: [&[IntVal]; 7] = [
+			&[2, 3, 4, 5, 6],
+			&[1, 2, 5],
+			&[2, 4],
+			&[1, 3, 7],
+			&[7],
+			&[2, 5, 7],
+			&[1, 3, 8],
+		];
+		let views: Vec<_> = domains
+			.iter()
+			.map(|d| {
+				slv.new_int_decision(IntSet::from_iter(d.iter().map(|&v| v..=v)))
+					.order_literals(LiteralStrategy::Eager)
+					.direct_literals(LiteralStrategy::Eager)
+					.view()
+			})
+			.collect();
+		IntUniqueDomain::post(&mut slv, views.clone());
+		let (status, opt) = slv.solve().minimize(views[0]);
+		assert_eq!(status, crate::solver::Status::Complete);
+		assert_eq!(
+			opt,
+			Some(2),
+			"unsound Hall-set reason: domain propagator proved a wrong optimum"
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
The domain-consistent `int_unique` propagator (Régin SCC) produced an unsound Hall-set explanation. When an SCC's values were pruned from outside variables, the reason pinned each Hall-set member out of every value not in the SCC's value set `V` (Downing/Feydy/Stuckey Eq. 1). That is only valid when every member can only assigned values in `V`. However, a member in a discovered Régin SCC may still holds an out-of-`V` value, which makes the Hall set non-tight, so the nogood is too weak and can wrongly cut feasible assignments, which leads to an incorrect optimum.

Fix:
- Rebuild a tight Hall set as a down-closure when explaining: from the SCC's variables, repeatedly pull every value in a member's domain into `V` and the variable matched to each such value into the member set. This yields a bijective (|H| == |V|) Hall set whose pin literals are entailed, so the reason is sound by construction.
- Use the 2-cycle residual-graph construction (a variable keeps the edge to its matched value) so every matched pair shares an SCC and no value-only SCC can arise, removing the special-case that the previous code mis-handled.

Add `test_all_different_domain_hall_set_reason_soundness`: The pre-fix propagator proved 3 by excluding the feasible `x[0] = 2`. The fixed propagator proves 2.