### PR TITLE
fix: emit Fixed event when bound tightening collapses a gapped domain

### DIFF
--- a/crates/huub/src/constraints/int_unique.rs
+++ b/crates/huub/src/constraints/int_unique.rs
@@ -187,4 +187,32 @@ mod tests {
 
 		assert!(prb.unique(prev.iter().copied()).post().is_err());
 	}
+
+	#[test]
+	#[traced_test]
+	fn test_lowering_gapped_fixed_sound() {
+		use itertools::Itertools;
+
+		use crate::solver::Solver;
+
+		let mut prb = Model::default();
+		let vars: Vec<_> = [
+			IntSet::from_iter([1..=2, 4..=6]),
+			IntSet::from_iter([1..=1, 3..=4, 6..=6]),
+			IntSet::from_iter([2..=2, 5..=5]),
+			IntSet::from_iter([3..=3, 5..=5]),
+			IntSet::from_iter([3..=6]),
+			(2..=2).into(),
+		]
+		.into_iter()
+		.map(|domain| prb.new_int_decision(domain))
+		.collect();
+		prb.unique(vars.iter().copied())
+			.post()
+			.expect("post failed");
+
+		let (mut slv, map): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");
+		let views: Vec<_> = vars.iter().map(|&v| map.get(&mut slv, v)).collect();
+		slv.assert_all_solutions(&views, |sol| sol.iter().all_unique());
+	}
 }

--- a/crates/huub/src/model/decision/integer.rs
+++ b/crates/huub/src/model/decision/integer.rs
@@ -307,16 +307,17 @@ impl Resolved<Decision<IntVal>> {
 		if *dom == diff {
 			return Ok(());
 		}
-		if diff.card() == Some(1) {
-			let val = *diff.min().unwrap();
-			ctx.int_vars[self.idx()].domain = Domain::Alias(val.into());
+		let min = *diff.min().unwrap();
+		let max = *diff.max().unwrap();
+		if min == max {
+			ctx.int_vars[self.idx()].domain = Domain::Alias(min.into());
 			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
 		} else {
 			let entry = ctx.int_events.entry(self.0.0).or_insert(IntEvent::Domain);
-			if dom.min().unwrap() != diff.min().unwrap() {
+			if *dom.min().unwrap() != min {
 				*entry += IntEvent::LowerBound;
 			}
-			if dom.max().unwrap() != diff.max().unwrap() {
+			if *dom.max().unwrap() != max {
 				*entry += IntEvent::UpperBound;
 			}
 
@@ -377,16 +378,17 @@ impl Resolved<Decision<IntVal>> {
 		} else if *dom == intersect {
 			return Ok(());
 		}
-		if intersect.card() == Some(1) {
-			let val = *intersect.min().unwrap();
-			ctx.int_vars[self.idx()].domain = Domain::Alias(val.into());
+		let min = *intersect.min().unwrap();
+		let max = *intersect.max().unwrap();
+		if min == max {
+			ctx.int_vars[self.idx()].domain = Domain::Alias(min.into());
 			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
 		} else {
 			let entry = ctx.int_events.entry(self.0.0).or_insert(IntEvent::Domain);
-			if dom.min().unwrap() != intersect.min().unwrap() {
+			if *dom.min().unwrap() != min {
 				*entry += IntEvent::LowerBound;
 			}
-			if dom.max().unwrap() != intersect.max().unwrap() {
+			if *dom.max().unwrap() != max {
 				*entry += IntEvent::UpperBound;
 			}
 
@@ -412,15 +414,16 @@ impl Resolved<Decision<IntVal>> {
 		} else if val < *dom.min().unwrap() {
 			return Err(ctx.create_conflict(View(BoolView::IntLess(self.0, val + 1)), reason));
 		}
-		if val != *dom.min().unwrap() {
-			dom.tighten_max(val);
+		dom.tighten_max(val);
+		let min = *dom.min().unwrap();
+		if min == *dom.max().unwrap() {
+			def.domain = Domain::Alias(min.into());
+			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
+		} else {
 			ctx.int_events
 				.entry(self.0.0)
 				.and_modify(|v| *v += IntEvent::UpperBound)
 				.or_insert(IntEvent::UpperBound);
-		} else {
-			def.domain = Domain::Alias(val.into());
-			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
 		};
 		Ok(())
 	}
@@ -442,15 +445,16 @@ impl Resolved<Decision<IntVal>> {
 		} else if val > *dom.max().unwrap() {
 			return Err(ctx.create_conflict(View(BoolView::IntGreaterEq(self.0, val)), reason));
 		}
-		if val != *dom.max().unwrap() {
-			dom.tighten_min(val);
+		dom.tighten_min(val);
+		let min = *dom.min().unwrap();
+		if min == *dom.max().unwrap() {
+			def.domain = Domain::Alias(min.into());
+			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
+		} else {
 			ctx.int_events
 				.entry(self.0.0)
 				.and_modify(|e| *e += IntEvent::LowerBound)
 				.or_insert(IntEvent::LowerBound);
-		} else {
-			def.domain = Domain::Alias(val.into());
-			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
 		};
 		Ok(())
 	}


### PR DESCRIPTION
Tightening a bound on a gapped domain (e.g. {3,5} to max 4 -> {3}) can
fix a variable even when the bound value differs from the opposite bound.
The old Model notification logic missed this, so value-based propagators
were never notified.
