### PR TITLE
perf: enable override feature for mimalloc to enable the allocator in C

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ expect-test = "1.5.1"
 flatzinc-serde = { version = "0.5.1" }
 humantime = "2.3.0"
 itertools = "0.15.0"
-mimalloc = "0.1.52"
+mimalloc = { version = "0.1.52", features = ["override"] }
 pindakaas = { version = "0.5.1", features = ["external-propagation"] }
 rangelist = "0.5.0"
 rustc-hash = "2.1.2"


### PR DESCRIPTION
Before the `cc` compiled dependencies would still use the system
allocator
