### PR TITLE
fix: resolve linear constraints with no terms at posting time

### DIFF
--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -546,6 +546,12 @@ where
 	fn to_solver(&self, slv: &mut LoweringContext<'_>) -> Result<(), LoweringError> {
 		use Reification::*;
 
+		// Linear constraints should otherwise have been simplified.
+		debug_assert!(
+			self.terms.len() > 1,
+			"`IntLinear` must have at least two terms"
+		);
+
 		let terms = self.terms.iter().map(|&v| slv.solver_view(v)).collect_vec();
 		let r = self.reif.as_ref().map(|&r| {
 			slv.solver_view(match r {
@@ -677,6 +683,12 @@ where
 impl IntLinearLessEqBounds<OverflowPossible, solver::View<IntVal>> {
 	/// Create a new [`IntLinearLessEqBounds`] propagator and post it in the
 	/// solver.
+	///
+	/// # Panics
+	///
+	/// Panics if no terms are given. An empty linear constraint is a constant
+	/// comparison rather than a propagation problem, so the caller must
+	/// evaluate it directly instead of posting a propagator.
 	pub fn post<E>(
 		solver: &mut E,
 		vars: impl IntoIterator<Item = solver::View<IntVal>>,
@@ -697,6 +709,10 @@ impl IntLinearLessEqBounds<OverflowPossible, solver::View<IntVal>> {
 				}
 			})
 			.collect();
+		assert!(
+			!vars.is_empty(),
+			"`IntLinearLessEqBounds::post` must be given at least one term"
+		);
 
 		solver.add_propagator(Box::new(Self {
 			terms: vars.clone(),
@@ -810,6 +826,12 @@ where
 impl IntLinearLessEqImpBounds<OverflowPossible, solver::View<IntVal>, Decision<bool>> {
 	/// Create a new [`IntLinearLessEqImpBounds`] propagator and post it in the
 	/// solver.
+	///
+	/// # Panics
+	///
+	/// Panics if no terms are given. An empty linear constraint is a constant
+	/// comparison rather than a propagation problem, so the caller must
+	/// evaluate it directly instead of posting a propagator.
 	pub fn post<E>(
 		solver: &mut E,
 		vars: impl IntoIterator<Item = solver::View<IntVal>>,
@@ -838,6 +860,10 @@ impl IntLinearLessEqImpBounds<OverflowPossible, solver::View<IntVal>, Decision<b
 				}
 			})
 			.collect();
+		assert!(
+			!vars.is_empty(),
+			"`IntLinearLessEqImpBounds::post` must be given at least one term"
+		);
 
 		solver.add_propagator(Box::new(Self {
 			terms: vars.clone(),
@@ -850,6 +876,12 @@ impl IntLinearLessEqImpBounds<OverflowPossible, solver::View<IntVal>, Decision<b
 impl IntLinearNotEqImpValue<OverflowPossible, solver::View<IntVal>, Decision<bool>> {
 	/// Create a new [`IntLinearNotEqImpValue`] propagator and post it in the
 	/// solver.
+	///
+	/// # Panics
+	///
+	/// Panics if no terms are given. An empty linear constraint is a constant
+	/// comparison rather than a propagation problem, so the caller must
+	/// evaluate it directly instead of posting a propagator.
 	pub fn post<E>(
 		solver: &mut E,
 		vars: impl IntoIterator<Item = solver::View<IntVal>>,
@@ -885,6 +917,11 @@ impl IntLinearNotEqImpValue<OverflowPossible, solver::View<IntVal>, Decision<boo
 				}
 			})
 			.collect();
+		assert!(
+			!vars.is_empty(),
+			"`IntLinearNotEqImpValue::post` must be given at least one term"
+		);
+
 		let num_free = solver.new_trailed(vars.len() + 1);
 
 		if IntLinear::can_overflow(solver, &vars) || IntVal::try_from(violation).is_err() {
@@ -910,6 +947,12 @@ impl IntLinearNotEqImpValue<OverflowPossible, solver::View<IntVal>, Decision<boo
 impl IntLinearNotEqValue<OverflowPossible, solver::View<IntVal>> {
 	/// Create a new [`IntLinearNotEqImpValue`] propagator and post it in the
 	/// solver.
+	///
+	/// # Panics
+	///
+	/// Panics if no terms are given. An empty linear constraint is a constant
+	/// comparison rather than a propagation problem, so the caller must
+	/// evaluate it directly instead of posting a propagator.
 	pub fn post<E>(
 		solver: &mut E,
 		vars: impl IntoIterator<Item = solver::View<IntVal>>,
@@ -930,6 +973,11 @@ impl IntLinearNotEqValue<OverflowPossible, solver::View<IntVal>> {
 				}
 			})
 			.collect();
+		assert!(
+			!vars.is_empty(),
+			"`IntLinearNotEqValue::post` must be given at least one term"
+		);
+
 		let num_free = solver.new_trailed(vars.len());
 
 		if IntLinear::can_overflow(solver, &vars) || IntVal::try_from(violation).is_err() {

--- a/crates/huub/src/model/expressions.rs
+++ b/crates/huub/src/model/expressions.rs
@@ -27,7 +27,10 @@ pub use crate::model::expressions::{
 };
 use crate::{
 	IntSet, IntVal,
-	actions::{IntInspectionActions, IntPropagationActions, IntSimplificationActions},
+	actions::{
+		BoolPropagationActions, IntInspectionActions, IntPropagationActions,
+		IntSimplificationActions,
+	},
 	constraints::{
 		Conflict,
 		cumulative::CumulativeTimeTable,
@@ -248,6 +251,26 @@ impl Model {
 				}
 			}
 			terms.push(v.bounding_mul(self, k)?);
+		}
+
+		if terms.is_empty() {
+			// All variable terms cancelled out, so the constraint reduces to a
+			// comparison between the constant `0` and the (constant) `rhs`. Evaluate
+			// it directly, then either enforce it or fix the reification literal.
+			let satisfied = match comparator {
+				Comparator::NotEqual => 0 != rhs,
+				Comparator::Equal => 0 == rhs,
+				Comparator::Less => 0 < rhs,
+				Comparator::LessEqual => 0 <= rhs,
+				Comparator::GreaterEqual => 0 >= rhs,
+				Comparator::Greater => 0 > rhs,
+			};
+			return match reif {
+				None => satisfied.require(self, []),
+				Some(Reification::ReifiedBy(r)) => r.fix(self, satisfied, []),
+				Some(Reification::ImpliedBy(_)) if satisfied => Ok(()),
+				Some(Reification::ImpliedBy(r)) => r.fix(self, false, []),
+			};
 		}
 
 		let mut negate_terms = || -> Result<(), Conflict<View<bool>>> {
@@ -900,5 +923,44 @@ impl<'a, S: model_proposition_builder::State> ModelPropositionBuilder<'a, S> {
 		let res = self.self_receiver.new_bool_decision();
 		self.reified_by(res).post().unwrap();
 		res
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use expect_test::expect;
+
+	use crate::model::Model;
+
+	#[test]
+	fn test_empty_linear_implied_false() {
+		// `0 == 5` is false, so the half-reification literal `r` must be fixed to
+		// false (the model stays satisfiable).
+		let mut prb = Model::default();
+		let x = prb.new_int_decision(1..=5);
+		let r = prb.new_bool_decision();
+		prb.linear(x - x).eq(5).implied_by(r).post().unwrap();
+		prb.expect_solutions(&[r], expect!["false"]);
+	}
+
+	#[test]
+	fn test_empty_linear_reified_false() {
+		// `0 == 5` is false, so the reification literal `r` must be fixed to false
+		// and the model must remain satisfiable.
+		let mut prb = Model::default();
+		let x = prb.new_int_decision(1..=5);
+		let r = prb.new_bool_decision();
+		prb.linear(x - x).eq(5).reified_by(r).post().unwrap();
+		prb.expect_solutions(&[r], expect!["false"]);
+	}
+
+	#[test]
+	fn test_empty_linear_reified_true() {
+		// `0 == 0` is true, so the reification literal `r` must be fixed to true.
+		let mut prb = Model::default();
+		let x = prb.new_int_decision(1..=5);
+		let r = prb.new_bool_decision();
+		prb.linear(x - x).eq(0).reified_by(r).post().unwrap();
+		prb.expect_solutions(&[r], expect!["true"]);
 	}
 }


### PR DESCRIPTION
If every term of a linear constraint cancels out, the constraint reduces
to a comparison between two constants. These were previously lowered into
propagators with an empty term list.
`Model::linear` now rewrites this when the constraint is posted.
The solver-level `IntLinear*::post` functions now assert that they are
given at least one term.
