### PR TITLE
Reason allocation optimization within `Engine`

### DIFF
--- a/crates/huub/src/actions.rs
+++ b/crates/huub/src/actions.rs
@@ -20,7 +20,7 @@ pub use crate::actions::{
 	},
 };
 use crate::{
-	constraints::{BoxedPropagator, Constraint, DeferredReason, ReasonBuilder},
+	constraints::{BoxedPropagator, Constraint},
 	helpers::bytes::Bytes,
 };
 
@@ -40,9 +40,22 @@ pub trait DecisionActions: TrailingActions {
 	fn num_conflicts(&self) -> u64;
 }
 
+/// A reason sink that additionally lets a propagator *defer* a reason: instead
+/// of creating it immediately, it records that the reason is to be computed on
+/// demand by the current propagator's
+/// [`explain`](crate::constraints::Propagator::explain) (given `data`).
+///
+/// These actions are only available to [`PropagationContext`]s that are given
+/// to [`Propagator`](crate::constraints::Propagator) implementations.
+pub trait DeferReasonActions<Atom>: ReasonActions<Atom> {
+	/// Defer this reason to the current propagator, which will compute it using
+	/// `data` when the reason is needed.
+	fn defer(&mut self, data: u64);
+}
+
 /// Actions that can be performed when posting propagators to the
 /// [`Solver`](crate::solver::Solver).
-pub trait PostingActions: ConstructionActions + ReasoningContext {
+pub trait PostingActions: ConstructionActions + PropagationContext {
 	/// Add a new clause to be enforced by the solver.
 	fn add_clause(
 		&mut self,
@@ -55,31 +68,38 @@ pub trait PostingActions: ConstructionActions + ReasoningContext {
 
 /// General actions that can be performed in
 /// [`ReasoningEngine::PropagationContext`].
-pub trait PropagationActions: DecisionActions + ReasoningContext {
-	/// Declare that the given reason, seen as a conjunction of atoms,
-	/// represents a conflict in the current state, requiring backtracking.
+pub trait PropagationActions: DecisionActions + PropagationContext {
+	/// Declare that the reason built by the given closure represents a conflict
+	/// in the current state, requiring backtracking.
 	///
 	/// Note that it is generally recommended to use this method only when
 	/// integer or Boolean propagation methods do not seem relevant.
-	fn declare_conflict(&mut self, reason: impl ReasonBuilder<Self>) -> Self::Conflict;
+	fn declare_conflict(
+		&mut self,
+		reason: impl FnOnce(&mut Self, &mut Self::ReasonSink<'_>),
+	) -> Self::Conflict;
+}
 
-	/// Create a placeholder reason that will cause the solver to call the
-	/// propagator's [`crate::constraints::Propagator::explain`] method when the
-	/// reason is needed.
-	fn deferred_reason(&self, data: u64) -> DeferredReason;
+/// A context that can raise conflicts and build reasons for the changes it
+/// makes.
+///
+/// This extends [`ReasoningContext`] with the
+/// [`Conflict`](PropagationContext::Conflict) it can raise and the
+/// [`ReasonSink`](PropagationContext::ReasonSink) into which a reason closure
+/// pushes its atoms.
+pub trait PropagationContext: ReasoningContext {
+	/// Type used to represent a conflict that occurs during propagation.
+	type Conflict;
+
+	/// The sink into which a reason closure pushes the atoms of a reason while
+	/// it is being built in this context.
+	type ReasonSink<'a>: ReasonActions<Self::Atom>;
 }
 
 /// Actions for building the explanation of a propagation: the conjunction of
 /// reason atoms that imply the change being explained (see
 /// [`Propagator::explain`](crate::constraints::Propagator::explain)).
-pub trait ReasonActions<Atom> {
-	/// Add several reason atoms to the explanation.
-	fn extend(&mut self, atoms: impl IntoIterator<Item = Atom>) {
-		for atom in atoms {
-			self.push(atom);
-		}
-	}
-
+pub trait ReasonActions<Atom>: Extend<Atom> {
 	/// Add a reason atom to the explanation.
 	fn push(&mut self, atom: Atom);
 
@@ -97,8 +117,6 @@ pub trait ReasonActions<Atom> {
 pub trait ReasoningContext {
 	/// Type used to represent an atom in a reason for propagation.
 	type Atom: BoolOperations + Not<Output = Self::Atom>;
-	/// Type used to represent a conflict that occurs during propagation.
-	type Conflict;
 }
 
 /// Trait for environments that support constraint propagation and decision
@@ -110,26 +128,31 @@ pub trait ReasoningEngine {
 	type Conflict;
 
 	/// The context given to the constraint propagator when they are asked to
-	/// explain a reason for a change they made using
-	/// [`PropagationActions::deferred_reason`].
-	type ExplanationContext<'a>: ReasoningContext<Atom = Self::Atom, Conflict = Self::Conflict>
-		+ TrailingActions;
+	/// explain a reason for a change they deferred with
+	/// [`DeferReasonActions::defer`].
+	type ExplanationContext<'a>: ReasoningContext<Atom = Self::Atom> + TrailingActions;
 	/// The context given to constraint propagators to attach themselves to
 	/// changes in the state of the reasoning engine or decision variables.
-	type InitializationContext<'a>: ReasoningContext<Atom = Self::Atom, Conflict = Self::Conflict>
-		+ InitActions;
+	type InitializationContext<'a>: ReasoningContext<Atom = Self::Atom> + InitActions;
 	/// The context given to constraint propagators when they are advised of a
 	/// change in the state of the reasoning engine or decision variables.
-	type NotificationContext<'a>: ReasoningContext<Atom = Self::Atom, Conflict = Self::Conflict>
-		+ TrailingActions;
+	type NotificationContext<'a>: ReasoningContext<Atom = Self::Atom> + TrailingActions;
 	/// The context given to constraint propagators when they are asked to
 	/// propagate changes based on the constraint they enforce.
-	type PropagationContext<'a>: ReasoningContext<Atom = Self::Atom, Conflict = Self::Conflict>
-		+ PropagationActions<Atom = Self::Atom, Conflict = Self::Conflict>;
+	type PropagationContext<'a>: for<'b> PropagationContext<
+			Atom = Self::Atom,
+			Conflict = Self::Conflict,
+			ReasonSink<'b>: DeferReasonActions<Self::Atom>,
+		> + PropagationActions<Atom = Self::Atom, Conflict = Self::Conflict>;
 
-	/// A sink for the conjunctive reason atoms emitted by
-	/// [`Propagator::explain`](crate::constraints::Propagator::explain) that
-	/// imply the propagated literal.
+	/// The sink given to
+	/// [`Propagator::explain`](crate::constraints::Propagator::explain)
+	/// to receive the conjunction of reason atoms that imply the propagated
+	/// atom.
+	///
+	/// Unlike the propagation context's reason sink, an explanation is always
+	/// eager and can never defer so this is only a [`ReasonActions`], and not a
+	/// [`DeferReasonActions`].
 	type ReasonSink<'a>: ReasonActions<Self::Atom>;
 }
 
@@ -174,10 +197,6 @@ pub trait TrailingActions {
 }
 
 impl<Atom> ReasonActions<Atom> for Vec<Atom> {
-	fn extend(&mut self, atoms: impl IntoIterator<Item = Atom>) {
-		Extend::extend(self, atoms);
-	}
-
 	fn push(&mut self, atom: Atom) {
 		Vec::push(self, atom);
 	}

--- a/crates/huub/src/actions/boolean.rs
+++ b/crates/huub/src/actions/boolean.rs
@@ -3,8 +3,7 @@
 use std::{fmt::Debug, hash::Hash, ops::Not};
 
 use crate::{
-	actions::{PropagationActions, ReasoningContext},
-	constraints::ReasonBuilder,
+	actions::{PropagationActions, PropagationContext, ReasoningContext},
 	model::view::View,
 };
 
@@ -27,7 +26,7 @@ pub trait BoolOperations: Clone + Debug + Eq + Hash + Not + 'static {}
 /// for Boolean decision variables.
 pub trait BoolPropagationActions<Context>: BoolInspectionActions<Context>
 where
-	Context: ReasoningContext + ?Sized,
+	Context: PropagationContext + ?Sized,
 {
 	/// Enforce that the value of a Boolean decision variable must be `val`
 	/// because of the given reason.
@@ -35,7 +34,7 @@ where
 		&self,
 		ctx: &mut Context,
 		val: bool,
-		reason: impl ReasonBuilder<Context>,
+		reason: impl FnOnce(&mut Context, &mut Context::ReasonSink<'_>),
 	) -> Result<(), Context::Conflict>;
 
 	/// Enforce that the value of a Boolean decision variable must be `true`
@@ -43,7 +42,7 @@ where
 	fn require(
 		&self,
 		ctx: &mut Context,
-		reason: impl ReasonBuilder<Context>,
+		reason: impl FnOnce(&mut Context, &mut Context::ReasonSink<'_>),
 	) -> Result<(), Context::Conflict> {
 		self.fix(ctx, true, reason)
 	}
@@ -59,7 +58,7 @@ where
 pub trait BoolSimplificationActions<Context>:
 	BoolPropagationActions<Context> + Into<View<bool>>
 where
-	Context: ReasoningContext + ?Sized,
+	Context: PropagationContext + ?Sized,
 {
 	/// Mark `self` as being equivalent to `other`, instructing the reasoning
 	/// engine to use the same representation.
@@ -86,8 +85,8 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: bool,
-		reason: impl ReasonBuilder<Ctx>,
-	) -> Result<(), <Ctx as ReasoningContext>::Conflict> {
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
+	) -> Result<(), <Ctx as PropagationContext>::Conflict> {
 		if *self != val {
 			return Err(ctx.declare_conflict(reason));
 		}

--- a/crates/huub/src/actions/integer.rs
+++ b/crates/huub/src/actions/integer.rs
@@ -6,8 +6,8 @@ use rangelist::IntervalIterator;
 
 use crate::{
 	IntSet, IntVal,
-	actions::{PropagationActions, ReasoningContext},
-	constraints::ReasonBuilder,
+	actions::{PropagationActions, PropagationContext, ReasoningContext},
+	constraints::NO_REASON,
 	solver::IntLitMeaning,
 };
 
@@ -151,7 +151,7 @@ pub enum IntPropCond {
 /// [`ReasoningEngine::PropagationContext`](crate::actions::ReasoningEngine::PropagationContext) for integer decision variables.
 pub trait IntPropagationActions<Context>: IntDecisionActions<Context>
 where
-	Context: ReasoningContext + ?Sized,
+	Context: PropagationContext + ?Sized,
 {
 	/// Enforce that an integer view takes the value `val` because of the given
 	/// `reason`.
@@ -159,7 +159,7 @@ where
 		&self,
 		ctx: &mut Context,
 		val: IntVal,
-		reason: impl ReasonBuilder<Context>,
+		reason: impl FnOnce(&mut Context, &mut Context::ReasonSink<'_>),
 	) -> Result<(), Context::Conflict>;
 
 	/// Enforce that an integer view cannot take the value `val` because of the
@@ -168,7 +168,7 @@ where
 		&self,
 		ctx: &mut Context,
 		val: IntVal,
-		reason: impl ReasonBuilder<Context>,
+		reason: impl FnOnce(&mut Context, &mut Context::ReasonSink<'_>),
 	) -> Result<(), Context::Conflict>;
 
 	/// Enforce that an integer view takes a value that is less than or equal to
@@ -177,7 +177,7 @@ where
 		&self,
 		ctx: &mut Context,
 		val: IntVal,
-		reason: impl ReasonBuilder<Context>,
+		reason: impl FnOnce(&mut Context, &mut Context::ReasonSink<'_>),
 	) -> Result<(), Context::Conflict>;
 
 	/// Enforce that an integer view takes a value that is greater than or equal
@@ -186,7 +186,7 @@ where
 		&self,
 		ctx: &mut Context,
 		val: IntVal,
-		reason: impl ReasonBuilder<Context>,
+		reason: impl FnOnce(&mut Context, &mut Context::ReasonSink<'_>),
 	) -> Result<(), Context::Conflict>;
 }
 
@@ -199,7 +199,7 @@ where
 /// [`Constraint::simplify`](crate::constraints::Constraint::simplify).
 pub trait IntSimplificationActions<Context>: IntPropagationActions<Context>
 where
-	Context: ReasoningContext + ?Sized,
+	Context: PropagationContext + ?Sized,
 {
 	/// Enforce that a given integer expression cannot take any of the values in
 	/// the given set.
@@ -207,7 +207,7 @@ where
 		&self,
 		ctx: &mut Context,
 		values: &IntSet,
-		reason: impl ReasonBuilder<Context>,
+		reason: impl FnOnce(&mut Context, &mut Context::ReasonSink<'_>),
 	) -> Result<(), Context::Conflict>;
 
 	/// Enforce that the given integer expression takes a value in the given
@@ -216,7 +216,7 @@ where
 		&self,
 		ctx: &mut Context,
 		domain: &IntSet,
-		reason: impl ReasonBuilder<Context>,
+		reason: impl FnOnce(&mut Context, &mut Context::ReasonSink<'_>),
 	) -> Result<(), Context::Conflict>;
 
 	/// Mark two integer decisions as being equivalent, ensuring the two use the
@@ -307,7 +307,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		if val != *self {
 			Err(ctx.declare_conflict(reason))
@@ -320,7 +320,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		if val == *self {
 			Err(ctx.declare_conflict(reason))
@@ -333,7 +333,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		if val < *self {
 			Err(ctx.declare_conflict(reason))
@@ -346,7 +346,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		if val > *self {
 			Err(ctx.declare_conflict(reason))
@@ -365,7 +365,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		values: &IntSet,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		if values.contains(self) {
 			Err(ctx.declare_conflict(reason))
@@ -378,7 +378,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		domain: &IntSet,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		if !domain.contains(self) {
 			Err(ctx.declare_conflict(reason))
@@ -391,7 +391,7 @@ where
 		if self == &other.into() {
 			Ok(())
 		} else {
-			Err(ctx.declare_conflict([]))
+			Err(ctx.declare_conflict(NO_REASON))
 		}
 	}
 }

--- a/crates/huub/src/constraints.rs
+++ b/crates/huub/src/constraints.rs
@@ -20,13 +20,11 @@ use std::{
 	any::Any,
 	error::Error,
 	fmt::{self, Debug},
-	mem,
+	slice,
 };
 
 use dyn_clone::DynClone;
-use itertools::Itertools;
 use pindakaas::solver::propagation::ClauseBuilder;
-use tracing::warn;
 
 use crate::{
 	IntVal,
@@ -34,13 +32,13 @@ use crate::{
 		BoolAnalyzeActions, BoolInitActions, BoolInspectionActions, BoolPropagationActions,
 		BoolSimplificationActions, IntAnalyzeActions, IntEvent, IntExplanationActions,
 		IntInitActions, IntInspectionActions, IntPropagationActions, IntSimplificationActions,
-		ReasonActions, ReasoningContext, ReasoningEngine,
+		PropagationContext, ReasoningEngine,
 	},
 	lower::{LoweringContext, LoweringError},
 	model::{self, Model},
 	solver::{
 		self,
-		engine::{Engine, ReasonSink, State},
+		engine::{Engine, EngineReasonSink, State},
 		view::boolean::BoolView,
 	},
 };
@@ -76,29 +74,36 @@ pub(crate) type BoxedConstraint = Box<dyn Constraint<Model>>;
 /// by [`Engine`].
 pub(crate) type BoxedPropagator = Box<dyn Propagator<Engine>>;
 
-/// A `ReasonBuilder` whose result is cached so it can be used multiple times,
-/// and is only evaluated once used.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub(crate) enum CachedReason<B, Atom> {
-	/// An evaluated reason that can be reused.
-	Cached(Result<Reason<Atom>, bool>),
-	/// A reason that has not yet been evaluated.
-	Builder(B),
-}
-
-/// Conflict is an error type returned when a variable is assigned two
-/// inconsistent values.
+/// A conflict raised during propagation: the nogood clause the current state
+/// falsifies, possibly still deferred to a propagator.
+///
+/// This is the propagation-internal conflict type. It appears in the
+/// propagation API as `E::Conflict`, but it is **opaque to the user**: its only
+/// field is private, so it cannot be constructed or inspected outside the
+/// crate. Before a conflict is handed back to the user it is always resolved
+/// into a [`Nogood`]; the user-facing `Model`/`Solver`/[`LoweringError`]
+/// boundaries only ever expose a [`Nogood`].
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Conflict<Atom> {
-	/// The subject of the conflict (i.e., the literal that couldn't be
-	/// propagated).
-	///
-	/// If `None`, the conflict is a root conflict.
-	pub(crate) subject: Option<Atom>,
-	/// The reason for the conflict.
-	///
-	/// This reason must produce a conjunction that implies false.
-	pub(crate) reason: Reason<Atom>,
+pub struct Conflict<Atom>(pub(crate) ConflictInner<Atom>);
+
+/// The internal representation of a [`Conflict`]: a ready clause, or a reason
+/// deferred to a propagator that holds it (which may be unresolved inside the
+/// propagation loop).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ConflictInner<Atom> {
+	/// A conflict clause, holding the literals of the nogood directly.
+	Clause(Box<[Atom]>),
+	/// A conflict whose clause is computed on demand by a propagator (see
+	/// [`DeferReasonActions::defer`](crate::actions::DeferReasonActions::defer)).
+	Deferred {
+		/// The literal whose (failed) assignment the propagator explains as the
+		/// head of the clause, or `None` for a root conflict.
+		subject: Option<Atom>,
+		/// Reference to the propagator that computes the conflict clause.
+		propagator: u32,
+		/// Data to be given to the propagator to compute the reason.
+		data: u64,
+	},
 }
 
 /// A trait for constraints that can be placed in a [`Model`] object.
@@ -135,15 +140,6 @@ pub trait Constraint<E: ReasoningEngine + ?Sized>: Any + Debug + DynClone + Prop
 	fn to_solver(&self, context: &mut LoweringContext<'_>) -> Result<(), LoweringError>;
 }
 
-/// A note that the mentioned propagator will compute the `Reason` if requested.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct DeferredReason {
-	/// Reference to the propagator that will compute the reason.
-	pub(crate) propagator: u32,
-	/// Data to be given to the propagator to compute the reason.
-	pub(crate) data: u64,
-}
-
 /// Helper trait to simplify trait bounds for [`Constraint`] implementations.
 pub trait IntModelActions<E>
 where
@@ -166,6 +162,13 @@ where
 {
 }
 
+/// A resolved conflict clause (nogood) reported to the user.
+///
+/// This is the form a [`Conflict`] takes once it leaves the propagation loop;
+/// unlike [`Conflict`] it never holds a deferred reason.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Nogood<Atom>(pub(crate) Box<[Atom]>);
+
 /// A trait for a propagator that is called during the search process to filter
 /// the domains of decision variables, and detect inconsistencies.
 ///
@@ -173,7 +176,7 @@ where
 /// domains of decision variables as a conjunction of literals that imply the
 /// change. If these explanations are too expensive to compute during
 /// propagation, then the propagator can delay giving the explanation using
-/// [`PropagationActions::deferred_reason`](crate::actions::PropagationActions::deferred_reason).
+/// [`DeferReasonActions::defer`](crate::actions::DeferReasonActions::defer).
 /// If the explanation is needed, then the propagation engine will revert the
 /// state of the solver and call [`Propagator::explain`] to receive the
 /// explanation.
@@ -220,7 +223,7 @@ pub trait Propagator<E: ReasoningEngine + ?Sized>: Debug + DynClone + 'static {
 	/// propagated.
 	///
 	/// The method is called with the data that was passed to the
-	/// [`PropagationActions::deferred_reason`](crate::actions::PropagationActions::deferred_reason)
+	/// [`DeferReasonActions::defer`](crate::actions::DeferReasonActions::defer)
 	/// method, and the literal that was propagated. If the `lit` argument is
 	/// `None`, then the reason was used to explain `false`.
 	///
@@ -250,26 +253,6 @@ pub trait Propagator<E: ReasoningEngine + ?Sized>: Debug + DynClone + 'static {
 	fn propagate(&mut self, context: &mut E::PropagationContext<'_>) -> Result<(), E::Conflict>;
 }
 
-/// A conjunction of literals that implies a change in the state.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Reason<Atom> {
-	/// A promise that a given propagator will compute a causation of the change
-	/// when given the attached data.
-	Lazy(DeferredReason),
-	/// A conjunction of literals forming the causation of the change.
-	Eager(Box<[Atom]>),
-	/// A single literal that is the causation of the change.
-	Simple(Atom),
-}
-
-/// A trait for types that can be used to construct a reason for the propagation
-/// in the `Context` from `Atom`s.
-pub trait ReasonBuilder<Context: ReasoningContext + ?Sized> {
-	/// Construct a `Reason`, or return a Boolean indicating that the reason is
-	/// trivial.
-	fn build_reason(self, ctx: &mut Context) -> Result<Reason<Context::Atom>, bool>;
-}
-
 /// Status returned by the [`Constraint::simplify`] method,
 /// indicating whether the constraint has been subsumed (such that it can be
 /// removed from the [`Model`]) or not.
@@ -283,6 +266,43 @@ pub enum SimplificationStatus {
 	/// The constraint has been simplified to the point where it is subsumed.
 	/// The constraint can be removed from the [`Model`].
 	Subsumed,
+}
+
+/// A reason closure that pushes no conditions: the propagation or conflict it
+/// justifies holds *unconditionally*.
+///
+/// The deliberately alarming, `UPPER_CASE` name marks this as dangerous: using
+/// an empty reason for a fact that is not genuinely unconditional produces an
+/// unsound explanation. Pass it in place of a reason closure, e.g.
+/// `ctx.declare_conflict(NO_REASON)`.
+#[expect(
+	non_snake_case,
+	reason = "an UPPER_CASE marker makes an empty (dangerous) reason stand out at call sites"
+)]
+pub(crate) fn NO_REASON<Ctx: PropagationContext + ?Sized>(
+	_ctx: &mut Ctx,
+	_reason: &mut Ctx::ReasonSink<'_>,
+) {
+}
+
+/// Pin the argument types of a reason closure to a given
+/// [`PropagationContext`], returning the closure unchanged.
+///
+/// Passing the closure through this function supplies `Ctx` explicitly via the
+/// turbofish; the `FnOnce` bound then drives inference of both parameters,
+/// keeping the closure arguments type annotation-free:
+///
+/// ```ignore
+/// let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
+///     reason.push(self.x.min_lit(ctx));
+/// });
+/// self.y.tighten_min(ctx, bound, reason)?;
+/// self.y.tighten_max(ctx, other, reason)?;
+/// ```
+pub(crate) fn reason_ty<Ctx: PropagationContext, F: FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>)>(
+	f: F,
+) -> F {
+	f
 }
 
 impl<E, B> BoolModelActions<E> for B
@@ -318,117 +338,52 @@ impl Clone for BoxedPropagator {
 	}
 }
 
-impl<C> ReasonBuilder<C> for &[C::Atom]
-where
-	C: ReasoningContext + ?Sized,
-{
-	fn build_reason(self, _: &mut C) -> Result<Reason<C::Atom>, bool> {
-		Reason::from_iter(self.iter().cloned())
-	}
-}
-
-impl<C, const N: usize> ReasonBuilder<C> for &[C::Atom; N]
-where
-	C: ReasoningContext + ?Sized,
-{
-	fn build_reason(self, ctx: &mut C) -> Result<Reason<C::Atom>, bool> {
-		self[..].build_reason(ctx)
-	}
-}
-
-impl<C, const N: usize> ReasonBuilder<C> for [C::Atom; N]
-where
-	C: ReasoningContext + ?Sized,
-{
-	fn build_reason(self, _: &mut C) -> Result<Reason<C::Atom>, bool> {
-		Reason::from_iter(self)
-	}
-}
-
-impl<A, B> CachedReason<B, A> {
-	/// Create a new [`CachedReason`] from a [`ReasonBuilder`].
-	pub(crate) fn new(builder: B) -> Self {
-		CachedReason::Builder(builder)
-	}
-}
-
-impl<B, C> ReasonBuilder<C> for &'_ mut CachedReason<B, C::Atom>
-where
-	C: ReasoningContext + ?Sized,
-	B: ReasonBuilder<C>,
-{
-	fn build_reason(self, ctx: &mut C) -> Result<Reason<C::Atom>, bool> {
-		match self {
-			CachedReason::Cached(items) => items.clone(),
-			CachedReason::Builder(_) => {
-				let CachedReason::Builder(builder) =
-					mem::replace(self, CachedReason::Cached(Err(false)))
-				else {
-					unreachable!()
-				};
-				let reason = builder.build_reason(ctx);
-				*self = CachedReason::Cached(reason.clone());
-				reason
+impl<Atom> Conflict<Atom> {
+	/// Resolve the conflict into its [`Nogood`] clause.
+	///
+	/// A conflict is only ever handed to the user after the propagation loop
+	/// has resolved any deferred reason (the engine in
+	/// [`SolvingContext`](crate::solver::solving_context::SolvingContext), the
+	/// model in `Model::propagate_single`), so it must be a ready clause by
+	/// this point.
+	pub(crate) fn into_nogood(self) -> Nogood<Atom> {
+		match self.0 {
+			ConflictInner::Clause(lits) => Nogood(lits),
+			ConflictInner::Deferred { .. } => {
+				unreachable!("a deferred conflict must be resolved before reaching the user")
 			}
 		}
 	}
 }
 
 impl Conflict<solver::Decision<bool>> {
-	/// Create a new conflict with the given reason.
-	pub(crate) fn new<Ctx: ReasoningContext<Atom = solver::View<bool>> + ?Sized>(
-		ctx: &mut Ctx,
-		subject: Option<solver::Decision<bool>>,
-		reason: impl ReasonBuilder<Ctx>,
-	) -> Self {
-		match Reason::from_view(reason.build_reason(ctx)) {
-			Ok(reason) => Self { subject, reason },
-			Err(true) => match subject {
-				Some(subject) => Self {
-					subject: None,
-					reason: Reason::Simple(!subject),
-				},
-				None => {
-					warn!(
-						target: "solver",
-						"empty conflict detected; additional model simplification reasoning may be possible"
-					);
-					Self {
-						subject: None,
-						reason: Reason::Eager(Box::new([])),
-					}
+	/// Write the conflict's nogood clause into `clause`.
+	///
+	/// A ready clause already holds the nogood in clausal form, so its literals
+	/// are copied straight in; a deferred conflict pushes its `subject` as the
+	/// head and asks the propagator to compute the reason, which it negates
+	/// through the [`EngineReasonSink`] sink.
+	pub(crate) fn explain(
+		&self,
+		props: &mut [BoxedPropagator],
+		actions: &mut State,
+		mut clause: ClauseBuilder<'_>,
+	) {
+		match &self.0 {
+			ConflictInner::Clause(lits) => clause.extend(lits.iter().map(|lit| lit.0)),
+			&ConflictInner::Deferred {
+				subject,
+				propagator,
+				data,
+			} => {
+				if let Some(subject) = subject {
+					clause.push(subject.0);
 				}
-			},
-			Err(false) => unreachable!("invalid reason"),
+				let mut explanation = EngineReasonSink(clause);
+				let head = subject.map(|s| s.into()).unwrap_or(true.into());
+				props[propagator as usize].explain(actions, head, data, &mut explanation);
+			}
 		}
-	}
-}
-
-impl<Atom: Debug> Error for Conflict<Atom> {}
-
-impl<Atom: Debug> fmt::Display for Conflict<Atom> {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "Conflict detected: nogood {:?}", self.reason)
-	}
-}
-
-impl<C> ReasonBuilder<C> for DeferredReason
-where
-	C: ReasoningContext + ?Sized,
-{
-	fn build_reason(self, _: &mut C) -> Result<Reason<C::Atom>, bool> {
-		Ok(Reason::Lazy(self))
-	}
-}
-
-impl<C, F, I> ReasonBuilder<C> for F
-where
-	C: ReasoningContext + ?Sized,
-	F: FnOnce(&mut C) -> I,
-	I: IntoIterator<Item = C::Atom>,
-{
-	fn build_reason(self, ctx: &mut C) -> Result<Reason<C::Atom>, bool> {
-		Reason::from_iter(self(ctx))
 	}
 }
 
@@ -452,86 +407,43 @@ where
 {
 }
 
-impl<A> Reason<A> {
-	/// Collect a conjunction of `BoolView` from an iterator into a `Reason`.
-	pub(crate) fn from_iter<I: IntoIterator<Item = A>>(iter: I) -> Result<Self, bool> {
-		let mut lits: Vec<_> = iter.into_iter().collect();
-		match lits.len() {
-			0 => Err(true),
-			1 => Ok(Reason::Simple(lits.remove(0))),
-			_ => Ok(Reason::Eager(lits.into_boxed_slice())),
-		}
+impl<Atom> Nogood<Atom> {
+	/// Returns an non-consuming iterator over the atom in the nogood clause.
+	pub fn iter(&self) -> slice::Iter<'_, Atom> {
+		self.0.iter()
 	}
 }
 
-impl Reason<solver::Decision<bool>> {
-	/// Write a reason clause from the `Reason` into `clause`.
-	///
-	/// The reason is the conjunction of (literal) premises that implies `lit`.
-	/// When `lit` is `None` then it explains `false`. In this method we rewrite
-	/// the implication form `(premise_1 /\ premise_2 /\ ...) -> lit` into a
-	/// direct clause `(¬premise_1 \/ ¬premise_2 \/ ... \/ lit)`. For a
-	/// [`Reason::Lazy`] reason, the propagator is asked to compute the
-	/// conjunction of premises.
-	pub(crate) fn explain(
-		&self,
-		props: &mut [BoxedPropagator],
-		actions: &mut State,
-		lit: Option<solver::Decision<bool>>,
-		mut clause: ClauseBuilder<'_>,
-	) {
-		if let Some(lit) = lit {
-			clause.push(lit.0);
-		}
-		let mut reason = ReasonSink(clause);
-		match self {
-			&Reason::Lazy(DeferredReason {
-				propagator: prop,
-				data,
-			}) => {
-				props[prop as usize].explain(
-					actions,
-					lit.map(|lit| lit.into()).unwrap_or(true.into()),
-					data,
-					&mut reason,
-				);
-			}
-			Reason::Eager(v) => reason.extend(v.iter().map(|&premise| premise.into())),
-			&Reason::Simple(premise) => reason.push(premise.into()),
-		}
-	}
-
-	/// Internal function used to tighten a [`Reason`] with [`BoolView`] atoms
-	/// to a [`Reason`] with [`RawLit`](pindakaas::Lit) atoms.
-	pub(crate) fn from_view(
-		reason: Result<Reason<solver::View<bool>>, bool>,
-	) -> Result<Self, bool> {
-		let v = match reason? {
-			Reason::Lazy(lazy) => return Ok(Self::Lazy(lazy)),
-			Reason::Eager(items) => items.into_vec(),
-			Reason::Simple(lit) => vec![lit],
-		};
-		let mut v: Vec<_> = v
-			.into_iter()
-			.filter_map(|v| match v.0 {
-				BoolView::Lit(lit) => Some(Ok(lit)),
-				BoolView::Const(false) => Some(Err(false)),
-				BoolView::Const(true) => None,
-			})
-			.try_collect()?;
-		match v.len() {
-			0 => Err(true),
-			1 => Ok(Reason::Simple(v.remove(0))),
-			_ => Ok(Reason::Eager(v.into_boxed_slice())),
-		}
+impl Nogood<solver::Decision<bool>> {
+	/// Build the reported [`Nogood`] from the Boolean views that make up a
+	/// conflict clause, resolving any constant views.
+	pub(crate) fn from_view_iter(iter: impl IntoIterator<Item = solver::View<bool>>) -> Self {
+		Self(
+			iter.into_iter()
+				.filter_map(|atom| match atom.0 {
+					BoolView::Lit(lit) => Some(lit),
+					BoolView::Const(true) => unreachable!("invalid nogood: contains `true`"),
+					BoolView::Const(false) => None,
+				})
+				.collect(),
+		)
 	}
 }
 
-impl<C> ReasonBuilder<C> for Vec<C::Atom>
-where
-	C: ReasoningContext + ?Sized,
-{
-	fn build_reason(self, _: &mut C) -> Result<Reason<C::Atom>, bool> {
-		Reason::from_iter(self)
+impl<Atom: Debug> Error for Nogood<Atom> {}
+
+impl<Atom> IntoIterator for Nogood<Atom> {
+	type IntoIter = <Box<[Atom]> as IntoIterator>::IntoIter;
+
+	type Item = Atom;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.into_iter()
+	}
+}
+
+impl<Atom: Debug> fmt::Display for Nogood<Atom> {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "conflict detected: nogood {:?}", self.0)
 	}
 }

--- a/crates/huub/src/constraints/bool_array_element.rs
+++ b/crates/huub/src/constraints/bool_array_element.rs
@@ -11,7 +11,7 @@ use crate::{
 		IntInitActions, IntInspectionActions, IntPropCond, IntPropagationActions, ReasoningEngine,
 	},
 	constraints::{
-		BoolModelActions, Constraint, IntModelActions, Propagator, SimplificationStatus,
+		BoolModelActions, Constraint, IntModelActions, NO_REASON, Propagator, SimplificationStatus,
 	},
 	lower::{LoweringContext, LoweringError},
 	model::view::View,
@@ -98,9 +98,9 @@ where
 
 	fn propagate(&mut self, ctx: &mut E::PropagationContext<'_>) -> Result<(), E::Conflict> {
 		// Restrict the index to the bounds of the array.
-		self.index.tighten_min(ctx, 0, vec![])?;
+		self.index.tighten_min(ctx, 0, NO_REASON)?;
 		self.index
-			.tighten_max(ctx, self.array.len() as IntVal - 1, vec![])?;
+			.tighten_max(ctx, self.array.len() as IntVal - 1, NO_REASON)?;
 
 		// TODO: Do more propagation
 		Ok(())

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -10,14 +10,13 @@ use itertools::Itertools;
 use tracing::trace;
 
 use crate::{
-	Conjunction, IntVal,
+	IntVal,
 	actions::{
 		InitActions, IntDecisionActions, IntInspectionActions, IntPropCond, PostingActions,
-		ReasoningContext, ReasoningEngine,
+		PropagationContext, ReasonActions, ReasoningContext, ReasoningEngine,
 	},
 	constraints::{
-		Constraint, IntModelActions, IntSolverActions, Propagator, ReasonBuilder,
-		SimplificationStatus,
+		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
 	},
 	lower::{LoweringContext, LoweringError},
 	solver::{IntLitMeaning, Polarity, engine::Engine, queue::PriorityLevel},
@@ -262,15 +261,15 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 		task_no: usize,
 		time_point: i64,
 		usage_limit: i64,
-	) -> impl ReasonBuilder<Ctx> + '_
+	) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + '_
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		I1: IntDecisionActions<Ctx>,
 		I2: IntDecisionActions<Ctx>,
 		I3: IntDecisionActions<Ctx>,
 		I4: IntDecisionActions<Ctx>,
 	{
-		move |ctx: &mut Ctx| {
+		move |ctx, reason| {
 			trace!(
 				target: "cumulative",
 				task_no,
@@ -297,27 +296,22 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 				"explain task usage limit"
 			);
 
-			let cap_lit = self.capacity.max_lit(ctx);
-
 			// Explanation: (1) relevant tasks (together with task `task_no`) have
 			// the required compulsory part at time `time_point`
-			relevant_tasks
-				.iter()
-				.chain(once(&task_no))
-				.flat_map(|&i| {
-					[
-						self.start_times[i].lit(ctx, IntLitMeaning::Less(time_point + 1)),
-						self.start_times[i].lit(
-							ctx,
-							IntLitMeaning::GreaterEq(time_point + 1 - self.durations[i].min(ctx)),
-						),
-						self.durations[i].min_lit(ctx),
-						self.usages[i].min_lit(ctx),
-					]
-				})
-				// Explanation: (2) the resource capacity is at a given level
-				.chain(once(cap_lit))
-				.collect_vec()
+			reason.extend(relevant_tasks.iter().chain(once(&task_no)).flat_map(|&i| {
+				[
+					self.start_times[i].lit(ctx, IntLitMeaning::Less(time_point + 1)),
+					self.start_times[i].lit(
+						ctx,
+						IntLitMeaning::GreaterEq(time_point + 1 - self.durations[i].min(ctx)),
+					),
+					self.durations[i].min_lit(ctx),
+					self.usages[i].min_lit(ctx),
+				]
+			}));
+
+			// Explanation: (2) the resource capacity is at a given level
+			reason.push(self.capacity.max_lit(ctx));
 		}
 	}
 
@@ -328,15 +322,15 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 		&self,
 		to_cover: i64,
 		time_point: i64,
-	) -> impl ReasonBuilder<Ctx> + '_
+	) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + '_
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		I1: IntDecisionActions<Ctx>,
 		I2: IntDecisionActions<Ctx>,
 		I3: IntDecisionActions<Ctx>,
 		I4: IntDecisionActions<Ctx>,
 	{
-		move |ctx: &mut Ctx| {
+		move |ctx, reason| {
 			let relevant_tasks = self.collect_compulsory_tasks(ctx, to_cover, time_point, None);
 
 			trace!(
@@ -351,25 +345,20 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 				"explain resource overload"
 			);
 
-			let cap_lit = self.capacity.max_lit(ctx);
-
 			// Explanation: relevant tasks have the required compulsory part at time
 			// `time_point`
-			relevant_tasks
-				.iter()
-				.flat_map(|&i| {
-					[
-						self.start_times[i].lit(ctx, IntLitMeaning::Less(time_point + 1)),
-						self.start_times[i].lit(
-							ctx,
-							IntLitMeaning::GreaterEq(time_point - self.durations[i].min(ctx) + 1),
-						),
-						self.durations[i].min_lit(ctx),
-						self.usages[i].min_lit(ctx),
-					]
-				})
-				.chain(once(cap_lit))
-				.collect_vec()
+			reason.extend(relevant_tasks.iter().flat_map(|&i| {
+				[
+					self.start_times[i].lit(ctx, IntLitMeaning::Less(time_point + 1)),
+					self.start_times[i].lit(
+						ctx,
+						IntLitMeaning::GreaterEq(time_point - self.durations[i].min(ctx) + 1),
+					),
+					self.durations[i].min_lit(ctx),
+					self.usages[i].min_lit(ctx),
+				]
+			}));
+			reason.push(self.capacity.max_lit(ctx));
 		}
 	}
 
@@ -381,15 +370,15 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 		task_no: usize,
 		propagation_rule: CumulativePropagationRule,
 		time_point: i64,
-	) -> impl ReasonBuilder<Ctx> + '_
+	) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + '_
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		I1: IntDecisionActions<Ctx>,
 		I2: IntDecisionActions<Ctx>,
 		I3: IntDecisionActions<Ctx>,
 		I4: IntDecisionActions<Ctx>,
 	{
-		move |ctx: &mut Ctx| {
+		move |ctx, reason| {
 			let capacity_ub = self.capacity.max(ctx);
 			let min_usage = self.usages[task_no].min(ctx);
 			let to_cover = capacity_ub - min_usage + 1;
@@ -408,9 +397,6 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 				rule =? propagation_rule,
 				"explain task sweeping"
 			);
-
-			// Construct the reason for the propagation
-			let mut reason = Conjunction::with_capacity(4 * relevant_tasks.len() + 4);
 
 			// Explanation: (1) relevant tasks have the required compulsory part at time
 			// `time_point`
@@ -446,8 +432,6 @@ impl<I1, I2, I3, I4> CumulativeTimeTable<I1, I2, I3, I4> {
 
 			// Explanation: (3) the resource capacity is at a given level
 			reason.push(self.capacity.max_lit(ctx));
-
-			reason
 		}
 	}
 

--- a/crates/huub/src/constraints/disjunctive.rs
+++ b/crates/huub/src/constraints/disjunctive.rs
@@ -7,13 +7,12 @@ use tracing::trace;
 use crate::{
 	IntVal,
 	actions::{
-		ConstructionActions, InitActions, IntDecisionActions, IntInspectionActions, IntPropCond,
-		PostingActions, PropagationActions, ReasonActions, ReasoningContext, ReasoningEngine,
-		Trailed, TrailingActions,
+		ConstructionActions, DeferReasonActions, InitActions, IntDecisionActions,
+		IntInspectionActions, IntPropCond, PostingActions, PropagationContext, ReasonActions,
+		ReasoningContext, ReasoningEngine, Trailed, TrailingActions,
 	},
 	constraints::{
-		Constraint, IntModelActions, IntSolverActions, Propagator, ReasonBuilder,
-		SimplificationStatus,
+		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
 	},
 	lower::{LoweringContext, LoweringError},
 	model,
@@ -431,12 +430,15 @@ impl<I> DisjunctivePropagator<I> {
 	/// Explain resource overload within the time window
 	/// [`earliest_start`,`time_bound`]. For details, refer to the CPAIOR paper
 	/// by Vilim (2005).
-	fn explain_overload_checking<Ctx>(&self, time_bound: i64) -> impl ReasonBuilder<Ctx> + '_
+	fn explain_overload_checking<Ctx>(
+		&self,
+		time_bound: i64,
+	) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + '_
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		I: IntDecisionActions<Ctx>,
 	{
-		move |ctx: &mut Ctx| {
+		move |ctx, reason| {
 			let binding_task = self.ot_tree.binding_task(time_bound, 0);
 			let earliest_start = self.start_times[binding_task].min(ctx);
 			let mut slack = time_bound - earliest_start;
@@ -461,16 +463,13 @@ impl<I> DisjunctivePropagator<I> {
 				}
 			}
 
-			e_tasks
-				.iter()
-				.flat_map(|&i| {
-					let bv = self.start_times[i].lit(
-						ctx,
-						IntLitMeaning::Less((time_bound - slack) - self.durations[i]),
-					);
-					[self.start_times[i].min_lit(ctx), bv]
-				})
-				.collect_vec()
+			reason.extend(e_tasks.iter().flat_map(|&i| {
+				let bv = self.start_times[i].lit(
+					ctx,
+					IntLitMeaning::Less((time_bound - slack) - self.durations[i]),
+				);
+				[self.start_times[i].min_lit(ctx), bv]
+			}));
 		}
 	}
 
@@ -732,7 +731,7 @@ impl<I> DisjunctivePropagator<I> {
 						earliest_completion_time,
 					);
 					let data = self.data_for_explanation(i, DisjunctivePropagationRule::Precedence);
-					v.tighten_min(ctx, updated_est[i], ctx.deferred_reason(data))?;
+					v.tighten_min(ctx, updated_est[i], |_, reason| reason.defer(data))?;
 					propagated = true;
 				}
 			}
@@ -848,11 +847,8 @@ impl<I> DisjunctivePropagator<I> {
 						blocked_task,
 						DisjunctivePropagationRule::EdgeFinding,
 					);
-					self.start_times[blocked_task].tighten_min(
-						ctx,
-						ect_in_tree,
-						ctx.deferred_reason(data),
-					)?;
+					self.start_times[blocked_task]
+						.tighten_min(ctx, ect_in_tree, |_, reason| reason.defer(data))?;
 					propagated = true;
 				}
 				// Remove the blocked task as the maximum propagation has been achieved
@@ -998,11 +994,9 @@ impl<I> DisjunctivePropagator<I> {
 
 				ctx.set_trailed(self.trailed_info[i].latest_completion, updated_lct[i]);
 				let data = self.data_for_explanation(i, DisjunctivePropagationRule::NotLast);
-				v.tighten_max(
-					ctx,
-					updated_lct[i] - self.durations[i],
-					ctx.deferred_reason(data),
-				)?;
+				v.tighten_max(ctx, updated_lct[i] - self.durations[i], |_, reason| {
+					reason.defer(data);
+				})?;
 				propagated = true;
 			}
 		}

--- a/crates/huub/src/constraints/int_abs.rs
+++ b/crates/huub/src/constraints/int_abs.rs
@@ -8,8 +8,8 @@ use std::{
 
 use crate::{
 	actions::{
-		InitActions, IntDecisionActions, IntPropCond, PostingActions, ReasoningContext,
-		ReasoningEngine,
+		InitActions, IntDecisionActions, IntPropCond, PostingActions, ReasonActions,
+		ReasoningContext, ReasoningEngine,
 	},
 	constraints::{
 		BoolModelActions, BoolSolverActions, Constraint, IntModelActions, IntSolverActions,
@@ -119,74 +119,68 @@ where
 		match self.origin_positive.val(ctx) {
 			Some(false) => {
 				// If we know that the origin is negative, then just negate the bounds
-				self.abs
-					.tighten_min(ctx, -ub, |ctx: &mut E::PropagationContext<'_>| {
-						[self.origin.max_lit(ctx)]
-					})?;
-				self.abs
-					.tighten_max(ctx, -lb, |ctx: &mut E::PropagationContext<'_>| {
-						[
-							self.origin.min_lit(ctx),
-							(!self.origin_positive.clone()).into(),
-						]
-					})?;
+				self.abs.tighten_min(ctx, -ub, |ctx, reason| {
+					reason.push(self.origin.max_lit(ctx));
+				})?;
+				self.abs.tighten_max(ctx, -lb, |ctx, reason| {
+					reason.extend([
+						self.origin.min_lit(ctx),
+						(!self.origin_positive.clone()).into(),
+					]);
+				})?;
 
 				let (lb, ub) = self.abs.bounds(ctx);
-				self.origin
-					.tighten_min(ctx, -ub, |ctx: &mut E::PropagationContext<'_>| {
-						[self.abs.max_lit(ctx)]
-					})?;
-				self.origin
-					.tighten_max(ctx, -lb, |ctx: &mut E::PropagationContext<'_>| {
-						[
-							self.abs.min_lit(ctx),
-							(!self.origin_positive.clone()).into(),
-						]
-					})?;
+				self.origin.tighten_min(ctx, -ub, |ctx, reason| {
+					reason.push(self.abs.max_lit(ctx));
+				})?;
+				self.origin.tighten_max(ctx, -lb, |ctx, reason| {
+					reason.extend([
+						self.abs.min_lit(ctx),
+						(!self.origin_positive.clone()).into(),
+					]);
+				})?;
 			}
 			Some(true) => {
 				// If we know that the origin is positive, then the bounds
 				// are the same.
-				self.abs
-					.tighten_min(ctx, lb, |ctx: &mut E::PropagationContext<'_>| {
-						[self.origin.min_lit(ctx)]
-					})?;
-				self.abs
-					.tighten_max(ctx, ub, |ctx: &mut E::PropagationContext<'_>| {
-						[
-							self.origin.max_lit(ctx),
-							self.origin_positive.clone().into(),
-						]
-					})?;
+				self.abs.tighten_min(ctx, lb, |ctx, reason| {
+					reason.push(self.origin.min_lit(ctx));
+				})?;
+				self.abs.tighten_max(ctx, ub, |ctx, reason| {
+					reason.extend([
+						self.origin.max_lit(ctx),
+						self.origin_positive.clone().into(),
+					]);
+				})?;
 
 				let (lb, ub) = self.abs.bounds(ctx);
-				self.origin
-					.tighten_min(ctx, lb, |ctx: &mut E::PropagationContext<'_>| {
-						[self.abs.min_lit(ctx), self.origin_positive.clone().into()]
-					})?;
-				self.origin
-					.tighten_max(ctx, ub, |ctx: &mut E::PropagationContext<'_>| {
-						[self.abs.max_lit(ctx)]
-					})?;
+				self.origin.tighten_min(ctx, lb, |ctx, reason| {
+					reason.extend([self.abs.min_lit(ctx), self.origin_positive.clone().into()]);
+				})?;
+				self.origin.tighten_max(ctx, ub, |ctx, reason| {
+					reason.push(self.abs.max_lit(ctx));
+				})?;
 			}
 			None => {
 				// If the origin can be either positive or negative, then the bounds are
 				// The maximum absolute value bounds the absolute value variable.
 				let abs_max = cmp::max(ub, -lb);
-				self.abs
-					.tighten_max(ctx, abs_max, |ctx: &mut E::PropagationContext<'_>| {
-						[
-							self.origin.lit(ctx, IntLitMeaning::GreaterEq(-abs_max)),
-							self.origin.lit(ctx, IntLitMeaning::Less(abs_max + 1)),
-						]
-					})?;
+				self.abs.tighten_max(ctx, abs_max, |ctx, reason| {
+					reason.extend([
+						self.origin.lit(ctx, IntLitMeaning::GreaterEq(-abs_max)),
+						self.origin.lit(ctx, IntLitMeaning::Less(abs_max + 1)),
+					]);
+				})?;
 
 				// If the upper bound of the absolute value variable has changed, we
 				// propagate bounds of the origin variable.
 				let abs_ub = self.abs.max(ctx);
-				let ub_lit = self.abs.max_lit(ctx);
-				self.origin.tighten_min(ctx, -abs_ub, [ub_lit.clone()])?;
-				self.origin.tighten_max(ctx, abs_ub, [ub_lit])?;
+				self.origin.tighten_min(ctx, -abs_ub, |ctx, reason| {
+					reason.push(self.abs.max_lit(ctx));
+				})?;
+				self.origin.tighten_max(ctx, abs_ub, |ctx, reason| {
+					reason.push(self.abs.max_lit(ctx));
+				})?;
 			}
 		}
 

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -12,11 +12,11 @@ use crate::{
 	IntSet, IntVal,
 	actions::{
 		ConstructionActions, InitActions, IntAnalyzeActions, IntDecisionActions,
-		IntInspectionActions, IntPropCond, IntSimplificationActions, PostingActions,
+		IntInspectionActions, IntPropCond, IntSimplificationActions, PostingActions, ReasonActions,
 		ReasoningContext, ReasoningEngine, SimplificationActions, Trailed, TrailingActions,
 	},
 	constraints::{
-		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
+		Constraint, IntModelActions, IntSolverActions, NO_REASON, Propagator, SimplificationStatus,
 	},
 	lower::{LoweringContext, LoweringError},
 	model::View,
@@ -140,9 +140,9 @@ where
 		ctx: &mut E::PropagationContext<'_>,
 	) -> Result<SimplificationStatus, E::Conflict> {
 		// Constrain the index to be within the bounds of the array
-		self.index.tighten_min(ctx, 0, [])?;
+		self.index.tighten_min(ctx, 0, NO_REASON)?;
 		self.index
-			.tighten_max(ctx, self.vars.len() as IntVal - 1, [])?;
+			.tighten_max(ctx, self.vars.len() as IntVal - 1, NO_REASON)?;
 
 		self.propagate(ctx)?;
 
@@ -217,34 +217,20 @@ where
 		if let Some(fixed_index) = self.index.val(ctx) {
 			let index_val_lit = self.index.val_lit(ctx).unwrap();
 			let fixed_var = &self.vars[fixed_index as usize];
-			self.result.tighten_min(
-				ctx,
-				fixed_var.min(ctx),
-				|ctx: &mut E::PropagationContext<'_>| {
-					[index_val_lit.clone(), fixed_var.min_lit(ctx)]
-				},
-			)?;
-			fixed_var.tighten_min(
-				ctx,
-				self.result.min(ctx),
-				|ctx: &mut E::PropagationContext<'_>| {
-					[index_val_lit.clone(), self.result.min_lit(ctx)]
-				},
-			)?;
-			self.result.tighten_max(
-				ctx,
-				fixed_var.max(ctx),
-				|ctx: &mut E::PropagationContext<'_>| {
-					[index_val_lit.clone(), fixed_var.max_lit(ctx)]
-				},
-			)?;
-			fixed_var.tighten_max(
-				ctx,
-				self.result.max(ctx),
-				|ctx: &mut E::PropagationContext<'_>| {
-					[index_val_lit.clone(), self.result.max_lit(ctx)]
-				},
-			)?;
+			self.result
+				.tighten_min(ctx, fixed_var.min(ctx), |ctx, reason| {
+					reason.extend([index_val_lit.clone(), fixed_var.min_lit(ctx)]);
+				})?;
+			fixed_var.tighten_min(ctx, self.result.min(ctx), |ctx, reason| {
+				reason.extend([index_val_lit.clone(), self.result.min_lit(ctx)]);
+			})?;
+			self.result
+				.tighten_max(ctx, fixed_var.max(ctx), |ctx, reason| {
+					reason.extend([index_val_lit.clone(), fixed_var.max_lit(ctx)]);
+				})?;
+			fixed_var.tighten_max(ctx, self.result.max(ctx), |ctx, reason| {
+				reason.extend([index_val_lit.clone(), self.result.max_lit(ctx)]);
+			})?;
 			return Ok(());
 		}
 
@@ -284,29 +270,21 @@ where
 
 			let (v_lb, v_ub) = v.bounds(ctx);
 			if result_ub < v_lb {
-				self.index.remove_val(
-					ctx,
-					i as IntVal,
-					|ctx: &mut E::PropagationContext<'_>| {
-						[
-							self.result.lit(ctx, IntLitMeaning::Less(v_lb)),
-							v.min_lit(ctx),
-						]
-					},
-				)?;
+				self.index.remove_val(ctx, i as IntVal, |ctx, reason| {
+					reason.extend([
+						self.result.lit(ctx, IntLitMeaning::Less(v_lb)),
+						v.min_lit(ctx),
+					]);
+				})?;
 			}
 
 			if v_ub < result_lb {
-				self.index.remove_val(
-					ctx,
-					i as IntVal,
-					|ctx: &mut E::PropagationContext<'_>| {
-						[
-							self.result.lit(ctx, IntLitMeaning::GreaterEq(v_ub + 1)),
-							v.max_lit(ctx),
-						]
-					},
-				)?;
+				self.index.remove_val(ctx, i as IntVal, |ctx, reason| {
+					reason.extend([
+						self.result.lit(ctx, IntLitMeaning::GreaterEq(v_ub + 1)),
+						v.max_lit(ctx),
+					]);
+				})?;
 			}
 
 			// update min_support if i is in the domain of self.index and the lower bound of
@@ -339,22 +317,19 @@ where
 		// only trigger when self.vars[min_support] is changed or self.vars[min_support]
 		// is out of domain
 		if new_min > result_lb {
-			self.result
-				.tighten_min(ctx, new_min, |ctx: &mut E::PropagationContext<'_>| {
-					let mut reason = Vec::with_capacity(self.vars.len());
-					let dom = self.index.domain(ctx);
-					let mut dom = dom.iter().flatten().peekable();
-					for (i, v) in self.vars.iter().enumerate() {
-						debug_assert!(dom.peek().is_none() || *dom.peek().unwrap() >= i as IntVal);
-						if dom.peek() == Some(&(i as IntVal)) {
-							reason.push(v.lit(ctx, IntLitMeaning::GreaterEq(new_min)));
-							dom.next();
-						} else {
-							reason.push(self.index.lit(ctx, IntLitMeaning::NotEq(i as IntVal)));
-						}
+			self.result.tighten_min(ctx, new_min, |ctx, reason| {
+				let dom = self.index.domain(ctx);
+				let mut dom = dom.iter().flatten().peekable();
+				for (i, v) in self.vars.iter().enumerate() {
+					debug_assert!(dom.peek().is_none() || *dom.peek().unwrap() >= i as IntVal);
+					if dom.peek() == Some(&(i as IntVal)) {
+						reason.push(v.lit(ctx, IntLitMeaning::GreaterEq(new_min)));
+						dom.next();
+					} else {
+						reason.push(self.index.lit(ctx, IntLitMeaning::NotEq(i as IntVal)));
 					}
-					reason
-				})?;
+				}
+			})?;
 		}
 
 		// propagate the upper bound of the selected variable y if max_support is not
@@ -365,22 +340,19 @@ where
 		// only trigger when self.vars[max_support] is changed or self.vars[max_support]
 		// is out of domain
 		if new_max < result_ub {
-			self.result
-				.tighten_max(ctx, new_max, |ctx: &mut E::PropagationContext<'_>| {
-					let mut reason = Vec::with_capacity(self.vars.len());
-					let dom = self.index.domain(ctx);
-					let mut dom = dom.iter().flatten().peekable();
-					for (i, v) in self.vars.iter().enumerate() {
-						debug_assert!(dom.peek().is_none() || *dom.peek().unwrap() >= i as IntVal);
-						if dom.peek() == Some(&(i as IntVal)) {
-							reason.push(v.lit(ctx, IntLitMeaning::Less(new_max + 1)));
-							dom.next();
-						} else {
-							reason.push(self.index.lit(ctx, IntLitMeaning::NotEq(i as IntVal)));
-						}
+			self.result.tighten_max(ctx, new_max, |ctx, reason| {
+				let dom = self.index.domain(ctx);
+				let mut dom = dom.iter().flatten().peekable();
+				for (i, v) in self.vars.iter().enumerate() {
+					debug_assert!(dom.peek().is_none() || *dom.peek().unwrap() >= i as IntVal);
+					if dom.peek() == Some(&(i as IntVal)) {
+						reason.push(v.lit(ctx, IntLitMeaning::Less(new_max + 1)));
+						dom.next();
+					} else {
+						reason.push(self.index.lit(ctx, IntLitMeaning::NotEq(i as IntVal)));
 					}
-					reason
-				})?;
+				}
+			})?;
 		}
 
 		Ok(())
@@ -408,10 +380,10 @@ where
 		ctx: &mut E::PropagationContext<'_>,
 	) -> Result<SimplificationStatus, E::Conflict> {
 		// Constrain the index to be within the bounds of the array
-		self.0.index.tighten_min(ctx, 0, [])?;
+		self.0.index.tighten_min(ctx, 0, NO_REASON)?;
 		self.0
 			.index
-			.tighten_max(ctx, self.0.vars.len() as IntVal - 1, [])?;
+			.tighten_max(ctx, self.0.vars.len() as IntVal - 1, NO_REASON)?;
 
 		self.0.propagate(ctx)?;
 
@@ -484,7 +456,7 @@ mod tests {
 	use crate::{
 		IntSet,
 		actions::{IntInspectionActions, IntPropagationActions},
-		constraints::int_array_element::IntArrayElementBounds,
+		constraints::{NO_REASON, int_array_element::IntArrayElementBounds},
 		model::Model,
 		solver::{LiteralStrategy, Solver},
 	};
@@ -503,7 +475,7 @@ mod tests {
 			.result(result)
 			.post()
 			.unwrap();
-		index.remove_val(&mut prb, 2, []).unwrap();
+		index.remove_val(&mut prb, 2, NO_REASON).unwrap();
 		let _: (Solver, _) = prb.lower().to_solver().unwrap();
 
 		assert_eq!(index.domain(&prb), (0..=1).into());
@@ -524,7 +496,7 @@ mod tests {
 			.result(result)
 			.post()
 			.unwrap();
-		index.remove_val(&mut prb, 0, []).unwrap();
+		index.remove_val(&mut prb, 0, NO_REASON).unwrap();
 		let _: (Solver, _) = prb.lower().to_solver().unwrap();
 
 		assert_eq!(index.domain(&prb), (1..=2).into());

--- a/crates/huub/src/constraints/int_array_minimum.rs
+++ b/crates/huub/src/constraints/int_array_minimum.rs
@@ -2,10 +2,8 @@
 //! enforces that a decision variable takes the minimum value of an array of
 //! decision variables.
 
-use itertools::Itertools;
-
 use crate::{
-	actions::{InitActions, IntPropCond, PostingActions, ReasoningEngine},
+	actions::{InitActions, IntPropCond, PostingActions, ReasonActions, ReasoningEngine},
 	constraints::{
 		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
 	},
@@ -68,7 +66,7 @@ where
 			&& self.vars.iter().any(|v| v.val(ctx) == Some(c))
 		{
 			for v in &self.vars {
-				v.tighten_min(ctx, c, [self.min.min_lit(ctx)])?;
+				v.tighten_min(ctx, c, |ctx, reason| reason.push(self.min.min_lit(ctx)))?;
 			}
 			return Ok(SimplificationStatus::Subsumed);
 		}
@@ -117,24 +115,24 @@ where
 			.map(|x| (x.max(ctx), x))
 			.min_by_key(|(ub, _)| *ub)
 			.unwrap();
-		let reason = min_ub_var.max_lit(ctx);
-		self.min.tighten_max(ctx, min_ub, [reason])?;
+		self.min.tighten_max(ctx, min_ub, |ctx, reason| {
+			reason.push(min_ub_var.max_lit(ctx));
+		})?;
 
 		// set y to be greater than or equal to the minimum of lower bounds of x_i
 		let min_lb = self.vars.iter().map(|x| x.min(ctx)).min().unwrap();
-		self.min
-			.tighten_min(ctx, min_lb, |ctx: &mut E::PropagationContext<'_>| {
+		self.min.tighten_min(ctx, min_lb, |ctx, reason| {
+			reason.extend(
 				self.vars
 					.iter()
-					.map(|x| x.lit(ctx, IntLitMeaning::GreaterEq(min_lb)))
-					.collect_vec()
-			})?;
+					.map(|x| x.lit(ctx, IntLitMeaning::GreaterEq(min_lb))),
+			);
+		})?;
 
 		// set x_i to be greater than or equal to y.lowerbound
-		let reason = &[self.min.min_lit(ctx)];
 		let y_lb = self.min.min(ctx);
 		for x in self.vars.iter() {
-			x.tighten_min(ctx, y_lb, reason)?;
+			x.tighten_min(ctx, y_lb, |ctx, reason| reason.push(self.min.min_lit(ctx)))?;
 		}
 
 		Ok(())

--- a/crates/huub/src/constraints/int_div.rs
+++ b/crates/huub/src/constraints/int_div.rs
@@ -11,7 +11,7 @@ use crate::{
 		PostingActions, ReasoningEngine, SimplificationActions,
 	},
 	constraints::{
-		BoolModelActions, Constraint, IntModelActions, IntSolverActions, Propagator,
+		BoolModelActions, Constraint, IntModelActions, IntSolverActions, NO_REASON, Propagator,
 		SimplificationStatus,
 	},
 	helpers::div_ceil,
@@ -100,55 +100,47 @@ impl<I1, I2, I3> IntDivBounds<I1, I2, I3> {
 
 		let new_res_lb = num_lb / denom_ub;
 		if new_res_lb > res_lb {
-			result.tighten_min(ctx, new_res_lb, |ctx: &mut E::PropagationContext<'_>| {
-				[
+			result.tighten_min(ctx, new_res_lb, |ctx, reason| {
+				reason.extend([
 					numerator.min_lit(ctx),
 					denominator.lit(ctx, IntLitMeaning::GreaterEq(1)),
 					denominator.max_lit(ctx),
-				]
+				]);
 			})?;
 		}
 
 		let new_num_lb = denom_lb * res_lb;
 		if new_num_lb > num_lb {
-			numerator.tighten_min(ctx, new_num_lb, |ctx: &mut E::PropagationContext<'_>| {
-				[denominator.min_lit(ctx), result.min_lit(ctx)]
+			numerator.tighten_min(ctx, new_num_lb, |ctx, reason| {
+				reason.extend([denominator.min_lit(ctx), result.min_lit(ctx)]);
 			})?;
 		}
 
 		if res_lb > 0 {
 			let new_denom_ub = num_ub / res_lb;
 			if new_denom_ub < denom_ub {
-				denominator.tighten_max(
-					ctx,
-					new_denom_ub,
-					|ctx: &mut E::PropagationContext<'_>| {
-						[
-							numerator.max_lit(ctx),
-							numerator.lit(ctx, IntLitMeaning::GreaterEq(0)),
-							result.min_lit(ctx),
-							denominator.lit(ctx, IntLitMeaning::GreaterEq(1)),
-						]
-					},
-				)?;
+				denominator.tighten_max(ctx, new_denom_ub, |ctx, reason| {
+					reason.extend([
+						numerator.max_lit(ctx),
+						numerator.lit(ctx, IntLitMeaning::GreaterEq(0)),
+						result.min_lit(ctx),
+						denominator.lit(ctx, IntLitMeaning::GreaterEq(1)),
+					]);
+				})?;
 			}
 		}
 
 		if let Some(res_ub_inc) = NonZero::new(res_ub + 1) {
 			let new_denom_lb = div_ceil(num_lb + 1, res_ub_inc);
 			if new_denom_lb > denom_lb {
-				denominator.tighten_min(
-					ctx,
-					new_denom_lb,
-					|ctx: &mut E::PropagationContext<'_>| {
-						[
-							numerator.min_lit(ctx),
-							result.max_lit(ctx),
-							result.lit(ctx, IntLitMeaning::GreaterEq(0)),
-							denominator.lit(ctx, IntLitMeaning::GreaterEq(1)),
-						]
-					},
-				)?;
+				denominator.tighten_min(ctx, new_denom_lb, |ctx, reason| {
+					reason.extend([
+						numerator.min_lit(ctx),
+						result.max_lit(ctx),
+						result.lit(ctx, IntLitMeaning::GreaterEq(0)),
+						denominator.lit(ctx, IntLitMeaning::GreaterEq(1)),
+					]);
+				})?;
 			}
 		}
 
@@ -176,20 +168,20 @@ impl<I1, I2, I3> IntDivBounds<I1, I2, I3> {
 		if denom_lb != 0 {
 			let new_res_ub = num_ub / denom_lb;
 			if new_res_ub < res_ub {
-				result.tighten_max(ctx, new_res_ub, |ctx: &mut E::PropagationContext<'_>| {
-					[numerator.max_lit(ctx), denominator.min_lit(ctx)]
+				result.tighten_max(ctx, new_res_ub, |ctx, reason| {
+					reason.extend([numerator.max_lit(ctx), denominator.min_lit(ctx)]);
 				})?;
 			}
 		}
 
 		let new_num_ub = (res_ub + 1) * denom_ub - 1;
 		if new_num_ub < num_ub {
-			numerator.tighten_max(ctx, new_num_ub, |ctx: &mut E::PropagationContext<'_>| {
-				[
+			numerator.tighten_max(ctx, new_num_ub, |ctx, reason| {
+				reason.extend([
 					denominator.lit(ctx, IntLitMeaning::GreaterEq(1)),
 					denominator.max_lit(ctx),
 					result.max_lit(ctx),
-				]
+				]);
 			})?;
 		}
 		Ok(())
@@ -210,7 +202,7 @@ where
 		use pindakaas::propositional_logic::Formula::*;
 
 		// Always exclude zero from the domain.
-		self.denominator.remove_val(ctx, 0, [])?;
+		self.denominator.remove_val(ctx, 0, NO_REASON)?;
 
 		// Channel the signs of the decision variables
 		let num_pos = self.numerator.lit(ctx, IntLitMeaning::GreaterEq(0));

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -15,14 +15,15 @@ use crate::{
 	IntVal,
 	actions::{
 		BoolAnalyzeActions, BoolInitActions, BoolInspectionActions, BoolPropagationActions,
-		BoolSimplificationActions, InitActions, IntAnalyzeActions, IntDecisionActions, IntEvent,
-		IntInitActions, IntInspectionActions, IntPropCond, IntPropagationActions,
-		IntSimplificationActions, PostingActions, PropagationActions, ReasonActions,
-		ReasoningContext, ReasoningEngine, SimplificationActions, Trailed, TrailingActions,
+		BoolSimplificationActions, DeferReasonActions, InitActions, IntAnalyzeActions,
+		IntDecisionActions, IntEvent, IntInitActions, IntInspectionActions, IntPropCond,
+		IntPropagationActions, IntSimplificationActions, PostingActions, PropagationActions,
+		PropagationContext, ReasonActions, ReasoningContext, ReasoningEngine,
+		SimplificationActions, Trailed, TrailingActions,
 	},
 	constraints::{
 		BoolModelActions, BoolSolverActions, Constraint, IntModelActions, IntSolverActions,
-		Propagator, ReasonBuilder, SimplificationStatus,
+		NO_REASON, Propagator, SimplificationStatus, reason_ty,
 	},
 	helpers::{
 		overflow::{OverflowImpossible, OverflowMode, OverflowPossible},
@@ -178,12 +179,20 @@ where
 
 	fn propagate(&mut self, ctx: &mut E::PropagationContext<'_>) -> Result<(), E::Conflict> {
 		// Channel bounds of self.vars[0] to self.vars[1]
-		self.vars[0].tighten_min(ctx, self.vars[1].min(ctx), [self.vars[1].min_lit(ctx)])?;
-		self.vars[0].tighten_max(ctx, self.vars[1].max(ctx), [self.vars[1].max_lit(ctx)])?;
+		self.vars[0].tighten_min(ctx, self.vars[1].min(ctx), |ctx, reason| {
+			reason.push(self.vars[1].min_lit(ctx));
+		})?;
+		self.vars[0].tighten_max(ctx, self.vars[1].max(ctx), |ctx, reason| {
+			reason.push(self.vars[1].max_lit(ctx));
+		})?;
 
 		// Channel bounds of self.vars[1] to self.vars[0]
-		self.vars[1].tighten_min(ctx, self.vars[0].min(ctx), [self.vars[0].min_lit(ctx)])?;
-		self.vars[1].tighten_max(ctx, self.vars[0].max(ctx), [self.vars[0].max_lit(ctx)])?;
+		self.vars[1].tighten_min(ctx, self.vars[0].min(ctx), |ctx, reason| {
+			reason.push(self.vars[0].min_lit(ctx));
+		})?;
+		self.vars[1].tighten_max(ctx, self.vars[0].max(ctx), |ctx, reason| {
+			reason.push(self.vars[0].max_lit(ctx));
+		})?;
 		Ok(())
 	}
 }
@@ -192,7 +201,7 @@ impl<OF: OverflowMode> IntLinear<OF> {
 	/// Internal method to negate the linear constraint.
 	fn negate<Ctx>(self, ctx: &mut Ctx) -> Result<Self, Ctx::Conflict>
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		model::View<IntVal>: IntPropagationActions<Ctx>,
 	{
 		Ok(match self.comparator {
@@ -350,16 +359,22 @@ where
 		match *self.terms.as_slice() {
 			[var] if self.reif.is_none() => {
 				match (self.comparator, self.rhs.try_into()) {
-					(LinComparator::Equal, Ok(rhs)) => var.fix(ctx, rhs, [])?,
-					(LinComparator::Equal, Err(_)) => return Err(ctx.declare_conflict([])),
-					(LinComparator::LessEq, Ok(rhs)) => var.tighten_max(ctx, rhs, [])?,
+					(LinComparator::Equal, Ok(rhs)) => var.fix(ctx, rhs, NO_REASON)?,
+					(LinComparator::Equal, Err(_)) => {
+						return Err(ctx.declare_conflict(NO_REASON));
+					}
+					(LinComparator::LessEq, Ok(rhs)) => {
+						var.tighten_max(ctx, rhs, NO_REASON)?;
+					}
 					(LinComparator::LessEq, Err(_)) if self.rhs < IntVal::MIN.into() => {
-						return Err(ctx.declare_conflict([]));
+						return Err(ctx.declare_conflict(NO_REASON));
 					}
 					(LinComparator::LessEq, Err(_)) => {
 						debug_assert!(self.rhs > IntVal::MAX.into());
 					}
-					(LinComparator::NotEqual, Ok(rhs)) => var.remove_val(ctx, rhs, [])?,
+					(LinComparator::NotEqual, Ok(rhs)) => {
+						var.remove_val(ctx, rhs, NO_REASON)?;
+					}
 					(LinComparator::NotEqual, Err(_)) => {}
 				}
 				return Ok(SimplificationStatus::Subsumed);
@@ -396,7 +411,7 @@ where
 					}
 					Err(_) => {
 						// TODO: might be incorrect
-						return Err(ctx.declare_conflict([]));
+						return Err(ctx.declare_conflict(NO_REASON));
 					}
 				}
 				return Ok(SimplificationStatus::Subsumed);
@@ -427,18 +442,15 @@ where
 			}
 			_ => None,
 		};
-		let fail_reason = |ctx: &mut E::PropagationContext<'_>| {
-			self.terms
-				.iter()
-				.map(|v| match self.comparator {
-					LinComparator::Equal if lb_sum > self.rhs => v.min_lit(ctx),
-					LinComparator::Equal if ub_sum < self.rhs => v.max_lit(ctx),
-					LinComparator::LessEq => v.min_lit(ctx),
-					LinComparator::NotEqual => v.val_lit(ctx).unwrap(),
-					_ => unreachable!(),
-				})
-				.collect_vec()
-		};
+		let fail_reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
+			reason.extend(self.terms.iter().map(|v| match self.comparator {
+				LinComparator::Equal if lb_sum > self.rhs => v.min_lit(ctx),
+				LinComparator::Equal if ub_sum < self.rhs => v.max_lit(ctx),
+				LinComparator::LessEq => v.min_lit(ctx),
+				LinComparator::NotEqual => v.val_lit(ctx).unwrap(),
+				_ => unreachable!(),
+			}));
+		});
 
 		if let Some(satisfied) = known_result {
 			return match self.reif {
@@ -449,23 +461,20 @@ where
 					Ok(SimplificationStatus::Subsumed)
 				}
 				Some(Reification::ReifiedBy(r)) if satisfied => {
-					r.require(ctx, |ctx: &mut E::PropagationContext<'_>| {
-						self.terms
-							.iter()
-							.flat_map(|v| match self.comparator {
-								LinComparator::NotEqual if lb_sum > self.rhs => {
-									vec![v.min_lit(ctx)]
-								}
-								LinComparator::NotEqual if ub_sum < self.rhs => {
-									vec![v.max_lit(ctx)]
-								}
-								LinComparator::LessEq => vec![v.max_lit(ctx)],
-								LinComparator::NotEqual => {
-									vec![v.min_lit(ctx), v.max_lit(ctx)]
-								}
-								_ => unreachable!(),
-							})
-							.collect_vec()
+					r.require(ctx, |ctx, reason| {
+						reason.extend(self.terms.iter().flat_map(|v| match self.comparator {
+							LinComparator::NotEqual if lb_sum > self.rhs => {
+								vec![v.min_lit(ctx)]
+							}
+							LinComparator::NotEqual if ub_sum < self.rhs => {
+								vec![v.max_lit(ctx)]
+							}
+							LinComparator::LessEq => vec![v.max_lit(ctx)],
+							LinComparator::NotEqual => {
+								vec![v.min_lit(ctx), v.max_lit(ctx)]
+							}
+							_ => unreachable!(),
+						}));
 					})?;
 					Ok(SimplificationStatus::Subsumed)
 				}
@@ -490,14 +499,15 @@ where
 		for (i, v) in self.terms.iter().enumerate() {
 			let lb_i = lb[i].into();
 			let new_ub = lb_diff + lb_i;
-			let reason = |ctx: &mut E::PropagationContext<'_>| {
-				self.terms
-					.iter()
-					.enumerate()
-					.filter(|&(j, _)| j != i)
-					.map(|(_, w)| w.min_lit(ctx))
-					.collect_vec()
-			};
+			let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
+				reason.extend(
+					self.terms
+						.iter()
+						.enumerate()
+						.filter(|&(j, _)| j != i)
+						.map(|(_, w)| w.min_lit(ctx)),
+				);
+			});
 			if let Some(Reification::ReifiedBy(r) | Reification::ImpliedBy(r)) = self.reif {
 				if lb_i > new_ub {
 					r.fix(ctx, false, reason)?;
@@ -506,7 +516,9 @@ where
 			} else {
 				match new_ub.try_into() {
 					Ok(new_ub) => v.tighten_max(ctx, new_ub, reason)?,
-					Err(_) if new_ub < IntVal::MIN.into() => return Err(ctx.declare_conflict([])),
+					Err(_) if new_ub < IntVal::MIN.into() => {
+						return Err(ctx.declare_conflict(NO_REASON));
+					}
 					Err(_) => {
 						debug_assert!(new_ub > IntVal::MAX.into());
 					}
@@ -527,14 +539,15 @@ where
 			for (i, v) in self.terms.iter().enumerate() {
 				let ub_i = ub[i].into();
 				let new_lb = ub_diff + ub_i;
-				let reason = |ctx: &mut E::PropagationContext<'_>| {
-					self.terms
-						.iter()
-						.enumerate()
-						.filter(|&(j, _)| j != i)
-						.map(|(_, &w)| w.max_lit(ctx))
-						.collect_vec()
-				};
+				let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
+					reason.extend(
+						self.terms
+							.iter()
+							.enumerate()
+							.filter(|&(j, _)| j != i)
+							.map(|(_, &w)| w.max_lit(ctx)),
+					);
+				});
 				if let Some(Reification::ReifiedBy(r) | Reification::ImpliedBy(r)) = self.reif {
 					if ub_i < new_lb {
 						r.fix(ctx, false, reason)?;
@@ -544,7 +557,7 @@ where
 					match new_lb.try_into() {
 						Ok(new_lb) => v.tighten_min(ctx, new_lb, reason)?,
 						Err(_) if new_lb > IntVal::MAX.into() => {
-							return Err(ctx.declare_conflict([]));
+							return Err(ctx.declare_conflict(NO_REASON));
 						}
 						Err(_) => {
 							debug_assert!(new_lb < IntVal::MAX.into());
@@ -809,10 +822,9 @@ where
 			// Propagate the reified variable if the sum of lower bounds is greater than the
 			// right-hand-side value
 			if lb_sum > self.max {
-				self.reification
-					.fix(ctx, false, |ctx: &mut E::PropagationContext<'_>| {
-						self.terms.iter().map(|v| v.min_lit(ctx)).collect_vec()
-					})?;
+				self.reification.fix(ctx, false, |ctx, reason| {
+					reason.extend(self.terms.iter().map(|v| v.min_lit(ctx)));
+				})?;
 			}
 		}
 
@@ -824,13 +836,12 @@ where
 
 		// propagate the upper bound of the variables
 		for (j, v) in self.terms.iter().enumerate() {
-			let reason = ctx.deferred_reason(j as u64);
 			let ub = (self.max - lb_sum) + v.min(ctx).into();
 			match ub.try_into() {
-				Ok(ub) => v.tighten_max(ctx, ub, reason)?,
+				Ok(ub) => v.tighten_max(ctx, ub, |_, rsn| rsn.defer(j as u64))?,
 				Err(_) if ub < IntVal::MIN.into() => v
 					.lit(ctx, IntLitMeaning::Less(IntVal::MIN))
-					.require(ctx, reason)?,
+					.require(ctx, |_, rsn| rsn.defer(j as u64))?,
 				Err(_) => {
 					debug_assert!(ub > v.max(ctx).into());
 				}
@@ -1035,29 +1046,23 @@ where
 	/// Helper function to construct the reason for propagation given the index
 	/// of the variable in the list of variables to sum or the length of the
 	/// list, if explaining the reification.
-	fn reason<Ctx>(&self, data: usize) -> impl ReasonBuilder<Ctx> + '_
+	fn reason<Ctx>(&self, data: usize) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + '_
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		IV: IntDecisionActions<Ctx>,
 		BV: Clone + Into<Ctx::Atom> + 'static,
 	{
-		move |ctx: &mut Ctx| {
-			let mut conj: Vec<_> = self
-				.terms
-				.iter()
-				.enumerate()
-				.filter_map(|(i, v)| {
-					if data != i {
-						Some(v.val_lit(ctx).unwrap())
-					} else {
-						None
-					}
-				})
-				.collect();
+		move |ctx, reason| {
+			reason.extend(self.terms.iter().enumerate().filter_map(|(i, v)| {
+				if data != i {
+					Some(v.val_lit(ctx).unwrap())
+				} else {
+					None
+				}
+			}));
 			if TypeId::of::<BV>() != TypeId::of::<True>() && data != self.terms.len() {
-				conj.push(self.reification.clone().into());
+				reason.push(self.reification.clone().into());
 			}
-			conj
 		}
 	}
 }

--- a/crates/huub/src/constraints/int_mul.rs
+++ b/crates/huub/src/constraints/int_mul.rs
@@ -13,7 +13,7 @@ use crate::{
 		ReasoningContext, ReasoningEngine,
 	},
 	constraints::{
-		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
+		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus, reason_ty,
 	},
 	helpers::{
 		div_ceil, div_floor,
@@ -152,21 +152,15 @@ where
 		skip(self, ctx)
 	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationContext<'_>) -> Result<(), E::Conflict> {
-		let (f1_lb, f1_ub) = self.factor1.bounds(ctx);
-		let f1_lb_lit = self.factor1.min_lit(ctx);
-		let f1_ub_lit = self.factor1.max_lit(ctx);
-		let (f2_lb, f2_ub) = self.factor2.bounds(ctx);
-		let f2_lb_lit = self.factor2.min_lit(ctx);
-		let f2_ub_lit = self.factor2.max_lit(ctx);
-		let (pr_lb, pr_ub) = self.product.bounds(ctx);
-		let pr_lb_lit = self.product.min_lit(ctx);
-		let pr_ub_lit = self.product.max_lit(ctx);
+		let (f1_min, f1_max) = self.factor1.bounds(ctx);
+		let (f2_min, f2_max) = self.factor2.bounds(ctx);
+		let (pr_min, pr_max) = self.product.bounds(ctx);
 
 		// TODO: Filter possibilities based on whether variables can be both positive
 		// and negative.
 
 		// Calculate possible bounds for the product
-		let minmax = iproduct!([f1_lb, f1_ub], [f2_lb, f2_ub])
+		let minmax = iproduct!([f1_min, f1_max], [f2_min, f2_max])
 			.map(|(a, b)| Self::mul(a, b))
 			.minmax();
 		let (min, max) = match minmax {
@@ -174,12 +168,15 @@ where
 			MinMaxResult::OneElement(b) => (b, b),
 			MinMaxResult::MinMax(min, max) => (min, max),
 		};
-		let reason = &[
-			f1_lb_lit.clone(),
-			f1_ub_lit.clone(),
-			f2_lb_lit.clone(),
-			f2_ub_lit.clone(),
-		];
+
+		let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
+			reason.extend([
+				self.factor1.min_lit(ctx),
+				self.factor1.max_lit(ctx),
+				self.factor2.min_lit(ctx),
+				self.factor2.max_lit(ctx),
+			]);
+		});
 		// z >= x * y
 		self.product.tighten_min(ctx, min, reason)?;
 		// z <= x * y
@@ -187,16 +184,23 @@ where
 
 		// Propagate the bounds of the first factor if the second factor is known
 		// positive or known negative.
-		if f2_lb > 0 || f2_ub < 0 {
-			let reason = &[pr_lb_lit.clone(), pr_ub_lit.clone(), f2_lb_lit, f2_ub_lit];
+		if f2_min > 0 || f2_max < 0 {
+			let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
+				reason.extend([
+					self.product.min_lit(ctx),
+					self.product.max_lit(ctx),
+					self.factor2.min_lit(ctx),
+					self.factor2.max_lit(ctx),
+				]);
+			});
 			// factor1 >= product / factor2
-			let min = iproduct!([pr_lb, pr_ub], [f2_lb, f2_ub])
+			let min = iproduct!([pr_min, pr_max], [f2_min, f2_max])
 				.map(|(pr, f2)| div_ceil(pr, NonZero::new(f2).unwrap()))
 				.min()
 				.unwrap();
 			self.factor1.tighten_min(ctx, min, reason)?;
 			// factor1 <= product / factor2
-			let max = iproduct!([pr_lb, pr_ub], [f2_lb, f2_ub])
+			let max = iproduct!([pr_min, pr_max], [f2_min, f2_max])
 				.map(|(pr, f2)| div_floor(pr, NonZero::new(f2).unwrap()))
 				.max()
 				.unwrap();
@@ -205,16 +209,23 @@ where
 
 		// Propagate the bounds of the second factor if the first factor is known
 		// positive or known negative.
-		if f1_lb > 0 || f1_ub < 0 {
-			let reason = &[pr_lb_lit, pr_ub_lit, f1_lb_lit, f1_ub_lit];
+		if f1_min > 0 || f1_max < 0 {
+			let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
+				reason.extend([
+					self.product.min_lit(ctx),
+					self.product.max_lit(ctx),
+					self.factor1.min_lit(ctx),
+					self.factor1.max_lit(ctx),
+				]);
+			});
 			// factor2 >= product / factor1
-			let min = iproduct!([pr_lb, pr_ub], [f1_lb, f1_ub])
+			let min = iproduct!([pr_min, pr_max], [f1_min, f1_max])
 				.map(|(pr, f1)| div_ceil(pr, NonZero::new(f1).unwrap()))
 				.min()
 				.unwrap();
 			self.factor2.tighten_min(ctx, min, reason)?;
 			// factor2 <= product / factor1
-			let max = iproduct!([pr_lb, pr_ub], [f1_lb, f1_ub])
+			let max = iproduct!([pr_min, pr_max], [f1_min, f1_max])
 				.map(|(pr, f1)| div_floor(pr, NonZero::new(f1).unwrap()))
 				.max()
 				.unwrap();

--- a/crates/huub/src/constraints/int_no_overlap.rs
+++ b/crates/huub/src/constraints/int_no_overlap.rs
@@ -13,7 +13,8 @@ use crate::{
 	IntVal,
 	actions::{
 		ConstructionActions, InitActions, IntDecisionActions, IntInspectionActions, IntPropCond,
-		PostingActions, ReasoningContext, ReasoningEngine, Trailed, TrailingActions,
+		PostingActions, PropagationContext, ReasonActions, ReasoningContext, ReasoningEngine,
+		Trailed, TrailingActions,
 	},
 	constraints::{
 		BoxedPropagator, Constraint, IntModelActions, IntSolverActions, Propagator,
@@ -180,17 +181,16 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 	/// the bounds if a forbidden region extends beyond the domain of the object
 	/// being pruned, which can lead to more general explanations.
 	fn explain_forbidden_regions<Ctx>(
-		&mut self,
+		&self,
 		ctx: &mut Ctx,
 		forbidden_regions: &[(Region, usize)],
 		obj: usize,
-	) -> Vec<Ctx::Atom>
-	where
-		Ctx: ReasoningContext + ?Sized,
+		reason: &mut Ctx::ReasonSink<'_>,
+	) where
+		Ctx: PropagationContext + ?Sized,
 		I1: IntDecisionActions<Ctx>,
 		I2: IntInspectionActions<Ctx>,
 	{
-		let mut reason = Vec::new();
 		for (region, support) in forbidden_regions.iter() {
 			for d in 0..self.num_dimensions() {
 				// If sizes are not [`IntVal`], their lower bounds contribute to the
@@ -223,7 +223,6 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 				);
 			}
 		}
-		reason
 	}
 
 	/// Generates a complete explanation for a pruning an object's origin
@@ -234,42 +233,41 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 	///    pruned (`dim`) of the object being pruned (`obj`).
 	/// 2. The literals that explain the existence of the forbidden regions that
 	///    forced the pruning.
-	fn explain_origin_propagation<Ctx>(
-		&mut self,
-		ctx: &mut Ctx,
-		forbidden_regions: &[(Region, usize)],
+	fn explain_origin_propagation<'a, Ctx>(
+		&'a self,
+		forbidden_regions: &'a [(Region, usize)],
 		obj: usize,
 		dim: usize,
 		prune_upper: bool,
-	) -> Vec<Ctx::Atom>
+	) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + 'a
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		I1: IntDecisionActions<Ctx>,
 		I2: IntInspectionActions<Ctx>,
 	{
-		let mut reason: Vec<_> = Vec::new();
-		for d in 0..self.num_dimensions() {
-			// If sizes are not [`IntVal`], their lower bounds contribute to the
-			// forbidden region and must be part of the explanation.
-			if TypeId::of::<I2>() != TypeId::of::<IntVal>() {
-				reason.push(self.size[[obj, d]].min_lit(ctx));
-			}
+		move |ctx, reason| {
+			for d in 0..self.num_dimensions() {
+				// If sizes are not [`IntVal`], their lower bounds contribute to the
+				// forbidden region and must be part of the explanation.
+				if TypeId::of::<I2>() != TypeId::of::<IntVal>() {
+					reason.push(self.size[[obj, d]].min_lit(ctx));
+				}
 
-			// The literal for the bound we are about to prune is implicitly part of the
-			// conclusion, so we only need to explain the *other* bounds of the object.
-			if d == dim {
-				if prune_upper {
-					reason.push(self.origin[[obj, d]].max_lit(ctx));
+				// The literal for the bound we are about to prune is implicitly part of the
+				// conclusion, so we only need to explain the *other* bounds of the object.
+				if d == dim {
+					if prune_upper {
+						reason.push(self.origin[[obj, d]].max_lit(ctx));
+					} else {
+						reason.push(self.origin[[obj, d]].min_lit(ctx));
+					}
 				} else {
+					reason.push(self.origin[[obj, d]].max_lit(ctx));
 					reason.push(self.origin[[obj, d]].min_lit(ctx));
 				}
-			} else {
-				reason.push(self.origin[[obj, d]].max_lit(ctx));
-				reason.push(self.origin[[obj, d]].min_lit(ctx));
 			}
+			self.explain_forbidden_regions(ctx, forbidden_regions, obj, reason);
 		}
-		reason.extend(self.explain_forbidden_regions(ctx, forbidden_regions, obj));
-		reason
 	}
 
 	/// Generates the explanation for a size reduction in dimension `dim` for
@@ -278,30 +276,29 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 	/// The propagation follows from the two objects being unable to separate in
 	/// any other dimension, and `cause` being unable to lie first in `dim`.
 	fn explain_size_propagation<Ctx>(
-		&mut self,
-		ctx: &mut Ctx,
+		&self,
 		target: usize,
 		cause: usize,
 		dim: usize,
-	) -> Vec<Ctx::Atom>
+	) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + '_
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		I1: IntDecisionActions<Ctx>,
 		I2: IntInspectionActions<Ctx>,
 	{
-		let mut reason = Vec::new();
-		for d in 0..self.num_dimensions() {
-			for obj in [target, cause] {
-				reason.push(self.origin[[obj, d]].min_lit(ctx));
-				reason.push(self.origin[[obj, d]].max_lit(ctx));
-				// Leave out `target`'s size lower bound in `dim`: the conclusion is an
-				// upper bound on its size, which does not depend on its lower bound.
-				if (obj, d) != (target, dim) {
-					reason.push(self.size[[obj, d]].min_lit(ctx));
+		move |ctx, reason| {
+			for d in 0..self.num_dimensions() {
+				for obj in [target, cause] {
+					reason.push(self.origin[[obj, d]].min_lit(ctx));
+					reason.push(self.origin[[obj, d]].max_lit(ctx));
+					// Leave out `target`'s size lower bound in `dim`: the conclusion is an
+					// upper bound on its size, which does not depend on its lower bound.
+					if (obj, d) != (target, dim) {
+						reason.push(self.size[[obj, d]].min_lit(ctx));
+					}
 				}
 			}
 		}
-		reason
 	}
 
 	/// Checks if the origin of a given object is fixed in all dimensions.
@@ -385,10 +382,11 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 			// there (it pokes out below the interval, `true`, but not above, `false`).
 			if single_free && let Some((dim, true, false)) = free {
 				let bound = self.origin_ub[[i, dim]] - self.origin_lb[[obj, dim]];
-				if bound < self.size[[obj, dim]].max(ctx) {
-					let reason = self.explain_size_propagation(ctx, obj, i, dim);
-					self.size[[obj, dim]].tighten_max(ctx, bound, reason)?;
-				}
+				self.size[[obj, dim]].tighten_max(
+					ctx,
+					bound,
+					self.explain_size_propagation(obj, i, dim),
+				)?;
 			}
 
 			// An interval that is empty in some dimension forbids no origin.
@@ -584,9 +582,11 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 
 		// If the sweep found a new, lower feasible upper bound, propagate it.
 		if sweep[dim] != self.origin_ub[[obj, dim]] {
-			let reason = self.explain_origin_propagation(ctx, forbidden_regions, obj, dim, true);
-			self.origin[[obj, dim]].tighten_max(ctx, sweep[dim], reason)?;
-
+			self.origin[[obj, dim]].tighten_max(
+				ctx,
+				sweep[dim],
+				self.explain_origin_propagation(forbidden_regions, obj, dim, true),
+			)?;
 			self.origin_ub[[obj, dim]] = sweep[dim];
 		}
 		Ok(())
@@ -642,9 +642,11 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 		}
 		// If the sweep found a new, higher feasible lower bound, propagate it.
 		if sweep[dim] != self.origin_lb[[obj, dim]] {
-			let reason = self.explain_origin_propagation(ctx, forbidden_regions, obj, dim, false);
-			self.origin[[obj, dim]].tighten_min(ctx, sweep[dim], reason)?;
-
+			self.origin[[obj, dim]].tighten_min(
+				ctx,
+				sweep[dim],
+				self.explain_origin_propagation(forbidden_regions, obj, dim, false),
+			)?;
 			self.origin_lb[[obj, dim]] = sweep[dim];
 		}
 		Ok(())
@@ -752,22 +754,24 @@ where
 
 			// Reason about the object's overlaps: collect the forbidden regions for
 			// the origin sweep below and, from the same intervals, tighten its size.
-			let forbidden_regions = self.forbidden_regions::<E>(ctx, obj)?;
-			if !forbidden_regions.is_empty() {
+			let forbidden = self.forbidden_regions::<E>(ctx, obj)?;
+			if !forbidden.is_empty() {
 				// Check for conflicts: if an object is fixed and is in a forbidden
 				// region, it's a conflict.
 				if self.fixed_object(obj) {
-					let reason =
-						self.explain_origin_propagation(ctx, &forbidden_regions, obj, 0, false);
 					// Trigger a conflict by increasing the lower bound.
-					self.origin[[obj, 0]].tighten_min(ctx, self.origin_lb[[obj, 0]] + 1, reason)?;
+					self.origin[[obj, 0]].tighten_min(
+						ctx,
+						self.origin_lb[[obj, 0]] + 1,
+						self.explain_origin_propagation(&forbidden, obj, 0, false),
+					)?;
 				}
 
 				// Prune the domains of the origin variables for the current object.
 				let mut all_fixed = true;
 				for d in 0..self.num_dimensions() {
-					self.prune_min(ctx, &forbidden_regions, obj, d)?;
-					self.prune_max(ctx, &forbidden_regions, obj, d)?;
+					self.prune_min(ctx, &forbidden, obj, d)?;
+					self.prune_max(ctx, &forbidden, obj, d)?;
 
 					if self.origin_lb[[obj, d]] != self.origin_ub[[obj, d]] {
 						all_fixed = false;

--- a/crates/huub/src/constraints/int_pow.rs
+++ b/crates/huub/src/constraints/int_pow.rs
@@ -10,11 +10,10 @@ use crate::{
 	IntVal,
 	actions::{
 		InitActions, IntDecisionActions, IntInspectionActions, IntPropCond, PostingActions,
-		ReasoningContext, ReasoningEngine,
+		ReasonActions, ReasoningContext, ReasoningEngine,
 	},
 	constraints::{
-		CachedReason, Constraint, IntModelActions, IntSolverActions, Propagator,
-		SimplificationStatus,
+		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus, reason_ty,
 	},
 	helpers::overflow::{OverflowImpossible, OverflowMode, OverflowPossible},
 	lower::{LoweringContext, LoweringError},
@@ -142,13 +141,13 @@ where
 			return Ok(());
 		}
 
-		let mut reason = CachedReason::new(|ctx: &mut E::PropagationContext<'_>| {
-			[
+		let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
+			reason.extend([
 				self.result.min_lit(ctx),
 				self.result.max_lit(ctx),
 				self.exponent.min_lit(ctx),
 				self.exponent.max_lit(ctx),
-			]
+			]);
 		});
 
 		// Propagate lower bound
@@ -169,7 +168,7 @@ where
 			{
 				min -= 1;
 			}
-			self.base.tighten_min(ctx, min, &mut reason)?;
+			self.base.tighten_min(ctx, min, reason)?;
 		}
 
 		// Propagate upper bound
@@ -189,7 +188,7 @@ where
 			if res_ub >= Self::pow(max + 1, if min < 0 { exp_pos_even } else { exp_lb }) {
 				max += 1;
 			}
-			self.base.tighten_max(ctx, max, &mut reason)?;
+			self.base.tighten_max(ctx, max, reason)?;
 		}
 		Ok(())
 	}
@@ -216,13 +215,13 @@ where
 		}
 
 		let (exp_lb, exp_ub) = self.exponent.bounds(ctx);
-		let mut reason = CachedReason::new(|ctx: &mut E::PropagationContext<'_>| {
-			[
+		let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
+			reason.extend([
 				self.result.min_lit(ctx),
 				self.result.max_lit(ctx),
 				self.base.min_lit(ctx),
 				self.base.max_lit(ctx),
-			]
+			]);
 		});
 
 		// Propagate lower bound
@@ -232,7 +231,7 @@ where
 			if res_lb <= Self::pow(base_lb, min - 1) {
 				min -= 1;
 			}
-			self.exponent.tighten_min(ctx, min, &mut reason)?;
+			self.exponent.tighten_min(ctx, min, reason)?;
 		}
 
 		// Propagate upper bound
@@ -242,7 +241,7 @@ where
 			if res_ub <= Self::pow(base_ub, max + 1) {
 				max += 1;
 			}
-			self.exponent.tighten_max(ctx, max, &mut reason)?;
+			self.exponent.tighten_max(ctx, max, reason)?;
 		}
 
 		Ok(())
@@ -324,16 +323,16 @@ where
 			MinMaxResult::MinMax(lb, ub) => (lb, ub),
 		};
 
-		let mut reason = CachedReason::new(|ctx: &mut E::PropagationContext<'_>| {
-			[
+		let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
+			reason.extend([
 				self.base.min_lit(ctx),
 				self.base.max_lit(ctx),
 				self.exponent.min_lit(ctx),
 				self.exponent.max_lit(ctx),
-			]
+			]);
 		});
-		self.result.tighten_min(ctx, lb, &mut reason)?;
-		self.result.tighten_max(ctx, ub, &mut reason)?;
+		self.result.tighten_min(ctx, lb, reason)?;
+		self.result.tighten_max(ctx, ub, reason)?;
 		Ok(())
 	}
 }
@@ -435,14 +434,14 @@ where
 	) -> Result<SimplificationStatus, E::Conflict> {
 		// If the base is negative, then the exponent cannot be zero
 		if self.base.max(ctx) < 0 {
-			self.base.remove_val(ctx, 0, [self.base.max_lit(ctx)])?;
+			self.base
+				.remove_val(ctx, 0, |ctx, reason| reason.push(self.base.max_lit(ctx)))?;
 		}
 		// If the exponent is zero, then the result is one
 		if self.exponent.val(ctx) == Some(0) {
-			self.result
-				.fix(ctx, 1, |ctx: &mut E::PropagationContext<'_>| {
-					[self.exponent.val_lit(ctx).unwrap()]
-				})?;
+			self.result.fix(ctx, 1, |ctx, reason| {
+				reason.push(self.exponent.val_lit(ctx).unwrap());
+			})?;
 		}
 
 		self.propagate(ctx)?;
@@ -503,14 +502,13 @@ where
 			&& let Some(exp) = self.exponent.val(ctx)
 			&& overflowing_pow(base, exp).1
 		{
-			self.exponent
-				.tighten_max(ctx, exp - 1, |ctx: &mut E::PropagationContext<'_>| {
-					[if base.is_positive() {
-						self.base.min_lit(ctx)
-					} else {
-						self.base.max_lit(ctx)
-					}]
-				})?;
+			self.exponent.tighten_max(ctx, exp - 1, |ctx, reason| {
+				reason.push(if base.is_positive() {
+					self.base.min_lit(ctx)
+				} else {
+					self.base.max_lit(ctx)
+				});
+			})?;
 		}
 
 		Ok(())

--- a/crates/huub/src/constraints/int_set_contains.rs
+++ b/crates/huub/src/constraints/int_set_contains.rs
@@ -2,7 +2,6 @@
 //! that an integer decision variable is assigned to a member of a given set
 //! if-and-only-if a given Boolean decision variable is assigned to `true`.
 
-use itertools::Itertools;
 use pindakaas::propositional_logic::Formula;
 use rangelist::IntervalIterator;
 
@@ -10,12 +9,12 @@ use crate::{
 	IntSet, IntVal,
 	actions::{
 		BoolInitActions, BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions,
-		IntInitActions, IntInspectionActions, IntPropCond, IntSimplificationActions,
+		IntInitActions, IntInspectionActions, IntPropCond, IntSimplificationActions, ReasonActions,
 		ReasoningEngine, SimplificationActions,
 	},
 	constraints::{
 		BoolModelActions, BoolSolverActions, Constraint, IntModelActions, IntSolverActions,
-		Propagator, SimplificationStatus,
+		NO_REASON, Propagator, SimplificationStatus,
 	},
 	lower::{LoweringContext, LoweringError},
 	model::{expressions::BoolFormula, view::View},
@@ -50,12 +49,17 @@ where
 		// Check whether `reif` is set, then just enforce the domain.
 		match self.reif.val(ctx) {
 			Some(true) => {
-				self.var
-					.restrict_domain(ctx, &self.set, [self.reif.into()])?;
+				self.var.restrict_domain(ctx, &self.set, |_, reason| {
+					let atom: E::Atom = self.reif.into();
+					reason.push(atom);
+				})?;
 				return Ok(SimplificationStatus::Subsumed);
 			}
 			Some(false) => {
-				self.var.exclude(ctx, &self.set, [(!self.reif).into()])?;
+				self.var.exclude(ctx, &self.set, |_, reason| {
+					let atom: E::Atom = (!self.reif).into();
+					reason.push(atom);
+				})?;
 				return Ok(SimplificationStatus::Subsumed);
 			}
 			None => {}
@@ -65,20 +69,20 @@ where
 		self.set = self.set.intersect(&domain);
 		// If the intersection is empty, then `reif` must be false.
 		if self.set.is_empty() {
-			self.reif
-				.fix(ctx, false, |_: &mut E::PropagationContext<'_>| {
+			self.reif.fix(ctx, false, |_, reason| {
+				reason.extend(
 					self.set
 						.iter()
 						.flatten()
-						.map(|v| self.var.ne(v).into())
-						.collect_vec()
-				})?;
+						.map(|v| -> E::Atom { self.var.ne(v).into() }),
+				);
+			})?;
 			return Ok(SimplificationStatus::Subsumed);
 		}
 		// If `set` is a superset of domain, then it is known that `reif` is true.
 		// (After intersection, we can just check equality)
 		if domain == self.set {
-			self.reif.require(ctx, [])?;
+			self.reif.require(ctx, NO_REASON)?;
 			return Ok(SimplificationStatus::Subsumed);
 		}
 		// Otherwise, we check whether we can rewrite the constraint into a simpler

--- a/crates/huub/src/constraints/int_table.rs
+++ b/crates/huub/src/constraints/int_table.rs
@@ -14,7 +14,7 @@ use crate::{
 		ReasoningEngine,
 	},
 	constraints::{
-		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
+		Constraint, IntModelActions, IntSolverActions, NO_REASON, Propagator, SimplificationStatus,
 	},
 	lower::{LoweringContext, LoweringError},
 	model::View,
@@ -54,7 +54,7 @@ where
 			0 => return Ok(SimplificationStatus::Subsumed),
 			1 => {
 				let dom = self.table.iter().map(|v| v[0]..=v[0]).collect();
-				self.vars[0].restrict_domain(ctx, &dom, [])?;
+				self.vars[0].restrict_domain(ctx, &dom, NO_REASON)?;
 				return Ok(SimplificationStatus::Subsumed);
 			}
 			_ => {}
@@ -73,14 +73,14 @@ where
 
 		// If no tuples remain, then the problem is trivially unsatisfiable.
 		if self.table.is_empty() {
-			return Err(ctx.declare_conflict([]));
+			return Err(ctx.declare_conflict(NO_REASON));
 		}
 
 		// Restrict the domain of the variables to the values it can take in the
 		// tuple.
 		if self.table.len() == 1 {
 			for (j, &var) in self.vars.iter().enumerate() {
-				var.fix(ctx, self.table[0][j], [])?;
+				var.fix(ctx, self.table[0][j], NO_REASON)?;
 			}
 			return Ok(SimplificationStatus::Subsumed);
 		}
@@ -89,7 +89,7 @@ where
 			let dom = (0..self.table.len())
 				.map(|i| self.table[i][j]..=self.table[i][j])
 				.collect();
-			var.restrict_domain(ctx, &dom, [])?;
+			var.restrict_domain(ctx, &dom, NO_REASON)?;
 		}
 
 		Ok(SimplificationStatus::NoFixpoint)

--- a/crates/huub/src/constraints/int_unique/bounds.rs
+++ b/crates/huub/src/constraints/int_unique/bounds.rs
@@ -121,7 +121,9 @@ impl<I> IntUniqueBounds<I> {
 					k -= 1;
 				}
 
-				self.vars[self.max_sorted[i]].tighten_min(ctx, hall_max, reason)?;
+				self.vars[self.max_sorted[i]].tighten_min(ctx, hall_max, |_, sink| {
+					sink.extend(reason);
+				})?;
 				self.lb_cache[self.max_sorted[i]] = hall_max;
 
 				Self::path_set(&mut self.hall_interval, min_rank, w, w);
@@ -192,7 +194,9 @@ impl<I> IntUniqueBounds<I> {
 					k += 1;
 				}
 
-				self.vars[self.min_sorted[i]].tighten_max(ctx, hall_min - 1, reason)?;
+				self.vars[self.min_sorted[i]].tighten_max(ctx, hall_min - 1, |_, sink| {
+					sink.extend(reason);
+				})?;
 				self.ub_cache[self.min_sorted[i]] = hall_min - 1;
 
 				Self::path_set(&mut self.hall_interval, max_rank, w, w);

--- a/crates/huub/src/constraints/int_unique/domain.rs
+++ b/crates/huub/src/constraints/int_unique/domain.rs
@@ -12,8 +12,8 @@ use tracing::trace;
 use crate::{
 	IntVal,
 	actions::{
-		InitActions, IntEvent, IntInspectionActions, IntPropCond, PostingActions,
-		PropagationActions, ReasonActions, ReasoningContext, ReasoningEngine,
+		DeferReasonActions, InitActions, IntEvent, IntInspectionActions, IntPropCond,
+		PostingActions, PropagationActions, ReasonActions, ReasoningContext, ReasoningEngine,
 	},
 	constraints::{IntSolverActions, Propagator},
 	helpers::trailed_partition::TrailedPartition,
@@ -312,18 +312,11 @@ impl<I> IntUniqueDomain<I> {
 			self.graph.dcn_to_val[start_dcn] = Some(val_idx);
 		}
 
-		Err(ctx.declare_conflict(
-			move |ctx: &mut E::PropagationContext<'_>| -> Vec<<E as ReasoningEngine>::Atom> {
-				let mut reason = Vec::new();
-				self.build_hall_set_reason(
-					ctx,
-					&self.bfs.queue,
-					&mut reason,
-					|dcn, ctx, meaning| dcn.lit(ctx, meaning),
-				);
-				reason
-			},
-		))
+		Err(ctx.declare_conflict(move |ctx, reason| {
+			self.build_hall_set_reason(ctx, &self.bfs.queue, reason, |dcn, ctx, meaning| {
+				dcn.lit(ctx, meaning)
+			});
+		}))
 	}
 
 	/// Create a new [`IntUniqueDomain`] propagator and post it in the solver.
@@ -405,17 +398,16 @@ impl<I> IntUniqueDomain<I> {
 		// values (a matched val's matched_dcn is in this SCC; for an unmatched
 		// val, any in-SCC decision serves as the SCC representative). One scc_id
 		// covers every value in the SCC.
-		let scc_id = new_root;
-		let val_reason = ctx.deferred_reason(scc_id as u64);
+		let scc_id = new_root as u64;
 		for &val_idx in self.tarjan.vals_buf.iter() {
 			let val = self.graph.value_at(val_idx);
 			for pos in orig_root..new_root {
 				let dcn_idx = self.partition.elements()[pos];
-				let dcn = self.graph.dcns[dcn_idx].clone();
+				let dcn = &self.graph.dcns[dcn_idx];
 				if !dcn.in_domain(ctx, val) {
 					continue;
 				}
-				dcn.remove_val(ctx, val, val_reason)?;
+				dcn.remove_val(ctx, val, |_, reason| reason.defer(scc_id))?;
 			}
 		}
 		Ok(())
@@ -718,15 +710,13 @@ impl<I> IntUniqueDomain<I> {
 			if let Some(val) = self.graph.dcns[i].val(ctx) {
 				let scc_id = self.partition.block_root(i, ctx);
 				let scc_end = self.partition.block_end(scc_id, ctx);
+				let reason_lit = self.graph.dcns[i].lit(ctx, IntLitMeaning::Eq(val));
 				for pos in scc_id..scc_end {
 					let idx = self.partition.elements()[pos];
-					let reason_lit = self.graph.dcns[i].lit(ctx, IntLitMeaning::Eq(val));
 					if idx != i {
-						self.graph.dcns[idx].remove_val(
-							ctx,
-							val,
-							[reason_lit.clone()].as_slice(),
-						)?;
+						self.graph.dcns[idx].remove_val(ctx, val, |_, reason| {
+							reason.push(reason_lit.clone());
+						})?;
 						// If `val` was the matched value for decision at `idx`, then it is now
 						// unmatched.
 						if self.graph.dcn_to_val[idx]

--- a/crates/huub/src/constraints/int_unique/value.rs
+++ b/crates/huub/src/constraints/int_unique/value.rs
@@ -8,7 +8,7 @@
 use itertools::Itertools;
 
 use crate::{
-	actions::{InitActions, IntEvent, IntPropCond, PostingActions, ReasoningEngine},
+	actions::{InitActions, IntEvent, IntPropCond, PostingActions, ReasonActions, ReasoningEngine},
 	constraints::{IntSolverActions, Propagator},
 	solver::engine::Engine,
 };
@@ -100,13 +100,13 @@ where
 		for &i in &self.action_list {
 			// Retrieve the value and value literal for the fixed decision.
 			let val = self.vars[i].val(ctx).unwrap();
-			let reason = &[self.vars[i].val_lit(ctx).unwrap()];
+			let val_lit = self.vars[i].val_lit(ctx).unwrap();
 
 			// We now enforce that all other decisions (at different indices) are not
 			// equal to the fixed value.
 			for (j, v) in self.vars.iter().enumerate() {
 				if j != i {
-					v.remove_val(ctx, val, reason)?;
+					v.remove_val(ctx, val, |_, reason| reason.push(val_lit.clone()))?;
 				}
 			}
 		}

--- a/crates/huub/src/constraints/int_value_precede.rs
+++ b/crates/huub/src/constraints/int_value_precede.rs
@@ -5,10 +5,11 @@
 use std::cmp::{max, min};
 
 use crate::{
-	Conjunction, IntVal,
+	IntVal,
 	actions::{
 		ConstructionActions, InitActions, IntDecisionActions, IntInspectionActions, IntPropCond,
-		PostingActions, ReasoningContext, ReasoningEngine, Trailed, TrailingActions,
+		PostingActions, PropagationContext, ReasonActions, ReasoningContext, ReasoningEngine,
+		Trailed, TrailingActions,
 	},
 	constraints::{
 		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
@@ -78,13 +79,12 @@ impl<I> IntSeqPrecedeChainBounds<I> {
 		&self,
 		i: usize,
 		k: IntVal,
-	) -> impl FnOnce(&mut Ctx) -> Conjunction<Ctx::Atom> + '_
+	) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + '_
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		I: IntDecisionActions<Ctx>,
 	{
-		move |ctx: &mut Ctx| {
-			let mut reason = Vec::new();
+		move |ctx, reason| {
 			// Explain a lower bound via 3 cases:
 			// - Lower bound of var i is above k - This is the value that required the
 			//   earlier lower bound that is currently explained (end of recursion).
@@ -109,8 +109,7 @@ impl<I> IntSeqPrecedeChainBounds<I> {
 				}
 			}
 
-			reason.extend(self.explain_upper(i, k)(ctx));
-			reason
+			self.explain_upper(i, k)(ctx, reason);
 		}
 	}
 
@@ -119,17 +118,18 @@ impl<I> IntSeqPrecedeChainBounds<I> {
 		&self,
 		i: usize,
 		k: IntVal,
-	) -> impl FnOnce(&mut Ctx) -> Conjunction<Ctx::Atom> + '_
+	) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + '_
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		I: IntDecisionActions<Ctx>,
 	{
-		move |ctx: &mut Ctx| {
-			self.vars
-				.iter()
-				.take(i)
-				.map(|v| v.lit(ctx, IntLitMeaning::Less(k)))
-				.collect()
+		move |ctx, reason| {
+			reason.extend(
+				self.vars
+					.iter()
+					.take(i)
+					.map(|v| v.lit(ctx, IntLitMeaning::Less(k))),
+			);
 		}
 	}
 
@@ -443,14 +443,12 @@ impl<I> IntValuePrecedeChainValue<I> {
 		&self,
 		i: usize,
 		j: usize,
-	) -> impl FnOnce(&mut Ctx) -> Conjunction<Ctx::Atom> + '_
+	) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + '_
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		I: IntDecisionActions<Ctx>,
 	{
-		move |ctx: &mut Ctx| {
-			let mut reason = Vec::new();
-
+		move |ctx, reason| {
 			// Explain a lower bound via 3 cases:
 			// - Current lower bound index is above k - This is the value that required the
 			//   earlier lower bound that is currently explained (end of recursion).
@@ -495,9 +493,8 @@ impl<I> IntValuePrecedeChainValue<I> {
 			}
 
 			if j > 0 {
-				reason.extend(self.explain_upper(i, j)(ctx));
+				self.explain_upper(i, j)(ctx, reason);
 			}
-			reason
 		}
 	}
 
@@ -507,17 +504,18 @@ impl<I> IntValuePrecedeChainValue<I> {
 		&self,
 		i: usize,
 		j: usize,
-	) -> impl FnOnce(&mut Ctx) -> Conjunction<Ctx::Atom> + '_
+	) -> impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>) + '_
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		I: IntDecisionActions<Ctx>,
 	{
-		move |ctx: &mut Ctx| {
-			self.vars
-				.iter()
-				.take(i)
-				.map(|v| v.lit(ctx, IntLitMeaning::NotEq(self.values[j - 1])))
-				.collect()
+		move |ctx, reason| {
+			reason.extend(
+				self.vars
+					.iter()
+					.take(i)
+					.map(|v| v.lit(ctx, IntLitMeaning::NotEq(self.values[j - 1]))),
+			);
 		}
 	}
 

--- a/crates/huub/src/helpers/true_type.rs
+++ b/crates/huub/src/helpers/true_type.rs
@@ -5,9 +5,8 @@ use std::ops::Not;
 use crate::{
 	actions::{
 		BoolInitActions, BoolInspectionActions, BoolPropagationActions, PropagationActions,
-		ReasoningContext,
+		PropagationContext, ReasoningContext,
 	},
-	constraints::ReasonBuilder,
 	model, solver,
 };
 
@@ -42,8 +41,8 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: bool,
-		reason: impl ReasonBuilder<Ctx>,
-	) -> Result<(), <Ctx as ReasoningContext>::Conflict> {
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
+	) -> Result<(), <Ctx as PropagationContext>::Conflict> {
 		if !val {
 			return Err(ctx.declare_conflict(reason));
 		}

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -76,10 +76,6 @@ use rangelist::RangeList;
 /// documentation.
 type Clause<L> = Vec<L>;
 
-/// Type alias for a conjunction of literals, used for internal type
-/// documentation.
-type Conjunction<L> = Vec<L>;
-
 /// Type alias for an integer set parameter value.
 type IntSet = Set<IntVal>;
 

--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -8,6 +8,7 @@ use std::{
 	fmt::{self, Debug, Display},
 	marker::PhantomData,
 	num::NonZeroI32,
+	ops::Not,
 };
 
 use bon::Builder;
@@ -28,10 +29,10 @@ use crate::{
 	IntSet, IntVal,
 	actions::{
 		BoolInspectionActions, ConstructionActions, IntDecisionActions, IntInspectionActions,
-		PostingActions, ReasoningContext, ReasoningEngine, Trailed,
+		PostingActions, PropagationContext, ReasoningContext, ReasoningEngine, Trailed,
 	},
 	constraints::{
-		BoxedConstraint, BoxedPropagator, Conflict, Constraint, ReasonBuilder,
+		BoxedConstraint, BoxedPropagator, Constraint, NO_REASON, Nogood,
 		int_array_minimum::IntArrayMinimumBounds,
 		int_div::IntDivBounds,
 		int_linear::{IntEq, IntLinear, LinComparator},
@@ -152,7 +153,7 @@ trait LoweringActions {
 	fn add_clause(
 		&mut self,
 		clause: Vec<solver::View<bool>>,
-	) -> Result<(), <Engine as ReasoningEngine>::Conflict>;
+	) -> Result<(), Nogood<solver::Decision<bool>>>;
 
 	/// Add a propagator to the solver.
 	fn add_propagator(&mut self, propagator: BoxedPropagator);
@@ -238,10 +239,10 @@ pub struct LoweringContext<'a> {
 pub enum LoweringError {
 	/// Error used when a conflict is found during the simplification process of
 	/// the model.
-	Simplification(<Model as ReasoningEngine>::Conflict),
+	Simplification(Nogood<model::View<bool>>),
 	/// Error used when a conflict is found by the SAT solver when lowering the
 	/// problem.
-	Lowering(<Engine as ReasoningEngine>::Conflict),
+	Lowering(Nogood<solver::Decision<bool>>),
 }
 
 /// A lowering helper that maps decisions in a [`Model`] object to the
@@ -824,7 +825,7 @@ impl<'a> LoweringContext<'a> {
 			Err(false) => unreachable!(),
 			Err(true) => return Ok(()),
 			Ok(clause) if clause.is_empty() => {
-				return Err(self.declare_conflict([]).into());
+				return Err(self.declare_conflict(NO_REASON).into());
 			}
 			Ok(clause) => clause,
 		};
@@ -854,9 +855,11 @@ impl<'a> LoweringContext<'a> {
 	/// lowering.
 	pub fn declare_conflict(
 		&mut self,
-		reason: impl ReasonBuilder<Self>,
-	) -> <Self as ReasoningContext>::Conflict {
-		Conflict::new(self, None, reason)
+		reason: impl FnOnce(&mut Self, &mut <Self as PropagationContext>::ReasonSink<'_>),
+	) -> <Self as PropagationContext>::Conflict {
+		let mut sink = Vec::new();
+		reason(self, &mut sink);
+		Nogood::from_view_iter(sink.into_iter().map(Not::not))
 	}
 
 	/// Read a trailed value from the [`Model`] trail.
@@ -951,9 +954,13 @@ impl PostingActions for LoweringContext<'_> {
 	}
 }
 
+impl PropagationContext for LoweringContext<'_> {
+	type Conflict = <Solver as PropagationContext>::Conflict;
+	type ReasonSink<'a> = Vec<Self::Atom>;
+}
+
 impl ReasoningContext for LoweringContext<'_> {
 	type Atom = <Engine as ReasoningEngine>::Atom;
-	type Conflict = <Engine as ReasoningEngine>::Conflict;
 }
 
 impl Display for LoweringError {
@@ -973,13 +980,25 @@ impl Error for LoweringError {}
 
 impl From<<Engine as ReasoningEngine>::Conflict> for LoweringError {
 	fn from(value: <Engine as ReasoningEngine>::Conflict) -> Self {
-		Self::Lowering(value)
+		Self::Lowering(value.into_nogood())
 	}
 }
 
 impl From<<Model as ReasoningEngine>::Conflict> for LoweringError {
 	fn from(value: <Model as ReasoningEngine>::Conflict) -> Self {
+		Self::Simplification(value.into_nogood())
+	}
+}
+
+impl From<Nogood<model::View<bool>>> for LoweringError {
+	fn from(value: Nogood<model::View<bool>>) -> Self {
 		Self::Simplification(value)
+	}
+}
+
+impl From<Nogood<solver::Decision<bool>>> for LoweringError {
+	fn from(value: Nogood<solver::Decision<bool>>) -> Self {
+		Self::Lowering(value)
 	}
 }
 
@@ -1243,8 +1262,8 @@ impl<Sat: ExternalPropagation> LoweringActions for Solver<Sat> {
 	fn add_clause(
 		&mut self,
 		clause: Vec<solver::View<bool>>,
-	) -> Result<(), <Engine as ReasoningEngine>::Conflict> {
-		Solver::add_clause(self, clause)
+	) -> Result<(), <Solver as PropagationContext>::Conflict> {
+		self.add_clause(clause)
 	}
 
 	fn add_propagator(&mut self, propagator: BoxedPropagator) {
@@ -1312,9 +1331,13 @@ impl<Sat: ExternalPropagation> LoweringActions for Solver<Sat> {
 	}
 }
 
+impl PropagationContext for dyn LoweringActions + '_ {
+	type Conflict = <Solver as PropagationContext>::Conflict;
+	type ReasonSink<'a> = <Solver as PropagationContext>::ReasonSink<'a>;
+}
+
 impl ReasoningContext for dyn LoweringActions + '_ {
 	type Atom = <Engine as ReasoningEngine>::Atom;
-	type Conflict = <Engine as ReasoningEngine>::Conflict;
 }
 
 impl BoolInspectionActions<LoweringContext<'_>> for solver::Decision<bool> {

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -27,12 +27,12 @@ pub use crate::model::{
 use crate::{
 	IntSet, IntVal,
 	actions::{
-		ConstructionActions, DecisionActions, IntEvent, IntInspectionActions, PropagationActions,
-		ReasoningContext, ReasoningEngine, SimplificationActions, Trailed, TrailingActions,
+		ConstructionActions, DecisionActions, DeferReasonActions, IntEvent, IntInspectionActions,
+		PropagationActions, PropagationContext, ReasonActions, ReasoningContext, ReasoningEngine,
+		SimplificationActions, Trailed, TrailingActions,
 	},
 	constraints::{
-		BoxedConstraint, Conflict, Constraint, DeferredReason, Reason, ReasonBuilder,
-		SimplificationStatus,
+		BoxedConstraint, Conflict, ConflictInner, Constraint, Nogood, SimplificationStatus,
 	},
 	helpers::bytes::Bytes,
 	lower::{Lowerer, LowererComplete},
@@ -138,6 +138,26 @@ pub struct Model {
 	advisors: Vec<Advisor>,
 }
 
+/// The engine-internal [`PropagationContext`] used while simplifying a
+/// [`Model`]'s constraints.
+#[derive(Debug)]
+pub struct SimplificationContext<'a>(pub(crate) &'a mut Model);
+
+/// The reason-build sink for a [`SimplificationContext`]: a reason closure
+/// either collects the reason atoms into `conditions`, or defers the reason to
+/// the current propagator via [`DeferReasonActions::defer`].
+///
+/// Unlike the user-facing [`Model`] reason sink, this sink implements
+/// [`DeferReasonActions`], so only constraint reasons can defer.
+#[derive(Debug, Default)]
+pub struct SimplificationReasonSink {
+	/// The reason atoms pushed so far.
+	pub(crate) conditions: Vec<View<bool>>,
+	/// `Some(data)` once the reason has been deferred; the propagator index is
+	/// folded in by the caller.
+	pub(crate) deferred: Option<u64>,
+}
+
 impl AdvRef {
 	/// Recreate the advisor reference from a raw value.
 	pub(crate) fn from_raw(raw: u32) -> Self {
@@ -187,6 +207,15 @@ impl ConRef {
 }
 
 impl Model {
+	/// Adapt a reason closure written against the user-facing [`Model`] into
+	/// one usable within a [`SimplificationContext`]. The model closure cannot
+	/// defer, so nothing is lost.
+	pub(crate) fn adapt_reason<'a>(
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink) {
+		move |ctx, sink| reason(&mut *ctx.0, &mut sink.conditions)
+	}
+
 	/// Notify a single boolean advisor or propagator.
 	fn advise_of_bool_change(&mut self, con: ConRef, data: u64) -> bool {
 		if let Some(mut c) = self.constraints[con.index()].take() {
@@ -206,26 +235,6 @@ impl Model {
 			ret
 		} else {
 			false
-		}
-	}
-
-	/// Create a [`ReasoningEngine::Conflict`] instance based on the failure to
-	/// set `subject`, that must be set because of `reason`.
-	fn create_conflict(
-		&mut self,
-		subject: View<bool>,
-		reason: impl ReasonBuilder<Self>,
-	) -> <Self as ReasoningEngine>::Conflict {
-		match reason.build_reason(self) {
-			Ok(reason) => Conflict {
-				subject: Some(subject),
-				reason,
-			},
-			Err(true) => Conflict {
-				subject: None,
-				reason: Reason::Simple(!subject),
-			},
-			Err(false) => unreachable!("invalid reason"),
 		}
 	}
 
@@ -490,7 +499,7 @@ impl Model {
 	pub fn post_constraint<C: Constraint<Self>>(
 		&mut self,
 		constraint: C,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		let (con, enqueue) = self.initialize_constraint(constraint);
 		if enqueue {
 			self.propagate_single(con)?;
@@ -521,7 +530,7 @@ impl Model {
 	/// process (see [`Self::lower`]). You generally only need to call this
 	/// method manually if you want to inspect the results of propagation
 	/// (e.g. decision variable domains) during the modeling process.
-	pub fn propagate(&mut self) -> Result<(), Conflict<View<bool>>> {
+	pub fn propagate(&mut self) -> Result<(), Nogood<View<bool>>> {
 		self.notify_advisors();
 		while let Some(con) = self.propagator_queue.pop() {
 			self.propagate_single(ConRef::from_raw(con))?;
@@ -531,30 +540,32 @@ impl Model {
 
 	/// Propagate the constraint at index `con`, updating the domains of the
 	/// variables and rewriting the constraint if necessary.
-	pub(crate) fn propagate_single(&mut self, con: ConRef) -> Result<(), Conflict<View<bool>>> {
+	pub(crate) fn propagate_single(&mut self, con: ConRef) -> Result<(), Nogood<View<bool>>> {
 		let Some(mut con_obj) = self.constraints[con.index()].take() else {
 			return Ok(());
 		};
 		self.cur_prop = Some(con);
-		let mut status = con_obj.simplify(self);
+		let mut status = con_obj.simplify(&mut SimplificationContext(&mut *self));
 		self.cur_prop = None;
 
-		// Resolve lazy explanation if it is required.
-		if let Err(Conflict {
+		// Resolve a deferred conflict's clause while the propagator is available.
+		if let Err(Conflict(ConflictInner::Deferred {
 			subject,
-			reason: Reason::Lazy(r),
-		}) = status
+			propagator,
+			data,
+		})) = status
 		{
-			debug_assert_eq!(ConRef::new(r.propagator as usize), con);
+			debug_assert_eq!(ConRef::new(propagator as usize), con);
 			let mut conj = Vec::new();
-			con_obj.explain(self, subject.unwrap_or(false.into()), r.data, &mut conj);
-			status = Err(Conflict {
-				subject,
-				reason: Reason::Eager(conj.into_boxed_slice()),
-			});
+			con_obj.explain(self, subject.unwrap_or(false.into()), data, &mut conj);
+			// Fold the subject in as the clause head.
+			if let Some(subject) = subject {
+				conj.push(subject);
+			}
+			status = Err(Conflict(ConflictInner::Clause(conj.into_boxed_slice())));
 		};
 
-		match status? {
+		match status.map_err(Conflict::into_nogood)? {
 			SimplificationStatus::Subsumed => {
 				// Constraint is known to be satisfied, no need to place back.
 			}
@@ -600,31 +611,23 @@ impl DecisionActions for Model {
 }
 
 impl PropagationActions for Model {
-	fn declare_conflict(&mut self, reason: impl ReasonBuilder<Self>) -> Conflict<View<bool>> {
-		match reason.build_reason(self) {
-			Ok(reason) => Conflict {
-				subject: None,
-				reason,
-			},
-			Err(false) => panic!("invalid reason"),
-			Err(true) => Conflict {
-				subject: None,
-				reason: Reason::Eager(Box::new([])),
-			},
-		}
+	fn declare_conflict(
+		&mut self,
+		reason: impl FnOnce(&mut Self, &mut Self::ReasonSink<'_>),
+	) -> Nogood<View<bool>> {
+		let mut sink = Vec::new();
+		reason(&mut *self, &mut sink);
+		Nogood(sink.into())
 	}
+}
 
-	fn deferred_reason(&self, data: u64) -> DeferredReason {
-		DeferredReason {
-			propagator: self.cur_prop.unwrap().index() as u32,
-			data,
-		}
-	}
+impl PropagationContext for Model {
+	type Conflict = Nogood<View<bool>>;
+	type ReasonSink<'a> = Vec<View<bool>>;
 }
 
 impl ReasoningContext for Model {
 	type Atom = <Self as ReasoningEngine>::Atom;
-	type Conflict = <Self as ReasoningEngine>::Conflict;
 }
 
 impl ReasoningEngine for Model {
@@ -634,7 +637,7 @@ impl ReasoningEngine for Model {
 	type ExplanationContext<'a> = Self;
 	type InitializationContext<'a> = ModelInitContext<'a>;
 	type NotificationContext<'a> = Self;
-	type PropagationContext<'a> = Self;
+	type PropagationContext<'a> = SimplificationContext<'a>;
 	type ReasonSink<'a> = Vec<View<bool>>;
 }
 
@@ -659,6 +662,110 @@ impl TrailingActions for Model {
 	}
 }
 
+impl SimplificationContext<'_> {
+	/// Create a conflict from the failure to set `subject` (folded in as the
+	/// clause head), required by `reason`.
+	pub(crate) fn create_conflict(
+		&mut self,
+		subject: View<bool>,
+		reason: impl FnOnce(&mut Self, &mut SimplificationReasonSink),
+	) -> Conflict<View<bool>> {
+		let mut sink = SimplificationReasonSink::default();
+		reason(&mut *self, &mut sink);
+		match sink.deferred {
+			Some(data) => Conflict(ConflictInner::Deferred {
+				subject: Some(subject),
+				propagator: self.0.cur_prop.unwrap().index() as u32,
+				data,
+			}),
+			None => {
+				// Fold the subject in as the clause head.
+				sink.conditions.push(subject);
+				Conflict(ConflictInner::Clause(sink.conditions.into_boxed_slice()))
+			}
+		}
+	}
+}
+
+impl ConstructionActions for SimplificationContext<'_> {
+	fn new_trailed<T: Bytes>(&mut self, init: T) -> Trailed<T> {
+		self.0.new_trailed(init)
+	}
+}
+
+impl DecisionActions for SimplificationContext<'_> {
+	fn num_conflicts(&self) -> u64 {
+		self.0.num_conflicts()
+	}
+}
+
+impl PropagationActions for SimplificationContext<'_> {
+	fn declare_conflict(
+		&mut self,
+		reason: impl FnOnce(&mut Self, &mut Self::ReasonSink<'_>),
+	) -> Conflict<View<bool>> {
+		let mut sink = SimplificationReasonSink::default();
+		reason(&mut *self, &mut sink);
+		match sink.deferred {
+			Some(data) => Conflict(ConflictInner::Deferred {
+				subject: None,
+				propagator: self.0.cur_prop.unwrap().index() as u32,
+				data,
+			}),
+			None => Conflict(ConflictInner::Clause(sink.conditions.into_boxed_slice())),
+		}
+	}
+}
+
+impl PropagationContext for SimplificationContext<'_> {
+	type Conflict = Conflict<View<bool>>;
+	type ReasonSink<'a> = SimplificationReasonSink;
+}
+
+impl ReasoningContext for SimplificationContext<'_> {
+	type Atom = View<bool>;
+}
+
+impl SimplificationActions for SimplificationContext<'_> {
+	type Target = Model;
+
+	fn post_constraint<C: Constraint<Model>>(&mut self, constraint: C) {
+		self.0.post_constraint_internal(constraint);
+	}
+}
+
+impl TrailingActions for SimplificationContext<'_> {
+	fn set_trailed<T: Bytes>(&mut self, i: Trailed<T>, v: T) -> T {
+		self.0.set_trailed(i, v)
+	}
+
+	fn trailed<T: Bytes>(&self, i: Trailed<T>) -> T {
+		self.0.trailed(i)
+	}
+}
+
+impl DeferReasonActions<View<bool>> for SimplificationReasonSink {
+	fn defer(&mut self, data: u64) {
+		self.deferred = Some(data);
+	}
+}
+
+impl Extend<View<bool>> for SimplificationReasonSink {
+	fn extend<T: IntoIterator<Item = View<bool>>>(&mut self, iter: T) {
+		self.conditions.extend(iter);
+	}
+}
+
+impl ReasonActions<View<bool>> for SimplificationReasonSink {
+	fn push(&mut self, atom: View<bool>) {
+		self.conditions.push(atom);
+	}
+
+	fn reserve(&mut self, additional: usize) {
+		self.conditions.reserve(additional);
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use expect_test::expect;
@@ -672,7 +779,8 @@ mod tests {
 			ReasoningEngine, Trailed, TrailingActions,
 		},
 		constraints::{
-			BoolModelActions, Constraint, IntModelActions, Propagator, SimplificationStatus,
+			BoolModelActions, Constraint, IntModelActions, NO_REASON, Propagator,
+			SimplificationStatus,
 		},
 		lower::{LoweringContext, LoweringError},
 		model::{Model, View, deserialize::AnyView},
@@ -721,7 +829,8 @@ mod tests {
 			int_check,
 		};
 		prb.post_constraint(t).unwrap();
-		i.tighten_min(&mut prb, 2, []).expect("tighten_min failed");
+		i.tighten_min(&mut prb, 2, NO_REASON)
+			.expect("tighten_min failed");
 		let (_, _): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");
 		assert_eq!(prb.trailed(bool_check), 1);
 	}
@@ -741,7 +850,8 @@ mod tests {
 			int_check,
 		};
 		prb.post_constraint(t).unwrap();
-		i.tighten_min(&mut prb, 1, []).expect("tighten_min failed");
+		i.tighten_min(&mut prb, 1, NO_REASON)
+			.expect("tighten_min failed");
 		let (_, _): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");
 		assert_eq!(prb.trailed(bool_check), 0);
 	}
@@ -761,8 +871,10 @@ mod tests {
 			int_check,
 		};
 		prb.post_constraint(t).unwrap();
-		i.tighten_min(&mut prb, 1, []).expect("tighten_min failed");
-		i.tighten_max(&mut prb, 2, []).expect("tighten_max failed");
+		i.tighten_min(&mut prb, 1, NO_REASON)
+			.expect("tighten_min failed");
+		i.tighten_max(&mut prb, 2, NO_REASON)
+			.expect("tighten_max failed");
 		let (mut slv, map): (Solver, _) = prb.lower().to_solver().expect("to_solver failed");
 		assert_eq!(prb.trailed(int_check), 1);
 		let i_slv = map.get(&mut slv, i);

--- a/crates/huub/src/model/decision/boolean.rs
+++ b/crates/huub/src/model/decision/boolean.rs
@@ -5,12 +5,10 @@ use std::ops::Not;
 use pindakaas::Lit as RawLit;
 
 use crate::{
-	actions::{
-		BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions, ReasoningContext,
-	},
-	constraints::ReasonBuilder,
+	actions::{BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions},
+	constraints::{Conflict, Nogood},
 	model::{
-		Model,
+		Model, SimplificationContext, SimplificationReasonSink,
 		decision::{Decision, DecisionReference, PolarityScore, private},
 		view::View,
 	},
@@ -55,14 +53,36 @@ impl BoolInspectionActions<Model> for Decision<bool> {
 	}
 }
 
+impl BoolInspectionActions<SimplificationContext<'_>> for Decision<bool> {
+	fn val(&self, ctx: &SimplificationContext<'_>) -> Option<bool> {
+		self.val(&*ctx.0)
+	}
+}
+
 impl BoolPropagationActions<Model> for Decision<bool> {
 	fn fix(
 		&self,
 		ctx: &mut Model,
 		val: bool,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		self.resolve_alias(ctx).fix(ctx, val, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.fix(
+			&mut SimplificationContext(ctx),
+			val,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
+	}
+}
+
+impl<'a> BoolPropagationActions<SimplificationContext<'a>> for Decision<bool> {
+	fn fix(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		val: bool,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).fix(ctx, val, reason)
 	}
 }
 
@@ -71,9 +91,20 @@ impl BoolSimplificationActions<Model> for Decision<bool> {
 		&self,
 		ctx: &mut Model,
 		other: impl Into<View<bool>>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let other = other.into().resolve_alias(ctx);
-		self.resolve_alias(ctx).unify(ctx, other)
+	) -> Result<(), Nogood<View<bool>>> {
+		self.unify(&mut SimplificationContext(ctx), other)
+			.map_err(Conflict::into_nogood)
+	}
+}
+
+impl BoolSimplificationActions<SimplificationContext<'_>> for Decision<bool> {
+	fn unify(
+		&self,
+		ctx: &mut SimplificationContext<'_>,
+		other: impl Into<View<bool>>,
+	) -> Result<(), Conflict<View<bool>>> {
+		let other = other.into().resolve_alias(&*ctx.0);
+		self.resolve_alias(&*ctx.0).unify(ctx, other)
 	}
 }
 

--- a/crates/huub/src/model/decision/integer.rs
+++ b/crates/huub/src/model/decision/integer.rs
@@ -10,9 +10,9 @@ use crate::{
 		IntDecisionActions, IntEvent, IntInspectionActions, IntPropCond, IntPropagationActions,
 		IntSimplificationActions, ReasoningContext,
 	},
-	constraints::ReasonBuilder,
+	constraints::{Conflict, NO_REASON, Nogood},
 	model::{
-		AdvRef, ConRef, Decision, Model,
+		AdvRef, ConRef, Decision, Model, SimplificationContext, SimplificationReasonSink,
 		decision::{DecisionReference, PolarityScore, private},
 		resolved::Resolved,
 		view::{View, boolean::BoolView, integer::IntView},
@@ -70,6 +70,16 @@ impl IntDecisionActions<Model> for Decision<IntVal> {
 	}
 }
 
+impl IntDecisionActions<SimplificationContext<'_>> for Decision<IntVal> {
+	fn lit(&self, ctx: &mut SimplificationContext<'_>, meaning: IntLitMeaning) -> View<bool> {
+		self.lit(&mut *ctx.0, meaning)
+	}
+
+	fn val_lit(&self, ctx: &mut SimplificationContext<'_>) -> Option<View<bool>> {
+		self.val_lit(&mut *ctx.0)
+	}
+}
+
 impl IntInspectionActions<Model> for Decision<IntVal> {
 	fn bounds(&self, ctx: &Model) -> (IntVal, IntVal) {
 		self.resolve_alias(ctx).bounds(ctx)
@@ -120,41 +130,155 @@ impl IntInspectionActions<Model> for Decision<IntVal> {
 	}
 }
 
+impl IntInspectionActions<SimplificationContext<'_>> for Decision<IntVal> {
+	fn bounds(&self, ctx: &SimplificationContext<'_>) -> (IntVal, IntVal) {
+		self.bounds(&*ctx.0)
+	}
+
+	fn domain(&self, ctx: &SimplificationContext<'_>) -> IntSet {
+		self.domain(&*ctx.0)
+	}
+
+	fn in_domain(&self, ctx: &SimplificationContext<'_>, val: IntVal) -> bool {
+		self.in_domain(&*ctx.0, val)
+	}
+
+	fn lit_meaning(
+		&self,
+		ctx: &SimplificationContext<'_>,
+		lit: <SimplificationContext<'_> as ReasoningContext>::Atom,
+	) -> Option<IntLitMeaning> {
+		self.lit_meaning(&*ctx.0, lit)
+	}
+
+	fn max(&self, ctx: &SimplificationContext<'_>) -> IntVal {
+		self.max(&*ctx.0)
+	}
+
+	fn max_lit(
+		&self,
+		ctx: &SimplificationContext<'_>,
+	) -> <SimplificationContext<'_> as ReasoningContext>::Atom {
+		self.max_lit(&*ctx.0)
+	}
+
+	fn min(&self, ctx: &SimplificationContext<'_>) -> IntVal {
+		self.min(&*ctx.0)
+	}
+
+	fn min_lit(
+		&self,
+		ctx: &SimplificationContext<'_>,
+	) -> <SimplificationContext<'_> as ReasoningContext>::Atom {
+		self.min_lit(&*ctx.0)
+	}
+
+	fn try_lit(
+		&self,
+		ctx: &SimplificationContext<'_>,
+		meaning: IntLitMeaning,
+	) -> Option<<SimplificationContext<'_> as ReasoningContext>::Atom> {
+		self.try_lit(&*ctx.0, meaning)
+	}
+
+	fn val(&self, ctx: &SimplificationContext<'_>) -> Option<IntVal> {
+		self.val(&*ctx.0)
+	}
+}
+
 impl IntPropagationActions<Model> for Decision<IntVal> {
 	fn fix(
 		&self,
 		ctx: &mut Model,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		self.resolve_alias(ctx).fix(ctx, val, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.fix(
+			&mut SimplificationContext(ctx),
+			val,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
 	}
 
 	fn remove_val(
 		&self,
 		ctx: &mut Model,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		self.resolve_alias(ctx).remove_val(ctx, val, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.remove_val(
+			&mut SimplificationContext(ctx),
+			val,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
 	}
 
 	fn tighten_max(
 		&self,
 		ctx: &mut Model,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		self.resolve_alias(ctx).tighten_max(ctx, val, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.tighten_max(
+			&mut SimplificationContext(ctx),
+			val,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
 	}
 
 	fn tighten_min(
 		&self,
 		ctx: &mut Model,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		self.resolve_alias(ctx).tighten_min(ctx, val, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.tighten_min(
+			&mut SimplificationContext(ctx),
+			val,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
+	}
+}
+
+impl<'a> IntPropagationActions<SimplificationContext<'a>> for Decision<IntVal> {
+	fn fix(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		val: IntVal,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).fix(ctx, val, reason)
+	}
+
+	fn remove_val(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		val: IntVal,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).remove_val(ctx, val, reason)
+	}
+
+	fn tighten_max(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		val: IntVal,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).tighten_max(ctx, val, reason)
+	}
+
+	fn tighten_min(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		val: IntVal,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).tighten_min(ctx, val, reason)
 	}
 }
 
@@ -163,27 +287,63 @@ impl IntSimplificationActions<Model> for Decision<IntVal> {
 		&self,
 		ctx: &mut Model,
 		values: &IntSet,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		self.resolve_alias(ctx).exclude(ctx, values, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.exclude(
+			&mut SimplificationContext(ctx),
+			values,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
 	}
 
 	fn restrict_domain(
 		&self,
 		ctx: &mut Model,
 		domain: &IntSet,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		self.resolve_alias(ctx).restrict_domain(ctx, domain, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.restrict_domain(
+			&mut SimplificationContext(ctx),
+			domain,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
+	}
+
+	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Nogood<View<bool>>> {
+		self.unify(&mut SimplificationContext(ctx), other)
+			.map_err(Conflict::into_nogood)
+	}
+}
+
+impl<'a> IntSimplificationActions<SimplificationContext<'a>> for Decision<IntVal> {
+	fn exclude(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		values: &IntSet,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).exclude(ctx, values, reason)
+	}
+
+	fn restrict_domain(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		domain: &IntSet,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0)
+			.restrict_domain(ctx, domain, reason)
 	}
 
 	fn unify(
 		&self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		other: impl Into<Self>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let me = self.resolve_alias(ctx);
-		let other = other.into().resolve_alias(ctx);
+	) -> Result<(), Conflict<View<bool>>> {
+		let me = self.resolve_alias(&*ctx.0);
+		let other = other.into().resolve_alias(&*ctx.0);
 		me.unify(ctx, other)?;
 		Ok(())
 	}
@@ -213,44 +373,47 @@ impl Resolved<Decision<IntVal>> {
 	/// that it can be aliased to directly point to `target`.
 	pub(crate) fn unify_internal(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'_>,
 		target: View<IntVal>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+	) -> Result<(), Conflict<View<bool>>> {
 		let idx = self.idx();
-		debug_assert!(matches!(ctx.int_vars[idx].domain, Domain::Domain(_)));
+		debug_assert!(matches!(ctx.0.int_vars[idx].domain, Domain::Domain(_)));
 
 		// Set the domain on the variable to be aliased to trigger subscription
 		// events.
-		self.restrict_domain(ctx, &target.domain(ctx), [])?;
+		self.restrict_domain(ctx, &target.domain(ctx), NO_REASON)?;
 		// Change variable to point to the target
-		match mem::replace(&mut ctx.int_vars[idx].domain, Domain::Alias(target)) {
+		match mem::replace(&mut ctx.0.int_vars[idx].domain, Domain::Alias(target)) {
 			// Restrict the domain of the target variable using the variable domain
 			// being aliased.
-			Domain::Domain(dom) => target.restrict_domain(ctx, &dom, [])?,
-			Domain::Alias(View(IntView::Const(v))) => target.fix(ctx, v, [])?,
+			Domain::Domain(dom) => target.restrict_domain(ctx, &dom, NO_REASON)?,
+			Domain::Alias(View(IntView::Const(v))) => target.fix(ctx, v, NO_REASON)?,
 			_ => unreachable!(),
 		};
 		// Process any pending integer events for the variable being aliased.
-		if let Some(event) = ctx.int_events.remove(&(idx as u32)) {
-			ctx.notify_int_event(idx as u32, event);
+		if let Some(event) = ctx.0.int_events.remove(&(idx as u32)) {
+			ctx.0.notify_int_event(idx as u32, event);
 		}
 		// Transfer any constraints from the aliased variable to the target variable
-		let constraints = mem::take(&mut ctx.int_vars[idx].constraints);
+		let constraints = mem::take(&mut ctx.0.int_vars[idx].constraints);
 		// Move subscriptions to target decision variable
 		match target.0 {
 			IntView::Linear(lin) => {
-				ctx.int_vars[lin.var.idx()].constraints.extend(constraints);
+				ctx.0.int_vars[lin.var.idx()]
+					.constraints
+					.extend(constraints);
 			}
 			IntView::Bool(lin) => match lin.var.0 {
 				inner @ (BoolView::IntEq(j, _)
 				| BoolView::IntNotEq(j, _)
 				| BoolView::IntGreaterEq(j, _)
 				| BoolView::IntLess(j, _)) => {
+					let model = &mut *ctx.0;
 					constraints.for_each_activated_by(
 						IntEvent::Fixed,
 						|act: ActivationAction<AdvRef, ConRef>| {
 							if let ActivationAction::Advise(adv) = act {
-								let def = &mut ctx.advisors[adv.index()];
+								let def = &mut model.advisors[adv.index()];
 								def.bool2int = true;
 								def.condition = Some(match inner {
 									BoolView::IntEq(_, v) => IntLitMeaning::Eq(v),
@@ -269,22 +432,23 @@ impl Resolved<Decision<IntVal>> {
 							} else {
 								IntPropCond::Bounds
 							};
-							ctx.int_vars[j.idx()].constraints.add(act, cond);
+							model.int_vars[j.idx()].constraints.add(act, cond);
 						},
 					);
 				}
 				// Move subscription to Boolean decision
 				BoolView::Decision(l) => {
 					let jdx = l.idx();
+					let model = &mut *ctx.0;
 					constraints.for_each_activated_by(
 						IntEvent::Fixed,
 						|act: ActivationAction<AdvRef, ConRef>| {
 							if let ActivationAction::Advise(adv) = act {
-								let def = &mut ctx.advisors[adv.index()];
+								let def = &mut model.advisors[adv.index()];
 								def.bool2int = true;
 								def.negated = false;
 							}
-							ctx.bool_vars[jdx].constraints.push(act.into());
+							model.bool_vars[jdx].constraints.push(act.into());
 						},
 					);
 				}
@@ -299,13 +463,13 @@ impl Resolved<Decision<IntVal>> {
 impl Resolved<Decision<IntVal>> {
 	/// Consuming variant of [`IntSimplificationActions::exclude`] for
 	/// canonical integer decisions.
-	pub(crate) fn exclude(
+	pub(crate) fn exclude<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		values: &IntSet,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let Domain::Domain(dom) = &ctx.int_vars[self.idx()].domain else {
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		let Domain::Domain(dom) = &ctx.0.int_vars[self.idx()].domain else {
 			unreachable!()
 		};
 		let diff: IntSet = dom.diff(values);
@@ -318,40 +482,43 @@ impl Resolved<Decision<IntVal>> {
 		if *dom == diff {
 			return Ok(());
 		}
+		let dom_min = *dom.min().unwrap();
+		let dom_max = *dom.max().unwrap();
 		let min = *diff.min().unwrap();
 		let max = *diff.max().unwrap();
 		if min == max {
-			ctx.int_vars[self.idx()].domain = Domain::Alias(min.into());
-			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
+			ctx.0.int_vars[self.idx()].domain = Domain::Alias(min.into());
+			ctx.0.int_events.insert(self.0.0, IntEvent::Fixed);
 		} else {
-			let entry = ctx.int_events.entry(self.0.0).or_insert(IntEvent::Domain);
-			if *dom.min().unwrap() != min {
+			let model = &mut *ctx.0;
+			let entry = model.int_events.entry(self.0.0).or_insert(IntEvent::Domain);
+			if dom_min != min {
 				*entry += IntEvent::LowerBound;
 			}
-			if *dom.max().unwrap() != max {
+			if dom_max != max {
 				*entry += IntEvent::UpperBound;
 			}
 
-			ctx.int_vars[self.idx()].domain = Domain::Domain(diff);
+			model.int_vars[self.idx()].domain = Domain::Domain(diff);
 		};
 		Ok(())
 	}
 
 	/// Consuming variant of [`IntPropagationActions::fix`] for canonical
 	/// integer decisions.
-	pub(crate) fn fix(
+	pub(crate) fn fix<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let def = &mut ctx.int_vars[self.idx()];
-		let Domain::Domain(dom) = &def.domain else {
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		let Domain::Domain(dom) = &ctx.0.int_vars[self.idx()].domain else {
 			unreachable!()
 		};
 		if dom.contains(&val) {
-			def.domain = Domain::Alias(val.into());
-			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
+			let model = &mut *ctx.0;
+			model.int_vars[self.idx()].domain = Domain::Alias(val.into());
+			model.int_events.insert(self.0.0, IntEvent::Fixed);
 			Ok(())
 		} else {
 			Err(ctx.create_conflict(View(BoolView::IntEq(self.0, val)), reason))
@@ -360,78 +527,86 @@ impl Resolved<Decision<IntVal>> {
 
 	/// Consuming variant of [`IntPropagationActions::remove_val`] for canonical
 	/// integer decisions.
-	pub(crate) fn remove_val(
+	pub(crate) fn remove_val<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
 		self.exclude(ctx, &(val..=val).into(), reason)
 	}
 
 	/// Consuming variant of [`IntSimplificationActions::restrict_domain`] for
 	/// canonical integer decisions.
-	pub(crate) fn restrict_domain(
+	pub(crate) fn restrict_domain<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		domain: &IntSet,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let Domain::Domain(dom) = &ctx.int_vars[self.idx()].domain else {
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		let Domain::Domain(dom) = &ctx.0.int_vars[self.idx()].domain else {
 			unreachable!()
 		};
 		let intersect: IntSet = dom.intersect(domain);
 		if intersect.is_empty() {
-			return Err(ctx.create_conflict(
-				View(BoolView::IntNotEq(self.0, *dom.min().unwrap())),
-				reason,
-			));
+			let subject = View(BoolView::IntNotEq(self.0, *dom.min().unwrap()));
+			return Err(ctx.create_conflict(subject, reason));
 		} else if *dom == intersect {
 			return Ok(());
 		}
+		let dom_min = *dom.min().unwrap();
+		let dom_max = *dom.max().unwrap();
 		let min = *intersect.min().unwrap();
 		let max = *intersect.max().unwrap();
 		if min == max {
-			ctx.int_vars[self.idx()].domain = Domain::Alias(min.into());
-			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
+			ctx.0.int_vars[self.idx()].domain = Domain::Alias(min.into());
+			ctx.0.int_events.insert(self.0.0, IntEvent::Fixed);
 		} else {
-			let entry = ctx.int_events.entry(self.0.0).or_insert(IntEvent::Domain);
-			if *dom.min().unwrap() != min {
+			let model = &mut *ctx.0;
+			let entry = model.int_events.entry(self.0.0).or_insert(IntEvent::Domain);
+			if dom_min != min {
 				*entry += IntEvent::LowerBound;
 			}
-			if *dom.max().unwrap() != max {
+			if dom_max != max {
 				*entry += IntEvent::UpperBound;
 			}
 
-			ctx.int_vars[self.idx()].domain = Domain::Domain(intersect);
+			model.int_vars[self.idx()].domain = Domain::Domain(intersect);
 		}
 		Ok(())
 	}
 
 	/// Consuming variant of [`IntPropagationActions::tighten_max`] for
 	/// canonical integer decisions.
-	pub(crate) fn tighten_max(
+	pub(crate) fn tighten_max<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let def = &mut ctx.int_vars[self.idx()];
-		let Domain::Domain(dom) = &mut def.domain else {
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		{
+			let Domain::Domain(dom) = &ctx.0.int_vars[self.idx()].domain else {
+				unreachable!()
+			};
+			if val >= *dom.max().unwrap() {
+				return Ok(());
+			} else if val < *dom.min().unwrap() {
+				return Err(ctx.create_conflict(View(BoolView::IntLess(self.0, val + 1)), reason));
+			}
+		}
+		let model = &mut *ctx.0;
+		let Domain::Domain(dom) = &mut model.int_vars[self.idx()].domain else {
 			unreachable!()
 		};
-		if val >= *dom.max().unwrap() {
-			return Ok(());
-		} else if val < *dom.min().unwrap() {
-			return Err(ctx.create_conflict(View(BoolView::IntLess(self.0, val + 1)), reason));
-		}
 		dom.tighten_max(val);
 		let min = *dom.min().unwrap();
-		if min == *dom.max().unwrap() {
-			def.domain = Domain::Alias(min.into());
-			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
+		let fixed = min == *dom.max().unwrap();
+		if fixed {
+			model.int_vars[self.idx()].domain = Domain::Alias(min.into());
+			model.int_events.insert(self.0.0, IntEvent::Fixed);
 		} else {
-			ctx.int_events
+			model
+				.int_events
 				.entry(self.0.0)
 				.and_modify(|v| *v += IntEvent::UpperBound)
 				.or_insert(IntEvent::UpperBound);
@@ -441,28 +616,35 @@ impl Resolved<Decision<IntVal>> {
 
 	/// Consuming variant of [`IntPropagationActions::tighten_min`] for
 	/// canonical integer decisions.
-	pub(crate) fn tighten_min(
+	pub(crate) fn tighten_min<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), <Model as ReasoningContext>::Conflict> {
-		let def = &mut ctx.int_vars[self.idx()];
-		let Domain::Domain(dom) = &mut def.domain else {
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		{
+			let Domain::Domain(dom) = &ctx.0.int_vars[self.idx()].domain else {
+				unreachable!()
+			};
+			if val <= *dom.min().unwrap() {
+				return Ok(());
+			} else if val > *dom.max().unwrap() {
+				return Err(ctx.create_conflict(View(BoolView::IntGreaterEq(self.0, val)), reason));
+			}
+		}
+		let model = &mut *ctx.0;
+		let Domain::Domain(dom) = &mut model.int_vars[self.idx()].domain else {
 			unreachable!()
 		};
-		if val <= *dom.min().unwrap() {
-			return Ok(());
-		} else if val > *dom.max().unwrap() {
-			return Err(ctx.create_conflict(View(BoolView::IntGreaterEq(self.0, val)), reason));
-		}
 		dom.tighten_min(val);
 		let min = *dom.min().unwrap();
-		if min == *dom.max().unwrap() {
-			def.domain = Domain::Alias(min.into());
-			ctx.int_events.insert(self.0.0, IntEvent::Fixed);
+		let fixed = min == *dom.max().unwrap();
+		if fixed {
+			model.int_vars[self.idx()].domain = Domain::Alias(min.into());
+			model.int_events.insert(self.0.0, IntEvent::Fixed);
 		} else {
-			ctx.int_events
+			model
+				.int_events
 				.entry(self.0.0)
 				.and_modify(|e| *e += IntEvent::LowerBound)
 				.or_insert(IntEvent::LowerBound);
@@ -479,6 +661,16 @@ impl IntDecisionActions<Model> for Resolved<Decision<IntVal>> {
 	fn val_lit(&self, ctx: &mut Model) -> Option<View<bool>> {
 		let val = self.val(ctx)?;
 		Some(View(BoolView::IntEq(self.0, val)))
+	}
+}
+
+impl IntDecisionActions<SimplificationContext<'_>> for Resolved<Decision<IntVal>> {
+	fn lit(&self, ctx: &mut SimplificationContext<'_>, meaning: IntLitMeaning) -> View<bool> {
+		self.lit(&mut *ctx.0, meaning)
+	}
+
+	fn val_lit(&self, ctx: &mut SimplificationContext<'_>) -> Option<View<bool>> {
+		self.val_lit(&mut *ctx.0)
 	}
 }
 
@@ -578,5 +770,61 @@ impl IntInspectionActions<Model> for Resolved<Decision<IntVal>> {
 			}
 			Domain::Alias(_) => unreachable!(),
 		}
+	}
+}
+
+impl IntInspectionActions<SimplificationContext<'_>> for Resolved<Decision<IntVal>> {
+	fn bounds(&self, ctx: &SimplificationContext<'_>) -> (IntVal, IntVal) {
+		self.bounds(&*ctx.0)
+	}
+
+	fn domain(&self, ctx: &SimplificationContext<'_>) -> IntSet {
+		self.domain(&*ctx.0)
+	}
+
+	fn in_domain(&self, ctx: &SimplificationContext<'_>, val: IntVal) -> bool {
+		self.in_domain(&*ctx.0, val)
+	}
+
+	fn lit_meaning(
+		&self,
+		ctx: &SimplificationContext<'_>,
+		lit: <SimplificationContext<'_> as ReasoningContext>::Atom,
+	) -> Option<IntLitMeaning> {
+		self.lit_meaning(&*ctx.0, lit)
+	}
+
+	fn max(&self, ctx: &SimplificationContext<'_>) -> IntVal {
+		self.max(&*ctx.0)
+	}
+
+	fn max_lit(
+		&self,
+		ctx: &SimplificationContext<'_>,
+	) -> <SimplificationContext<'_> as ReasoningContext>::Atom {
+		self.max_lit(&*ctx.0)
+	}
+
+	fn min(&self, ctx: &SimplificationContext<'_>) -> IntVal {
+		self.min(&*ctx.0)
+	}
+
+	fn min_lit(
+		&self,
+		ctx: &SimplificationContext<'_>,
+	) -> <SimplificationContext<'_> as ReasoningContext>::Atom {
+		self.min_lit(&*ctx.0)
+	}
+
+	fn try_lit(
+		&self,
+		ctx: &SimplificationContext<'_>,
+		meaning: IntLitMeaning,
+	) -> Option<<SimplificationContext<'_> as ReasoningContext>::Atom> {
+		self.try_lit(&*ctx.0, meaning)
+	}
+
+	fn val(&self, ctx: &SimplificationContext<'_>) -> Option<IntVal> {
+		self.val(&*ctx.0)
 	}
 }

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -28,6 +28,7 @@ use crate::{
 		BoolPropagationActions, BoolSimplificationActions, IntSimplificationActions,
 		PropagationActions, ReasoningEngine,
 	},
+	constraints::{NO_REASON, Nogood},
 	lower::{Lowerer, LowererComplete, LoweringError},
 	model::{
 		Model,
@@ -682,6 +683,12 @@ impl From<LoweringError> for FlatZincError {
 	}
 }
 
+impl From<Nogood<View<bool>>> for FlatZincError {
+	fn from(nogood: Nogood<View<bool>>) -> Self {
+		Self::ReformulationError(LoweringError::from(nogood))
+	}
+}
+
 impl Display for FznIdent {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
@@ -1222,7 +1229,7 @@ impl<'a> FznModelBuilder<'a> {
 						let AnyView::Int(view) = view else {
 							unreachable!()
 						};
-						view.restrict_domain(&mut me.prb, dom, vec![])?;
+						view.restrict_domain(&mut me.prb, dom, NO_REASON)?;
 					}
 					// Insert the view to use instead of a new variable for the name
 					e.insert(view);
@@ -1739,11 +1746,9 @@ impl<'a> FznModelBuilder<'a> {
 					if !satisfied {
 						match lits.len() {
 							0 => {
-								return Err(FlatZincError::ReformulationError(
-									LoweringError::Simplification(self.prb.declare_conflict([])),
-								));
+								return Err(self.prb.declare_conflict(NO_REASON).into());
 							}
-							1 => lits[0].require(&mut self.prb, vec![])?,
+							1 => lits[0].require(&mut self.prb, NO_REASON)?,
 							_ => {
 								self.prb
 									.proposition(Formula::Or(lits.into_iter().map_into().collect()))
@@ -2062,9 +2067,7 @@ impl<'a> FznModelBuilder<'a> {
 						});
 					}
 					if table.is_empty() {
-						return Err(FlatZincError::ReformulationError(
-							LoweringError::Simplification(self.prb.declare_conflict([])),
-						));
+						return Err(self.prb.declare_conflict(NO_REASON).into());
 					}
 					let table: Vec<Vec<_>> = table
 						.into_iter()
@@ -2275,7 +2278,7 @@ impl<'a> FznModelBuilder<'a> {
 					let x = self.arg_int(x)?;
 					let s = self.arg_par_set(s)?;
 
-					x.restrict_domain(&mut self.prb, &s, vec![])?;
+					x.restrict_domain(&mut self.prb, &s, NO_REASON)?;
 				}
 				ConstraintIdent::SetInReif => {
 					let [x, s, r] = c.args.as_slice() else {
@@ -2431,9 +2434,7 @@ impl<'a> FznModelBuilder<'a> {
 					match lit {
 						Literal::Bool(b) => {
 							if domain == Some(!b) {
-								return Err(FlatZincError::ReformulationError(
-									LoweringError::Simplification(self.prb.declare_conflict([])),
-								));
+								return Err(self.prb.declare_conflict(NO_REASON).into());
 							} else {
 								domain = Some(*b);
 							}

--- a/crates/huub/src/model/expressions.rs
+++ b/crates/huub/src/model/expressions.rs
@@ -13,6 +13,7 @@ use std::{cmp, marker::PhantomData, num::NonZero};
 
 use bon::bon;
 use itertools::{Itertools, MinMaxResult, iproduct};
+use rangelist::RangeList;
 
 pub use crate::model::expressions::{
 	bool_formula::BoolFormula, element::ElementConstraint, linear::IntLinearExp,
@@ -24,7 +25,7 @@ use crate::{
 		IntSimplificationActions,
 	},
 	constraints::{
-		Conflict,
+		NO_REASON, Nogood,
 		cumulative::CumulativeTimeTable,
 		disjunctive::{Disjunctive, DisjunctivePropagator},
 		int_abs::IntAbsBounds,
@@ -53,7 +54,7 @@ impl Model {
 		&mut self,
 		#[builder(into, start_fn)] origin: View<IntVal>,
 		#[builder(into)] result: View<IntVal>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		self.post_constraint(IntAbsBounds {
 			origin,
 			abs: result,
@@ -70,7 +71,7 @@ impl Model {
 		#[builder(start_fn, into)] collection: IntSet,
 		#[builder(into)] member: View<IntVal>,
 		#[builder(into)] result: View<bool>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		self.post_constraint(IntSetContainsReif {
 			var: member,
 			set: collection,
@@ -91,7 +92,7 @@ impl Model {
 		durations: Vec<impl Into<View<IntVal>>>,
 		usages: Vec<impl Into<View<IntVal>>>,
 		capacity: impl Into<View<IntVal>>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		assert_eq!(
 			start_times.len(),
 			durations.len(),
@@ -125,7 +126,7 @@ impl Model {
 		edge_finding_propagation: Option<bool>,
 		not_last_propagation: Option<bool>,
 		detectable_precedence_propagation: Option<bool>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		assert_eq!(
 			start_times.len(),
 			durations.len(),
@@ -153,7 +154,7 @@ impl Model {
 		#[builder(into, start_fn)] numerator: View<IntVal>,
 		#[builder(into, start_fn)] denominator: View<IntVal>,
 		#[builder(into)] result: View<IntVal>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		self.post_constraint(IntDivBounds {
 			numerator,
 			denominator,
@@ -170,7 +171,7 @@ impl Model {
 		#[builder(start_fn)] array: Vec<E>,
 		#[builder(getter(name = index_internal, vis = ""), into)] index: View<IntVal>,
 		result: <E as ElementConstraint>::Result,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		<E as ElementConstraint>::element_constraint(self, array, index, result)
 	}
 
@@ -221,7 +222,7 @@ impl Model {
 		#[builder(setters(name = comparator_internal, vis = ""))] comparator: Comparator,
 		#[builder(setters(name = rhs_internal, vis = ""))] rhs: IntLinearExp,
 		#[builder(setters(name = reif_internal, vis = ""))] reif: Option<Reification>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		// Subtract the RHS from the LHS to get a linear expression with a constant 0 on
 		// the RHS
 		expr -= rhs;
@@ -258,14 +259,14 @@ impl Model {
 				Comparator::Greater => 0 > rhs,
 			};
 			return match reif {
-				None => satisfied.require(self, []),
-				Some(Reification::ReifiedBy(r)) => r.fix(self, satisfied, []),
+				None => satisfied.require(self, NO_REASON),
+				Some(Reification::ReifiedBy(r)) => r.fix(self, satisfied, NO_REASON),
 				Some(Reification::ImpliedBy(_)) if satisfied => Ok(()),
-				Some(Reification::ImpliedBy(r)) => r.fix(self, false, []),
+				Some(Reification::ImpliedBy(r)) => r.fix(self, false, NO_REASON),
 			};
 		}
 
-		let mut negate_terms = || -> Result<(), Conflict<View<bool>>> {
+		let mut negate_terms = || -> Result<(), Nogood<View<bool>>> {
 			for v in &mut terms {
 				*v = v.bounding_neg(self)?;
 			}
@@ -310,7 +311,7 @@ impl Model {
 		&mut self,
 		#[builder(start_fn)] vars: impl IntoIterator<Item = View<IntVal>>,
 		#[builder(into)] result: View<IntVal>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		self.minimum(vars.into_iter().map(|v| -v))
 			.result(-result)
 			.post()
@@ -323,7 +324,7 @@ impl Model {
 		&mut self,
 		#[builder(start_fn)] vars: impl IntoIterator<Item = View<IntVal>>,
 		#[builder(into)] result: View<IntVal>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		self.post_constraint(IntArrayMinimumBounds {
 			vars: vars.into_iter().collect(),
 			min: result,
@@ -338,7 +339,7 @@ impl Model {
 		#[builder(start_fn)] factor1: View<IntVal>,
 		#[builder(start_fn)] factor2: View<IntVal>,
 		result: View<IntVal>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		if IntMulBounds::<_, _, _, View<IntVal>>::can_overflow(self, &factor1, &factor2) {
 			self.post_constraint(IntMulBounds::<OverflowPossible, _, _, _> {
 				factor1,
@@ -382,7 +383,7 @@ impl Model {
 		origins: Vec<Vec<View<IntVal>>>,
 		sizes: Vec<Vec<View<IntVal>>>,
 		#[builder(default = true)] strict: bool,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		if strict {
 			let prop = IntNoOverlapSweep::<true, _, _>::new(self, origins, sizes);
 			self.post_constraint(prop)
@@ -401,7 +402,7 @@ impl Model {
 		#[builder(start_fn, into)] base: View<IntVal>,
 		#[builder(start_fn, into)] exponent: View<IntVal>,
 		#[builder(into)] result: View<IntVal>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		if IntPowBounds::<_, _, _, View<IntVal>>::can_overflow(self, &base, &exponent) {
 			self.post_constraint(IntPowBounds::<OverflowPossible, _, _, _> {
 				base,
@@ -426,7 +427,7 @@ impl Model {
 		&mut self,
 		#[builder(start_fn, into)] mut formula: BoolFormula,
 		#[builder(setters(name = reif_internal, vis = ""))] reif: Option<Reification>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		match reif {
 			Some(Reification::ReifiedBy(b)) => {
 				formula = BoolFormula::Equiv(vec![BoolFormula::Atom(b), formula]);
@@ -447,7 +448,7 @@ impl Model {
 		&mut self,
 		#[builder(start_fn)] vars: impl IntoIterator<Item = View<IntVal>>,
 		values: impl IntoIterator<Item = Vec<IntVal>>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		let vars: Vec<_> = vars.into_iter().collect();
 		let table: Vec<_> = values.into_iter().collect();
 		assert!(
@@ -495,7 +496,7 @@ impl Model {
 		bounds_propagation: Option<bool>,
 		value_propagation: Option<bool>,
 		domain_propagation: Option<bool>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		let vars: Vec<_> = vars.into_iter().map_into().collect();
 		self.post_constraint(IntUnique {
 			bounds_prop: IntUniqueBounds::new(vars.clone()),
@@ -519,7 +520,7 @@ impl Model {
 		#[builder(start_fn)] vars: impl IntoIterator<Item = View<IntVal>>,
 		#[builder(with = |values: impl IntoIterator<Item = IntVal>| values.into_iter().collect())]
 		values: Option<Vec<IntVal>>,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		let mut offset = 0;
 		let vars: Vec<_> = vars.into_iter().collect();
 		// If there are no decision variables, then the constraint is trivially
@@ -539,7 +540,7 @@ impl Model {
 			if !values.iter().tuple_windows().all(|(&x, &y)| x + 1 == y)
 				|| *values.last().unwrap() < vars.iter().map(|v| v.max(self)).max().unwrap()
 			{
-				vars[0].exclude(self, &values[1..].iter().map(|&v| v..=v).collect(), [])?;
+				vars[0].exclude(self, &RangeList::from_elements(values.clone()), NO_REASON)?;
 
 				let con = IntValuePrecedeChainValue::new(self, values.into_iter().collect(), vars);
 				return self.post_constraint(con);
@@ -554,7 +555,7 @@ impl Model {
 			.into_iter()
 			.map(|v| v.bounding_sub(self, offset))
 			.collect::<Result<Vec<_>, _>>()?;
-		vars[0].tighten_max(self, 1, [])?;
+		vars[0].tighten_max(self, 1, NO_REASON)?;
 		match vars.len() {
 			1 => Ok(()),
 			_ => {

--- a/crates/huub/src/model/expressions/bool_formula.rs
+++ b/crates/huub/src/model/expressions/bool_formula.rs
@@ -12,7 +12,8 @@ use crate::{
 		PropagationActions, ReasoningEngine, SimplificationActions,
 	},
 	constraints::{
-		BoolModelActions, BoolSolverActions, Constraint, Propagator, SimplificationStatus,
+		BoolModelActions, BoolSolverActions, Constraint, NO_REASON, Propagator,
+		SimplificationStatus,
 	},
 	lower::{LoweringContext, LoweringError},
 	model::view::View,
@@ -43,7 +44,7 @@ where
 		let mut f = match result {
 			Ok(f) => f,
 			Err(true) => return Ok(SimplificationStatus::Subsumed),
-			Err(false) => return Err(ctx.declare_conflict([])),
+			Err(false) => return Err(ctx.declare_conflict(NO_REASON)),
 		};
 
 		let negate = |f: BoolFormula| match f {
@@ -92,11 +93,11 @@ where
 				for f in v {
 					match f {
 						Formula::Atom(x) => {
-							x.require(ctx, [])?;
+							x.require(ctx, NO_REASON)?;
 						}
 						Formula::Not(x) if matches!(*x, Formula::Atom(_)) => {
 							let Formula::Atom(x) = *x else { unreachable!() };
-							x.fix(ctx, false, [])?;
+							x.fix(ctx, false, NO_REASON)?;
 						}
 						f => {
 							ctx.post_constraint(f);
@@ -106,7 +107,7 @@ where
 				return Ok(SimplificationStatus::Subsumed);
 			}
 			Formula::Atom(b) => {
-				b.require(ctx, [])?;
+				b.require(ctx, NO_REASON)?;
 				return Ok(SimplificationStatus::Subsumed);
 			}
 			Formula::Not(_) => unreachable!(),
@@ -125,7 +126,7 @@ where
 		};
 		let result: Result<Formula<RawLit>, _> = self.clone().simplify_with(&mut resolver);
 		match result {
-			Err(false) => Err(slv.declare_conflict([]).into()),
+			Err(false) => Err(slv.declare_conflict(NO_REASON).into()),
 			Err(true) => Ok(()),
 			Ok(f) => slv.cnf_encode(&f, &TseitinEncoder),
 		}
@@ -179,7 +180,7 @@ mod tests {
 	use crate::{
 		actions::BoolInspectionActions,
 		constraints::{Constraint, SimplificationStatus},
-		model::{Model, expressions::bool_formula::BoolFormula},
+		model::{Model, SimplificationContext, expressions::bool_formula::BoolFormula},
 	};
 
 	#[test]
@@ -191,7 +192,10 @@ mod tests {
 		let x = prb.new_bool_decision();
 		let mut f: BoolFormula = And(vec![Atom(x), Atom(true.into())]);
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), Some(true));
@@ -200,7 +204,13 @@ mod tests {
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let mut f: BoolFormula = And(vec![Atom(x), Atom(false.into())]);
-		assert!(<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb).is_err());
+		assert!(
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			)
+			.is_err()
+		);
 	}
 
 	#[test]
@@ -212,7 +222,10 @@ mod tests {
 		let x = prb.new_bool_decision();
 		let mut f: BoolFormula = Equiv(vec![Atom(x), Atom(true.into())]);
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), Some(true));
@@ -222,7 +235,10 @@ mod tests {
 		let x = prb.new_bool_decision();
 		let mut f: BoolFormula = Equiv(vec![Atom(x), Atom(false.into())]);
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), Some(false));
@@ -242,7 +258,10 @@ mod tests {
 			els: Box::new(Atom(e)),
 		};
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(t.val(&prb), Some(true));
@@ -258,7 +277,10 @@ mod tests {
 			els: Box::new(Atom(e)),
 		};
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(t.val(&prb), None);
@@ -274,7 +296,10 @@ mod tests {
 		let y = prb.new_bool_decision();
 		let mut f: BoolFormula = Implies(Box::new(Atom(true.into())), Box::new(Atom(y)));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(y.val(&prb), Some(true));
@@ -284,7 +309,10 @@ mod tests {
 		let x = prb.new_bool_decision();
 		let mut f: BoolFormula = Implies(Box::new(Atom(x)), Box::new(Atom(false.into())));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), Some(false));
@@ -299,7 +327,10 @@ mod tests {
 		let x = prb.new_bool_decision();
 		let mut f: BoolFormula = Not(Box::new(Not(Box::new(Atom(x)))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), Some(true));
@@ -310,7 +341,10 @@ mod tests {
 		let y = prb.new_bool_decision();
 		let mut f: BoolFormula = Not(Box::new(And(vec![Atom(x), Atom(y)])));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::NoFixpoint)
 		);
 		assert_eq!(f, Or(vec![Atom(!x), Atom(!y)]));
@@ -321,7 +355,10 @@ mod tests {
 		let y = prb.new_bool_decision();
 		let mut f: BoolFormula = Not(Box::new(Or(vec![Atom(x), Atom(y)])));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), Some(false));
@@ -333,7 +370,10 @@ mod tests {
 		let y = prb.new_bool_decision();
 		let mut f: BoolFormula = Not(Box::new(Implies(Box::new(Atom(x)), Box::new(Atom(y)))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), Some(true));
@@ -350,7 +390,10 @@ mod tests {
 			els: Box::new(Atom(e)),
 		}));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::NoFixpoint)
 		);
 		assert_eq!(
@@ -368,7 +411,10 @@ mod tests {
 		let y = prb.new_bool_decision();
 		let mut f: BoolFormula = Not(Box::new(Equiv(vec![Atom(x), Atom(y)])));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed) // rewritten to two clauses
 		);
 		assert_eq!(x.val(&prb), None);
@@ -380,7 +426,10 @@ mod tests {
 		let y = prb.new_bool_decision();
 		let mut f: BoolFormula = Not(Box::new(Xor(vec![Atom(x), Atom(y)])));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::NoFixpoint)
 		);
 		assert_eq!(f, Equiv(vec![Atom(x), Atom(y)]));
@@ -392,7 +441,10 @@ mod tests {
 		let z = prb.new_bool_decision();
 		let mut f: BoolFormula = Not(Box::new(Xor(vec![Atom(x), Atom(y), Atom(z)])));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::NoFixpoint)
 		);
 		assert_eq!(f, Xor(vec![Atom(!x), Atom(y), Atom(z)]));
@@ -407,7 +459,10 @@ mod tests {
 		let x = prb.new_bool_decision();
 		let mut f: BoolFormula = Or(vec![Atom(x), Atom(true.into())]);
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), None);
@@ -417,7 +472,10 @@ mod tests {
 		let x = prb.new_bool_decision();
 		let mut f: BoolFormula = Or(vec![Atom(x), Atom(false.into())]);
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), Some(true));
@@ -432,7 +490,10 @@ mod tests {
 		let x = prb.new_bool_decision();
 		let mut f: BoolFormula = Xor(vec![Atom(x), Atom(false.into())]);
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), Some(true));
@@ -442,7 +503,10 @@ mod tests {
 		let x = prb.new_bool_decision();
 		let mut f: BoolFormula = Xor(vec![Atom(x), Atom(true.into())]);
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(&mut f, &mut prb),
+			<BoolFormula as Constraint<Model>>::simplify(
+				&mut f,
+				&mut SimplificationContext(&mut prb)
+			),
 			Ok(SimplificationStatus::Subsumed)
 		);
 		assert_eq!(x.val(&prb), Some(false));

--- a/crates/huub/src/model/expressions/element.rs
+++ b/crates/huub/src/model/expressions/element.rs
@@ -7,7 +7,7 @@ use crate::{
 	IntSet, IntVal,
 	actions::IntInspectionActions,
 	constraints::{
-		Conflict,
+		Nogood,
 		bool_array_element::BoolDecisionArrayElement,
 		int_array_element::{IntArrayElementBounds, IntValArrayElement},
 		int_set_contains::IntSetContainsReif,
@@ -34,7 +34,7 @@ pub trait ElementConstraint: Sized {
 		array: Vec<Self>,
 		index: View<IntVal>,
 		result: Self::Result,
-	) -> Result<(), Conflict<View<bool>>>;
+	) -> Result<(), Nogood<View<bool>>>;
 }
 
 impl ElementConstraint for IntVal {
@@ -55,7 +55,7 @@ impl ElementConstraint for IntVal {
 		array: Vec<Self>,
 		index: View<IntVal>,
 		result: Self::Result,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		let con = IntValArrayElement(IntArrayElementBounds::new(prb, array, index, result));
 		prb.post_constraint(con)
 	}
@@ -84,7 +84,7 @@ impl ElementConstraint for View<IntVal> {
 		array: Vec<Self>,
 		index: View<IntVal>,
 		result: Self::Result,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		let con = IntArrayElementBounds::new(prb, array, index, result);
 		prb.post_constraint(con)
 	}
@@ -103,7 +103,7 @@ impl ElementConstraint for View<bool> {
 		array: Vec<Self>,
 		index: View<IntVal>,
 		result: Self::Result,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		prb.post_constraint(Self::Constraint {
 			index,
 			array,
@@ -125,7 +125,7 @@ impl ElementConstraint for bool {
 		array: Vec<Self>,
 		index: View<IntVal>,
 		result: Self::Result,
-	) -> Result<(), Conflict<View<bool>>> {
+	) -> Result<(), Nogood<View<bool>>> {
 		// Convert array of boolean values to a set literals of the indices where
 		// the value is true
 		let mut ranges = Vec::new();

--- a/crates/huub/src/model/initilization_context.rs
+++ b/crates/huub/src/model/initilization_context.rs
@@ -181,7 +181,6 @@ impl InitActions for ModelInitContext<'_> {
 
 impl ReasoningContext for ModelInitContext<'_> {
 	type Atom = <Model as ReasoningEngine>::Atom;
-	type Conflict = <Model as ReasoningEngine>::Conflict;
 }
 
 impl BoolInitActions<ModelInitContext<'_>> for Resolved<Decision<bool>> {

--- a/crates/huub/src/model/view/boolean.rs
+++ b/crates/huub/src/model/view/boolean.rs
@@ -14,9 +14,9 @@ use crate::{
 		BoolSimplificationActions, IntInspectionActions, IntPropCond, PropagationActions,
 		ReasoningContext,
 	},
-	constraints::{Conflict, ReasonBuilder},
+	constraints::{Conflict, NO_REASON, Nogood},
 	model::{
-		AdvRef, Advisor, ConRef, Model,
+		AdvRef, Advisor, ConRef, Model, SimplificationContext, SimplificationReasonSink,
 		decision::Decision,
 		expressions::BoolFormula,
 		resolved::Resolved,
@@ -46,36 +46,42 @@ pub enum BoolView {
 
 impl Resolved<View<bool>> {
 	/// Consuming variant of [`BoolPropagationActions::fix`].
-	pub(crate) fn fix(
+	pub(crate) fn fix<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		val: bool,
-		reason: impl ReasonBuilder<Model>,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
 	) -> Result<(), Conflict<View<bool>>> {
 		let lit = if val { self.0 } else { !self.0 };
 		Resolved(lit).require(ctx, reason)
 	}
 
 	/// Consuming variant of [`BoolPropagationActions::require`].
-	pub(crate) fn require(
+	pub(crate) fn require<'a>(
 		self,
-		ctx: &mut Model,
-		reason: impl ReasonBuilder<Model>,
+		ctx: &mut SimplificationContext<'a>,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
 	) -> Result<(), Conflict<View<bool>>> {
 		use BoolView::*;
 
 		match self.0.0 {
 			Decision(l) => {
-				let def = &mut ctx.bool_vars[l.idx()];
+				let model = &mut *ctx.0;
+				let def = &mut model.bool_vars[l.idx()];
 				debug_assert!(def.alias.is_none());
 				def.alias = Some(View(Const(!l.is_negated())));
-				ctx.bool_events.push(l.var());
+				model.bool_events.push(l.var());
 			}
 			Const(c) => c.require(ctx, reason)?,
-			IntEq(iv, val) => iv.resolve_alias(ctx).fix(ctx, val, reason)?,
-			IntGreaterEq(iv, val) => iv.resolve_alias(ctx).tighten_min(ctx, val, reason)?,
-			IntLess(iv, val) => iv.resolve_alias(ctx).tighten_max(ctx, val - 1, reason)?,
-			IntNotEq(iv, val) => iv.resolve_alias(ctx).remove_val(ctx, val, reason)?,
+			IntEq(iv, val) => iv.resolve_alias(&*ctx.0).fix(ctx, val, reason)?,
+			IntGreaterEq(iv, val) => {
+				iv.resolve_alias(&*ctx.0).tighten_min(ctx, val, reason)?;
+			}
+			IntLess(iv, val) => {
+				iv.resolve_alias(&*ctx.0)
+					.tighten_max(ctx, val - 1, reason)?;
+			}
+			IntNotEq(iv, val) => iv.resolve_alias(&*ctx.0).remove_val(ctx, val, reason)?,
 		};
 		Ok(())
 	}
@@ -83,7 +89,7 @@ impl Resolved<View<bool>> {
 	/// Consuming variant of [`BoolSimplificationActions::unify`].
 	pub(crate) fn unify(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'_>,
 		other: Resolved<View<bool>>,
 	) -> Result<(), Conflict<View<bool>>> {
 		use BoolView::*;
@@ -94,10 +100,12 @@ impl Resolved<View<bool>> {
 		match (x.0, y.0) {
 			(x, y) if x == y => Ok(()),
 			(Decision(xl), Decision(yl)) if xl.var() == yl.var() => {
-				Err(ctx.declare_conflict([x, y]))
+				Err(ctx.declare_conflict(|_, reason| {
+					reason.extend([x, y]);
+				}))
 			}
-			(Const(x), Const(y)) if x != y => Err(ctx.declare_conflict([])),
-			(x, Const(b)) | (Const(b), x) => Resolved(View::<bool>(x)).fix(ctx, b, []),
+			(Const(x), Const(y)) if x != y => Err(ctx.declare_conflict(NO_REASON)),
+			(x, Const(b)) | (Const(b), x) => Resolved(View::<bool>(x)).fix(ctx, b, NO_REASON),
 			(Decision(x), y) | (y, Decision(x)) => {
 				let (x, y) = if let Decision(y) = y {
 					if x.0.var() > y.0.var() {
@@ -108,7 +116,8 @@ impl Resolved<View<bool>> {
 				} else {
 					(x, View(y))
 				};
-				let store = &mut ctx.bool_vars[x.idx()];
+				let model = &mut *ctx.0;
+				let store = &mut model.bool_vars[x.idx()];
 				debug_assert_eq!(store.alias, None);
 				store.alias = Some(if x.is_negated() { !y } else { y });
 
@@ -116,9 +125,7 @@ impl Resolved<View<bool>> {
 				let constraints = mem::take(&mut store.constraints);
 				match y.0 {
 					// Move subscriptions to another Boolean decision
-					Decision(lit) => {
-						ctx.bool_vars[lit.idx()].constraints.extend(constraints);
-					}
+					Decision(lit) => model.bool_vars[lit.idx()].constraints.extend(constraints),
 					// Move subscriptions to an integer decision
 					IntEq(j, _) | IntGreaterEq(j, _) | IntLess(j, _) | IntNotEq(j, _) => {
 						for act in constraints {
@@ -129,7 +136,7 @@ impl Resolved<View<bool>> {
 							};
 							match ActivationAction::<AdvRef, ConRef>::from(act) {
 								ActivationAction::Advise(adv) => {
-									let def: &mut Advisor = &mut ctx.advisors[adv.index()];
+									let def: &mut Advisor = &mut model.advisors[adv.index()];
 									def.condition = Some(match y.0 {
 										IntEq(_, v) => IntLitMeaning::Eq(v),
 										IntGreaterEq(_, v) => IntLitMeaning::GreaterEq(v),
@@ -137,14 +144,14 @@ impl Resolved<View<bool>> {
 										IntNotEq(_, v) => IntLitMeaning::NotEq(v),
 										_ => unreachable!(),
 									});
-									ctx.int_vars[j.idx()]
+									model.int_vars[j.idx()]
 										.constraints
 										.add(ActivationAction::Advise(adv), event);
 								}
 								me @ ActivationAction::Enqueue(_) => {
 									// TODO: This triggers even when the Boolean Condition does not
 									// change value
-									ctx.int_vars[j.idx()].constraints.add(me, event);
+									model.int_vars[j.idx()].constraints.add(me, event);
 								}
 							}
 						}
@@ -157,7 +164,8 @@ impl Resolved<View<bool>> {
 				let x = BoolFormula::Atom(View(x));
 				let y = BoolFormula::Atom(View(y));
 
-				ctx.post_constraint_internal(BoolFormula::Equiv(vec![x, y]));
+				ctx.0
+					.post_constraint_internal(BoolFormula::Equiv(vec![x, y]));
 				Ok(())
 			}
 		}
@@ -191,6 +199,12 @@ impl BoolInspectionActions<Model> for Resolved<View<bool>> {
 	}
 }
 
+impl BoolInspectionActions<SimplificationContext<'_>> for Resolved<View<bool>> {
+	fn val(&self, ctx: &SimplificationContext<'_>) -> Option<bool> {
+		self.val(&*ctx.0)
+	}
+}
+
 impl Add<IntVal> for View<bool> {
 	type Output = View<IntVal>;
 
@@ -220,29 +234,71 @@ impl BoolInspectionActions<Model> for View<bool> {
 	}
 }
 
+impl BoolInspectionActions<SimplificationContext<'_>> for View<bool> {
+	fn val(&self, ctx: &SimplificationContext<'_>) -> Option<bool> {
+		self.val(&*ctx.0)
+	}
+}
+
 impl BoolPropagationActions<Model> for View<bool> {
 	fn fix(
 		&self,
 		ctx: &mut Model,
 		val: bool,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), Conflict<View<bool>>> {
-		self.resolve_alias(ctx).fix(ctx, val, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.fix(
+			&mut SimplificationContext(ctx),
+			val,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
 	}
 
 	fn require(
 		&self,
 		ctx: &mut Model,
-		reason: impl ReasonBuilder<Model>,
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.require(&mut SimplificationContext(ctx), Model::adapt_reason(reason))
+			.map_err(Conflict::into_nogood)
+	}
+}
+
+impl<'a> BoolPropagationActions<SimplificationContext<'a>> for View<bool> {
+	fn fix(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		val: bool,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
 	) -> Result<(), Conflict<View<bool>>> {
-		self.resolve_alias(ctx).require(ctx, reason)
+		self.resolve_alias(&*ctx.0).fix(ctx, val, reason)
+	}
+
+	fn require(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).require(ctx, reason)
 	}
 }
 
 impl BoolSimplificationActions<Model> for View<bool> {
-	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Conflict<View<bool>>> {
-		let other = other.into().resolve_alias(ctx);
-		self.resolve_alias(ctx).unify(ctx, other)
+	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Nogood<View<bool>>> {
+		self.unify(&mut SimplificationContext(ctx), other)
+			.map_err(Conflict::into_nogood)
+	}
+}
+
+impl BoolSimplificationActions<SimplificationContext<'_>> for View<bool> {
+	fn unify(
+		&self,
+		ctx: &mut SimplificationContext<'_>,
+		other: impl Into<Self>,
+	) -> Result<(), Conflict<View<bool>>> {
+		let other = other.into().resolve_alias(&*ctx.0);
+		self.resolve_alias(&*ctx.0).unify(ctx, other)
 	}
 }
 
@@ -316,6 +372,7 @@ impl private::Sealed for bool {}
 mod tests {
 	use crate::{
 		actions::{BoolInspectionActions, IntInspectionActions, IntPropagationActions},
+		constraints::NO_REASON,
 		model::Model,
 	};
 
@@ -334,14 +391,14 @@ mod tests {
 
 		// Removing the single value `4` allows us to determine the value of the
 		// (in)equality.
-		x.remove_val(&mut prb, 4, []).unwrap();
+		x.remove_val(&mut prb, 4, NO_REASON).unwrap();
 		assert_eq!(x.val(&prb), None);
 		assert_eq!(x.eq(4).val(&prb), Some(false));
 		assert_eq!(x.ne(4).val(&prb), Some(true));
 
 		// Tightening the lower bound entails the threshold comparisons while `x`
 		// (now in 3, 5) stays unfixed.
-		x.tighten_min(&mut prb, 3, []).unwrap();
+		x.tighten_min(&mut prb, 3, NO_REASON).unwrap();
 		assert_eq!(x.val(&prb), None);
 		assert_eq!(x.geq(3).val(&prb), Some(true));
 		assert_eq!(x.lt(3).val(&prb), Some(false));

--- a/crates/huub/src/model/view/integer.rs
+++ b/crates/huub/src/model/view/integer.rs
@@ -12,11 +12,11 @@ use crate::{
 	actions::{
 		BoolPropagationActions, IntAnalyzeActions, IntDecisionActions, IntExplanationActions,
 		IntInspectionActions, IntPropagationActions, IntSimplificationActions, PropagationActions,
-		ReasoningContext,
+		PropagationContext, ReasonActions, ReasoningContext,
 	},
-	constraints::{Conflict, ReasonBuilder, int_linear::IntEq},
+	constraints::{Conflict, NO_REASON, Nogood, int_linear::IntEq},
 	model::{
-		Decision, Model, View,
+		Decision, Model, SimplificationContext, SimplificationReasonSink, View,
 		expressions::linear::IntLinearExp,
 		resolved::Resolved,
 		view::{DefaultView, boolean::BoolView, private},
@@ -46,11 +46,11 @@ impl private::Sealed for IntVal {}
 
 impl Resolved<View<IntVal>> {
 	/// Consuming variant of [`IntSimplificationActions::exclude`].
-	pub(crate) fn exclude(
+	pub(crate) fn exclude<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		values: &IntSet,
-		reason: impl ReasonBuilder<Model>,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
 	) -> Result<(), Conflict<View<bool>>> {
 		match self.0.0 {
 			IntView::Const(v) => v.exclude(ctx, values, reason),
@@ -62,11 +62,11 @@ impl Resolved<View<IntVal>> {
 	}
 
 	/// Consuming variant of [`IntPropagationActions::fix`].
-	pub(crate) fn fix(
+	pub(crate) fn fix<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
 	) -> Result<(), Conflict<View<bool>>> {
 		match self.0.0 {
 			IntView::Const(v) => v.fix(ctx, val, reason),
@@ -81,11 +81,11 @@ impl Resolved<View<IntVal>> {
 	}
 
 	/// Consuming variant of [`IntPropagationActions::remove_val`].
-	pub(crate) fn remove_val(
+	pub(crate) fn remove_val<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
 	) -> Result<(), Conflict<View<bool>>> {
 		match self.0.0 {
 			IntView::Const(v) => v.remove_val(ctx, val, reason),
@@ -100,11 +100,11 @@ impl Resolved<View<IntVal>> {
 	}
 
 	/// Consuming variant of [`IntSimplificationActions::restrict_domain`].
-	pub(crate) fn restrict_domain(
+	pub(crate) fn restrict_domain<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		values: &IntSet,
-		reason: impl ReasonBuilder<Model>,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
 	) -> Result<(), Conflict<View<bool>>> {
 		match self.0.0 {
 			IntView::Const(v) => v.restrict_domain(ctx, values, reason),
@@ -116,11 +116,11 @@ impl Resolved<View<IntVal>> {
 	}
 
 	/// Consuming variant of [`IntPropagationActions::tighten_max`].
-	pub(crate) fn tighten_max(
+	pub(crate) fn tighten_max<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		ub: IntVal,
-		reason: impl ReasonBuilder<Model>,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
 	) -> Result<(), Conflict<View<bool>>> {
 		match self.0.0 {
 			IntView::Const(v) => v.tighten_max(ctx, ub, reason),
@@ -136,11 +136,11 @@ impl Resolved<View<IntVal>> {
 	}
 
 	/// Consuming variant of [`IntPropagationActions::tighten_min`].
-	pub(crate) fn tighten_min(
+	pub(crate) fn tighten_min<'a>(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
 	) -> Result<(), Conflict<View<bool>>> {
 		match self.0.0 {
 			IntView::Const(v) => v.tighten_min(ctx, val, reason),
@@ -158,7 +158,7 @@ impl Resolved<View<IntVal>> {
 	/// Consuming variant of [`IntSimplificationActions::unify`].
 	pub(crate) fn unify(
 		self,
-		ctx: &mut Model,
+		ctx: &mut SimplificationContext<'_>,
 		other: Resolved<View<IntVal>>,
 	) -> Result<(), Conflict<View<bool>>> {
 		use IntView::*;
@@ -166,10 +166,12 @@ impl Resolved<View<IntVal>> {
 		let (idx, target) = match (self.0.0, other.0.0) {
 			(x, y) if x == y => return Ok(()),
 			(Bool(x), Bool(y)) => return x.unify(ctx, y),
-			(Const(x), Const(y)) if x != y => return Err(ctx.declare_conflict([])),
+			(Const(x), Const(y)) if x != y => {
+				return Err(ctx.declare_conflict(NO_REASON));
+			}
 			(Const(y), x) | (x, Const(y)) => {
 				let x = View::<IntVal>(x);
-				return x.fix(ctx, y, []);
+				return x.fix(ctx, y, NO_REASON);
 			}
 			(Linear(lin_x), Linear(lin_y)) => {
 				// Decide which variable to redefine based on the other.
@@ -184,7 +186,7 @@ impl Resolved<View<IntVal>> {
 				} else if can_define_x {
 					(lin_x, lin_y)
 				} else {
-					ctx.post_constraint_internal(IntEq {
+					ctx.0.post_constraint_internal(IntEq {
 						vars: [self.0, other.0],
 					});
 					return Ok(());
@@ -207,29 +209,29 @@ impl Resolved<View<IntVal>> {
 
 				match (contains_lb, contains_ub) {
 					(false, false) => {
-						return Err(ctx.declare_conflict(|ctx: &mut Model| {
-							[
+						return Err(ctx.declare_conflict(|ctx, reason| {
+							reason.extend([
 								lin.lit(ctx, IntLitMeaning::NotEq(lb)),
 								lin.lit(ctx, IntLitMeaning::NotEq(ub)),
-							]
+							]);
 						}));
 					}
 					(false, true) => {
 						let Some(val) = lin.try_reverse_val(ub) else {
 							unreachable!()
 						};
-						Resolved(lin.var).fix(ctx, val, [])?;
-						return b.var.require(ctx, |ctx: &mut Model| {
-							[lin.lit(ctx, IntLitMeaning::NotEq(lb))]
+						Resolved(lin.var).fix(ctx, val, NO_REASON)?;
+						return b.var.require(ctx, |ctx, reason| {
+							reason.push(lin.lit(ctx, IntLitMeaning::NotEq(lb)));
 						});
 					}
 					(true, false) => {
 						let Some(val) = lin.try_reverse_val(lb) else {
 							unreachable!()
 						};
-						Resolved(lin.var).fix(ctx, val, [])?;
-						return b.var.fix(ctx, false, |ctx: &mut Model| {
-							[lin.lit(ctx, IntLitMeaning::NotEq(ub))]
+						Resolved(lin.var).fix(ctx, val, NO_REASON)?;
+						return b.var.fix(ctx, false, |ctx, reason| {
+							reason.push(lin.lit(ctx, IntLitMeaning::NotEq(ub)));
 						});
 					}
 					(true, true) => {
@@ -267,6 +269,16 @@ impl IntDecisionActions<Model> for Resolved<View<IntVal>> {
 	fn val_lit(&self, ctx: &mut Model) -> Option<View<bool>> {
 		let val = self.val(ctx)?;
 		Some(IntInspectionActions::try_lit(self, ctx, IntLitMeaning::Eq(val)).unwrap())
+	}
+}
+
+impl IntDecisionActions<SimplificationContext<'_>> for Resolved<View<IntVal>> {
+	fn lit(&self, ctx: &mut SimplificationContext<'_>, meaning: IntLitMeaning) -> View<bool> {
+		self.lit(&mut *ctx.0, meaning)
+	}
+
+	fn val_lit(&self, ctx: &mut SimplificationContext<'_>) -> Option<View<bool>> {
+		self.val_lit(&mut *ctx.0)
 	}
 }
 
@@ -377,6 +389,56 @@ impl IntInspectionActions<Model> for Resolved<View<IntVal>> {
 	}
 }
 
+impl IntInspectionActions<SimplificationContext<'_>> for Resolved<View<IntVal>> {
+	fn bounds(&self, ctx: &SimplificationContext<'_>) -> (IntVal, IntVal) {
+		self.bounds(&*ctx.0)
+	}
+
+	fn domain(&self, ctx: &SimplificationContext<'_>) -> IntSet {
+		self.domain(&*ctx.0)
+	}
+
+	fn in_domain(&self, ctx: &SimplificationContext<'_>, val: IntVal) -> bool {
+		self.in_domain(&*ctx.0, val)
+	}
+
+	fn lit_meaning(
+		&self,
+		ctx: &SimplificationContext<'_>,
+		lit: View<bool>,
+	) -> Option<IntLitMeaning> {
+		self.lit_meaning(&*ctx.0, lit)
+	}
+
+	fn max(&self, ctx: &SimplificationContext<'_>) -> IntVal {
+		self.max(&*ctx.0)
+	}
+
+	fn max_lit(&self, ctx: &SimplificationContext<'_>) -> View<bool> {
+		self.max_lit(&*ctx.0)
+	}
+
+	fn min(&self, ctx: &SimplificationContext<'_>) -> IntVal {
+		self.min(&*ctx.0)
+	}
+
+	fn min_lit(&self, ctx: &SimplificationContext<'_>) -> View<bool> {
+		self.min_lit(&*ctx.0)
+	}
+
+	fn try_lit(
+		&self,
+		ctx: &SimplificationContext<'_>,
+		meaning: IntLitMeaning,
+	) -> Option<View<bool>> {
+		self.try_lit(&*ctx.0, meaning)
+	}
+
+	fn val(&self, ctx: &SimplificationContext<'_>) -> Option<IntVal> {
+		self.val(&*ctx.0)
+	}
+}
+
 impl View<IntVal> {
 	/// Create a view that represents the addition of a constant value to the
 	/// integer decision, while ensuring that the domain of the resulting view
@@ -387,17 +449,18 @@ impl View<IntVal> {
 		rhs: IntVal,
 	) -> Result<View<IntVal>, Ctx::Conflict>
 	where
-		Ctx: PropagationActions + ReasoningContext + ?Sized,
+		Ctx: PropagationActions + PropagationContext + ?Sized,
 		View<IntVal>: IntPropagationActions<Ctx>,
+		View<bool>: BoolPropagationActions<Ctx>,
 	{
 		if rhs.is_positive() {
 			let ub = self.max(ctx);
 			if ub.checked_add(rhs).is_none() {
 				if let Some(ub) = ub.checked_sub(rhs) {
-					self.tighten_max(ctx, ub, [])?;
+					self.tighten_max(ctx, ub, NO_REASON)?;
 				} else {
-					return Err(ctx.declare_conflict(|ctx: &mut Ctx| {
-						[self.lit(ctx, IntLitMeaning::Less(IntVal::MIN))]
+					return Err(ctx.declare_conflict(|ctx, reason| {
+						reason.push(self.lit(ctx, IntLitMeaning::Less(IntVal::MIN)));
 					}));
 				}
 			}
@@ -405,10 +468,10 @@ impl View<IntVal> {
 			let lb = self.min(ctx);
 			if lb.checked_add(rhs).is_none() {
 				if let Some(lb) = lb.checked_sub(rhs) {
-					self.tighten_min(ctx, lb, [])?;
+					self.tighten_min(ctx, lb, NO_REASON)?;
 				} else {
 					// Real conflict subject cannot be represented.
-					return Err(ctx.declare_conflict([]));
+					return Err(ctx.declare_conflict(NO_REASON));
 				}
 			}
 		}
@@ -424,8 +487,9 @@ impl View<IntVal> {
 		rhs: IntVal,
 	) -> Result<View<IntVal>, Ctx::Conflict>
 	where
-		Ctx: PropagationActions + ReasoningContext + ?Sized,
+		Ctx: PropagationActions + PropagationContext + ?Sized,
 		View<IntVal>: IntPropagationActions<Ctx>,
+		View<bool>: BoolPropagationActions<Ctx>,
 	{
 		let (lb, ub) = self.bounds(ctx);
 		let (min, max) = if rhs.is_positive() {
@@ -435,18 +499,18 @@ impl View<IntVal> {
 		};
 		if lb.checked_mul(rhs).is_none() {
 			if let Some(lb) = min.checked_div(rhs) {
-				self.tighten_min(ctx, lb, [])?;
+				self.tighten_min(ctx, lb, NO_REASON)?;
 			} else {
 				// Real conflict subject cannot be represented.
-				return Err(ctx.declare_conflict([]));
+				return Err(ctx.declare_conflict(NO_REASON));
 			}
 		}
 		if ub.checked_mul(rhs).is_none() {
 			if let Some(ub) = max.checked_div(rhs) {
-				self.tighten_max(ctx, ub, [])?;
+				self.tighten_max(ctx, ub, NO_REASON)?;
 			} else {
-				return Err(ctx.declare_conflict(|ctx: &mut Ctx| {
-					[self.lit(ctx, IntLitMeaning::Less(IntVal::MIN))]
+				return Err(ctx.declare_conflict(|ctx, reason| {
+					reason.push(self.lit(ctx, IntLitMeaning::Less(IntVal::MIN)));
 				}));
 			}
 		}
@@ -459,11 +523,11 @@ impl View<IntVal> {
 	/// tightening the domain of the view.
 	pub fn bounding_neg<Ctx>(self, ctx: &mut Ctx) -> Result<View<IntVal>, Ctx::Conflict>
 	where
-		Ctx: ReasoningContext + ?Sized,
+		Ctx: PropagationContext + ?Sized,
 		View<IntVal>: IntPropagationActions<Ctx>,
 	{
 		if self.min(ctx) == IntVal::MIN {
-			self.tighten_min(ctx, -IntVal::MAX, [])?;
+			self.tighten_min(ctx, -IntVal::MAX, NO_REASON)?;
 		}
 		Ok(-self)
 	}
@@ -477,8 +541,9 @@ impl View<IntVal> {
 		rhs: IntVal,
 	) -> Result<View<IntVal>, Ctx::Conflict>
 	where
-		Ctx: PropagationActions + ReasoningContext + ?Sized,
+		Ctx: PropagationActions + PropagationContext + ?Sized,
 		View<IntVal>: IntPropagationActions<Ctx>,
+		View<bool>: BoolPropagationActions<Ctx>,
 	{
 		self.bounding_add(ctx, rhs.saturating_neg())
 	}
@@ -664,9 +729,29 @@ impl IntDecisionActions<Model> for View<IntVal> {
 	}
 }
 
+impl IntDecisionActions<SimplificationContext<'_>> for View<IntVal> {
+	fn lit(&self, ctx: &mut SimplificationContext<'_>, meaning: IntLitMeaning) -> View<bool> {
+		self.lit(&mut *ctx.0, meaning)
+	}
+
+	fn val_lit(&self, ctx: &mut SimplificationContext<'_>) -> Option<View<bool>> {
+		self.val_lit(&mut *ctx.0)
+	}
+}
+
 impl IntExplanationActions<Model> for View<IntVal> {
 	fn lit_relaxed(&self, ctx: &Model, meaning: IntLitMeaning) -> (View<bool>, IntLitMeaning) {
 		(self.try_lit(ctx, meaning).unwrap(), meaning)
+	}
+}
+
+impl IntExplanationActions<SimplificationContext<'_>> for View<IntVal> {
+	fn lit_relaxed(
+		&self,
+		ctx: &SimplificationContext<'_>,
+		meaning: IntLitMeaning,
+	) -> (View<bool>, IntLitMeaning) {
+		self.lit_relaxed(&*ctx.0, meaning)
 	}
 }
 
@@ -712,41 +797,149 @@ impl IntInspectionActions<Model> for View<IntVal> {
 	}
 }
 
+impl IntInspectionActions<SimplificationContext<'_>> for View<IntVal> {
+	fn bounds(&self, ctx: &SimplificationContext<'_>) -> (IntVal, IntVal) {
+		self.bounds(&*ctx.0)
+	}
+
+	fn domain(&self, ctx: &SimplificationContext<'_>) -> IntSet {
+		self.domain(&*ctx.0)
+	}
+
+	fn in_domain(&self, ctx: &SimplificationContext<'_>, val: IntVal) -> bool {
+		self.in_domain(&*ctx.0, val)
+	}
+
+	fn lit_meaning(
+		&self,
+		ctx: &SimplificationContext<'_>,
+		lit: View<bool>,
+	) -> Option<IntLitMeaning> {
+		self.lit_meaning(&*ctx.0, lit)
+	}
+
+	fn max(&self, ctx: &SimplificationContext<'_>) -> IntVal {
+		self.max(&*ctx.0)
+	}
+
+	fn max_lit(&self, ctx: &SimplificationContext<'_>) -> View<bool> {
+		self.max_lit(&*ctx.0)
+	}
+
+	fn min(&self, ctx: &SimplificationContext<'_>) -> IntVal {
+		self.min(&*ctx.0)
+	}
+
+	fn min_lit(&self, ctx: &SimplificationContext<'_>) -> View<bool> {
+		self.min_lit(&*ctx.0)
+	}
+
+	fn try_lit(
+		&self,
+		ctx: &SimplificationContext<'_>,
+		meaning: IntLitMeaning,
+	) -> Option<View<bool>> {
+		self.try_lit(&*ctx.0, meaning)
+	}
+
+	fn val(&self, ctx: &SimplificationContext<'_>) -> Option<IntVal> {
+		self.val(&*ctx.0)
+	}
+}
+
 impl IntPropagationActions<Model> for View<IntVal> {
 	fn fix(
 		&self,
 		ctx: &mut Model,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), Conflict<View<bool>>> {
-		self.resolve_alias(ctx).fix(ctx, val, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.fix(
+			&mut SimplificationContext(ctx),
+			val,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
 	}
 
 	fn remove_val(
 		&self,
 		ctx: &mut Model,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), Conflict<View<bool>>> {
-		self.resolve_alias(ctx).remove_val(ctx, val, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.remove_val(
+			&mut SimplificationContext(ctx),
+			val,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
 	}
 
 	fn tighten_max(
 		&self,
 		ctx: &mut Model,
 		ub: IntVal,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), Conflict<View<bool>>> {
-		self.resolve_alias(ctx).tighten_max(ctx, ub, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.tighten_max(
+			&mut SimplificationContext(ctx),
+			ub,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
 	}
 
 	fn tighten_min(
 		&self,
 		ctx: &mut Model,
 		val: IntVal,
-		reason: impl ReasonBuilder<Model>,
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.tighten_min(
+			&mut SimplificationContext(ctx),
+			val,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
+	}
+}
+
+impl<'a> IntPropagationActions<SimplificationContext<'a>> for View<IntVal> {
+	fn fix(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		val: IntVal,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
 	) -> Result<(), Conflict<View<bool>>> {
-		self.resolve_alias(ctx).tighten_min(ctx, val, reason)
+		self.resolve_alias(&*ctx.0).fix(ctx, val, reason)
+	}
+
+	fn remove_val(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		val: IntVal,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).remove_val(ctx, val, reason)
+	}
+
+	fn tighten_max(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		ub: IntVal,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).tighten_max(ctx, ub, reason)
+	}
+
+	fn tighten_min(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		val: IntVal,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).tighten_min(ctx, val, reason)
 	}
 }
 
@@ -755,23 +948,63 @@ impl IntSimplificationActions<Model> for View<IntVal> {
 		&self,
 		ctx: &mut Model,
 		values: &IntSet,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), Conflict<View<bool>>> {
-		self.resolve_alias(ctx).exclude(ctx, values, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.exclude(
+			&mut SimplificationContext(ctx),
+			values,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
 	}
 
 	fn restrict_domain(
 		&self,
 		ctx: &mut Model,
 		values: &IntSet,
-		reason: impl ReasonBuilder<Model>,
-	) -> Result<(), Conflict<View<bool>>> {
-		self.resolve_alias(ctx).restrict_domain(ctx, values, reason)
+		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
+	) -> Result<(), Nogood<View<bool>>> {
+		self.restrict_domain(
+			&mut SimplificationContext(ctx),
+			values,
+			Model::adapt_reason(reason),
+		)
+		.map_err(Conflict::into_nogood)
 	}
 
-	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Conflict<View<bool>>> {
-		let other = other.into().resolve_alias(ctx);
-		self.resolve_alias(ctx).unify(ctx, other)
+	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Nogood<View<bool>>> {
+		self.unify(&mut SimplificationContext(ctx), other)
+			.map_err(Conflict::into_nogood)
+	}
+}
+
+impl<'a> IntSimplificationActions<SimplificationContext<'a>> for View<IntVal> {
+	fn exclude(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		values: &IntSet,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0).exclude(ctx, values, reason)
+	}
+
+	fn restrict_domain(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		values: &IntSet,
+		reason: impl FnOnce(&mut SimplificationContext<'a>, &mut SimplificationReasonSink),
+	) -> Result<(), Conflict<View<bool>>> {
+		self.resolve_alias(&*ctx.0)
+			.restrict_domain(ctx, values, reason)
+	}
+
+	fn unify(
+		&self,
+		ctx: &mut SimplificationContext<'a>,
+		other: impl Into<Self>,
+	) -> Result<(), Conflict<View<bool>>> {
+		let other = other.into().resolve_alias(&*ctx.0);
+		self.resolve_alias(&*ctx.0).unify(ctx, other)
 	}
 }
 

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -47,10 +47,10 @@ use crate::{
 	Clause, IntSet, IntVal,
 	actions::{
 		BrancherInitActions, ConstructionActions, DecisionActions, IntDecisionActions,
-		IntInspectionActions, PostingActions, ReasoningContext, ReasoningEngine, Trailed,
-		TrailingActions,
+		IntInspectionActions, PostingActions, PropagationActions, PropagationContext,
+		ReasoningContext, ReasoningEngine, Trailed, TrailingActions,
 	},
-	constraints::{BoxedPropagator, Conflict},
+	constraints::{BoxedPropagator, Nogood},
 	helpers::bytes::Bytes,
 	solver::{
 		branchers::BoxedBrancher,
@@ -748,7 +748,7 @@ where
 		};
 		assumptions.push(opt_lit.0);
 		loop {
-			solver.add_no_good(&vars, &vals).unwrap();
+			solver.add_solution_nogood(&vars, &vals).unwrap();
 
 			let result = solver.sat.solve_assuming(assumptions.clone());
 			match result {
@@ -887,31 +887,25 @@ where
 
 			debug_assert!(all_solutions.is_some());
 			let vars = all_solutions.as_ref().unwrap();
-			if solver.add_no_good(vars, &vals).is_err() {
+			if solver.add_solution_nogood(vars, &vals).is_err() {
 				break Status::Complete;
 			}
 		}
 	}
 }
 
-impl<Sat: ClauseDatabase> Solver<Sat> {
-	/// Add a clause to the solver
-	pub fn add_clause<Iter>(
-		&mut self,
-		clause: Iter,
-	) -> Result<(), <Self as ReasoningContext>::Conflict>
+impl<Sat: ExternalPropagation + ClauseDatabase> Solver<Sat> {
+	/// Add a clause to the solver, returning the resolved conflict [`Nogood`]
+	/// if the clause makes the problem unsatisfiable.
+	pub fn add_clause<Iter>(&mut self, clause: Iter) -> Result<(), Nogood<Decision<bool>>>
 	where
 		Iter: IntoIterator,
 		Iter::Item: Into<View<bool>>,
 	{
 		let clause = clause.into_iter().map(Into::into).collect_vec();
-		match ClauseDatabaseTools::add_clause(&mut self.sat, clause.clone()) {
+		match ClauseDatabaseTools::add_clause(&mut self.sat, clause.iter().cloned()) {
 			Ok(()) => Ok(()),
-			Err(Unsatisfiable) => Err(Conflict::new(
-				self,
-				None,
-				clause.into_iter().map(|l| !l).collect_vec(),
-			)),
+			Err(Unsatisfiable) => Err(Nogood::from_view_iter(clause)),
 		}
 	}
 }
@@ -1046,50 +1040,6 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 
 #[bon]
 impl<Sat: ExternalPropagation> Solver<Sat> {
-	/// Method used to add a no-good clause from a solution. This clause can be
-	/// used to ensure that the same solution is not found again.
-	///
-	/// ## Warning
-	/// This method will panic if the number of variables and values do not
-	/// match.
-	#[doc(hidden)]
-	pub fn add_no_good(
-		&mut self,
-		vars: &[AnyView],
-		vals: &[Value],
-	) -> Result<(), <Self as ReasoningContext>::Conflict> {
-		let clause = vars
-			.iter()
-			.zip_eq(vals)
-			.map(|(var, val)| match *var {
-				AnyView::Bool(bv) => match val {
-					Value::Bool(true) => !bv,
-					Value::Bool(false) => bv,
-					_ => unreachable!(),
-				},
-				AnyView::Int(iv) => {
-					let Value::Int(val) = val.clone() else {
-						unreachable!()
-					};
-					iv.lit(self, IntLitMeaning::NotEq(val))
-				}
-			})
-			.collect_vec();
-		debug!(
-			target: "solver",
-			clause = ?clause
-				.iter()
-				.filter_map(|&x| if let BoolView::Lit(x) = x.0 {
-					Some(i32::from(x.0))
-				} else {
-					None
-				})
-				.collect::<Vec<i32>>(),
-			"add solution nogood"
-		);
-		self.add_clause(clause)
-	}
-
 	/// Add a constraint propagator to the solver to enforce a constraint.
 	pub(crate) fn add_propagator(&mut self, propagator: BoxedPropagator, from_model: bool) {
 		let mut handle = self.engine.borrow_mut();
@@ -1124,6 +1074,50 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 			// Ensure the SAT solver knows the literal is observed.
 			self.sat.add_observed_var(v);
 		}
+	}
+
+	/// Method used to add a no-good clause from a solution. This clause can be
+	/// used to ensure that the same solution is not found again.
+	///
+	/// ## Warning
+	/// This method will panic if the number of variables and values do not
+	/// match.
+	#[doc(hidden)]
+	pub fn add_solution_nogood(
+		&mut self,
+		vars: &[AnyView],
+		vals: &[Value],
+	) -> Result<(), Nogood<Decision<bool>>> {
+		let clause = vars
+			.iter()
+			.zip_eq(vals)
+			.map(|(var, val)| match *var {
+				AnyView::Bool(bv) => match val {
+					Value::Bool(true) => !bv,
+					Value::Bool(false) => bv,
+					_ => unreachable!(),
+				},
+				AnyView::Int(iv) => {
+					let Value::Int(val) = val.clone() else {
+						unreachable!()
+					};
+					iv.lit(self, IntLitMeaning::NotEq(val))
+				}
+			})
+			.collect_vec();
+		debug!(
+			target: "solver",
+			clause = ?clause
+				.iter()
+				.filter_map(|&x| if let BoolView::Lit(x) = x.0 {
+					Some(i32::from(x.0))
+				} else {
+					None
+				})
+				.collect::<Vec<i32>>(),
+			"add solution nogood"
+		);
+		self.add_clause(clause)
 	}
 
 	/// Split the solver into a solving actions object that limits interaction
@@ -1485,7 +1479,7 @@ impl<Sat: ExternalPropagation> PostingActions for Solver<Sat> {
 		&mut self,
 		clause: impl IntoIterator<Item = Self::Atom>,
 	) -> Result<(), Self::Conflict> {
-		Solver::add_clause(self, clause)
+		self.add_clause(clause)
 	}
 
 	fn add_propagator(&mut self, propagator: BoxedPropagator) {
@@ -1493,9 +1487,24 @@ impl<Sat: ExternalPropagation> PostingActions for Solver<Sat> {
 	}
 }
 
+impl<Sat: ExternalPropagation> PropagationActions for Solver<Sat> {
+	fn declare_conflict(
+		&mut self,
+		reason: impl FnOnce(&mut Self, &mut Self::ReasonSink<'_>),
+	) -> Self::Conflict {
+		let mut sink = Vec::new();
+		reason(self, &mut sink);
+		Nogood::from_view_iter(sink.into_iter().map(Not::not))
+	}
+}
+
+impl<Sat> PropagationContext for Solver<Sat> {
+	type Conflict = Nogood<Decision<bool>>;
+	type ReasonSink<'a> = Vec<Self::Atom>;
+}
+
 impl<Sat> ReasoningContext for Solver<Sat> {
 	type Atom = <Engine as ReasoningEngine>::Atom;
-	type Conflict = <Engine as ReasoningEngine>::Conflict;
 }
 
 impl<Sat> TrailingActions for Solver<Sat> {

--- a/crates/huub/src/solver/decision/integer.rs
+++ b/crates/huub/src/solver/decision/integer.rs
@@ -1463,6 +1463,7 @@ mod tests {
 	use crate::{
 		IntSet, IntVal,
 		actions::{IntDecisionActions, IntInspectionActions},
+		constraints::NO_REASON,
 		solver::{
 			IntLitMeaning, LiteralStrategy, Polarity, Solver, Status, Valuation,
 			decision::{Decision, integer::IntDecision},
@@ -1540,7 +1541,7 @@ mod tests {
 				assert_eq!(x.bounds(&engine.state), (1, 6));
 				assert_eq!(x.domain(&engine.state), orig);
 				let mut ctx = SolvingContext::new(&mut actions, &mut engine.state);
-				x.tighten_min(&mut ctx, 6, []).unwrap();
+				x.tighten_min(&mut ctx, 6, NO_REASON).unwrap();
 
 				let state = &engine.state;
 				assert_eq!(x.bounds(state), (6, 6));
@@ -1554,7 +1555,7 @@ mod tests {
 				let (mut slv, x) = make_solver();
 				let (mut actions, mut engine) = slv.as_parts_mut();
 				let mut ctx = SolvingContext::new(&mut actions, &mut engine.state);
-				x.tighten_max(&mut ctx, 4, []).unwrap();
+				x.tighten_max(&mut ctx, 4, NO_REASON).unwrap();
 
 				let state = &engine.state;
 				assert_eq!(x.bounds(state), (1, 4));
@@ -1567,8 +1568,8 @@ mod tests {
 				let (mut slv, x) = make_solver();
 				let (mut actions, mut engine) = slv.as_parts_mut();
 				let mut ctx = SolvingContext::new(&mut actions, &mut engine.state);
-				x.tighten_min(&mut ctx, 3, []).unwrap();
-				x.remove_val(&mut ctx, 4, []).unwrap();
+				x.tighten_min(&mut ctx, 3, NO_REASON).unwrap();
+				x.remove_val(&mut ctx, 4, NO_REASON).unwrap();
 
 				let state = &engine.state;
 				assert_eq!(x.bounds(state), (3, 6));

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -38,7 +38,7 @@ use crate::{
 		BoolInspectionActions, IntEvent, ReasonActions, ReasoningContext, ReasoningEngine, Trailed,
 		TrailingActions,
 	},
-	constraints::{BoxedPropagator, Conflict, Reason},
+	constraints::{BoxedPropagator, Conflict, DeferredReason, Reason},
 	helpers::bytes::Bytes,
 	solver::{
 		IntLitMeaning, Polarity, SearchStrategy, SwitchTrigger,
@@ -86,6 +86,38 @@ pub struct Engine {
 	pub(crate) state: State,
 }
 
+/// A reason stored in [`State::reason_map`] explaining why a literal was
+/// propagated.
+///
+/// Reasons of up to three premises are stored inline (`Small`); longer ones are
+/// a slice `begin..begin + len` of the [`Trail`]'s reason arena (`Eager`); a
+/// `Lazy` reason is recomputed by the propagator on demand.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EngineReason {
+	/// Deferred reason: the propagator recomputes it from `data` on demand.
+	Lazy {
+		/// Index of the propagator that computes the reason.
+		propagator: u32,
+		/// Data passed back to the propagator to compute the reason.
+		data: u64,
+	},
+	/// 1–3 premise literals stored inline (no arena allocation).
+	Small {
+		/// Number of premise literals (1–3); only `lits[..len]` are populated.
+		len: u8,
+		/// The premise literals, padded with `None`.
+		lits: [Option<RawLit>; 3],
+	},
+	/// 4+ premise literals, stored as the `begin..begin + len` slice of the
+	/// [`Trail`]'s reason arena.
+	Eager {
+		/// Start index of the premises in the trail's reason arena.
+		begin: u64,
+		/// Number of premise literals.
+		len: u32,
+	},
+}
+
 /// Statistical information about the execution of the propagation engine.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub(crate) struct EngineStatistics {
@@ -114,7 +146,7 @@ pub(crate) struct LitPropagation {
 	/// The literal that was propagated.
 	pub(crate) lit: RawLit,
 	/// The reason for which the literal was propagated.
-	pub(crate) reason: Result<Reason<Decision<bool>>, bool>,
+	pub(crate) reason: Reason<View<bool>>,
 	/// The underlying event on complex types that triggered the propagation.
 	///
 	/// This event should be used to schedule further propagators.
@@ -151,8 +183,10 @@ pub struct State {
 	pub(crate) trail: Trail,
 	/// Literals to be propagated by the SAT solver
 	pub(crate) propagation_queue: VecDeque<LitPropagation>,
-	/// Reasons for setting values.
-	pub(crate) reason_map: FxHashMap<RawLit, Reason<Decision<bool>>>,
+	/// Reasons for propagating literals.
+	///
+	/// Literals of [`EngineReason::Eager`] reasons live in the [`Trail`].
+	pub(crate) reason_map: FxHashMap<RawLit, EngineReason>,
 	/// The conflict clause to communicate to the SAT solver, if a conflict has
 	/// been detected.
 	pub(crate) conflict: Option<Box<[RawLit]>>,
@@ -228,9 +262,9 @@ impl Engine {
 
 		use crate::actions::BoolInspectionActions;
 
-		if let Some(reason) = self.state.reason_map.get(&lit).cloned() {
+		if let Some(reason) = self.state.reason_map.get(&lit).copied() {
 			// If reason is lazy, go to the assignment level of the literal.
-			if let Reason::Lazy(_) = reason {
+			if let EngineReason::Lazy { .. } = reason {
 				self.state.trail.goto_assign_lit(lit);
 			}
 			// Reason is in the form (a /\ b /\ ...), which then forms the
@@ -239,7 +273,7 @@ impl Engine {
 			reason.explain(
 				&mut self.propagators,
 				&mut self.state,
-				Some(Decision(lit)),
+				lit,
 				ClauseBuilder::new(&mut clause),
 			);
 
@@ -285,7 +319,7 @@ impl Engine {
 				);
 			}
 			// If reason is lazy, return to current level
-			if let Reason::Lazy(_) = reason {
+			if let EngineReason::Lazy { .. } = reason {
 				self.state.trail.reset_to_trail_head();
 			}
 		} else {
@@ -498,7 +532,7 @@ impl PropagatorExtension for Engine {
 
 	fn explain_propagation(&mut self, propagated_lit: RawLit, mut clause: ClauseBuilder<'_>) {
 		// Find the stored reason, if any. When there is none, the reason clause is
-		// the unit clause `{propagated_lit}`; otherwise `Reason::explain` writes
+		// the unit clause `{propagated_lit}`; otherwise `EngineReason::explain`
 		// the full clause (head plus negated premises).
 		let Some(r) = self.state.reason_map.remove(&propagated_lit) else {
 			clause.push(propagated_lit);
@@ -506,13 +540,13 @@ impl PropagatorExtension for Engine {
 		};
 		// If the reason is lazy, restore the current state to the state when the
 		// propagation happened before explaining.
-		if matches!(r, Reason::Lazy(_)) {
+		if let EngineReason::Lazy { .. } = r {
 			self.state.trail.goto_assign_lit(propagated_lit);
 		}
 		r.explain(
 			&mut self.propagators,
 			&mut self.state,
-			Some(Decision(propagated_lit)),
+			propagated_lit,
 			clause,
 		);
 	}
@@ -837,6 +871,45 @@ impl PropRef {
 	}
 }
 
+impl EngineReason {
+	/// `EngineReason` is designed to fit in 128 bits, i.e., 16 bytes.
+	const _SIZE_ASSERT: () = assert!(size_of::<EngineReason>() == 16);
+
+	/// Write the reason clause for the propagated literal `head` into `clause`:
+	/// `head` itself plus the negated premises (an `Eager` reason's premises
+	/// are read from the trail's reason arena; a `Lazy` reason is recomputed by
+	/// its propagator).
+	fn explain(
+		self,
+		props: &mut [BoxedPropagator],
+		state: &mut State,
+		head: RawLit,
+		mut clause: ClauseBuilder<'_>,
+	) {
+		clause.push(head);
+		match self {
+			EngineReason::Small { len, lits } => {
+				for premise in lits.iter().take(len as usize).flatten() {
+					clause.push(!*premise);
+				}
+			}
+			EngineReason::Eager { begin, len } => {
+				let premises = state.trail.reason_lits(begin as usize, len as usize);
+				clause.extend(premises.iter().map(|&l| !l));
+			}
+			EngineReason::Lazy { propagator, data } => {
+				let mut explanation = ReasonSink(clause);
+				props[propagator as usize].explain(
+					state,
+					Decision(head).into(),
+					data,
+					&mut explanation,
+				);
+			}
+		}
+	}
+}
+
 impl<'a> ReasonSink<'a> {
 	/// Convert a premise atom (a [`View<bool>`] that currently holds) to its
 	/// literal. A constant `true` premise is vacuous and dropped; a constant
@@ -981,8 +1054,9 @@ impl State {
 				}
 			}
 			if level == 0 {
-				// Memory cleanup (Reasons are known to no longer be relevant)
+				// Memory cleanup (Reasons are known to no longer be relevant).
 				self.reason_map.clear();
+				self.trail.clear_reason_trail();
 			}
 		}
 	}
@@ -992,23 +1066,70 @@ impl State {
 		self.trail.notify_new_decision_level();
 	}
 
-	/// Register the [`Reason`] to explain why `lit` has been assigned.
-	pub(crate) fn register_reason(
-		&mut self,
-		lit: RawLit,
-		built_reason: Result<Reason<Decision<bool>>, bool>,
-	) {
-		match built_reason {
-			Ok(reason) => {
-				// Insert new reason, possibly overwriting old one (from previous search
-				// attempt)
-				self.reason_map.insert(lit, reason);
+	/// Register the [`Reason`] to explain why `lit` has been assigned,
+	/// converting it into an [`EngineReason`].
+	///
+	/// The `View<bool>` premises are tightened to literals (dropping vacuous
+	/// `Const(true)` premises); reasons of ≤3 literals are stored inline,
+	/// longer ones are appended to the trail's reusable reason arena. Any
+	/// previous reason for `lit` (from an earlier search attempt) is
+	/// overwritten.
+	pub(crate) fn register_reason(&mut self, lit: RawLit, reason: Reason<View<bool>>) {
+		match reason {
+			Reason::Lazy(DeferredReason { propagator, data }) => {
+				let _ = self
+					.reason_map
+					.insert(lit, EngineReason::Lazy { propagator, data });
 			}
-			Err(true) => {
-				// No (previous) reason required
-				self.reason_map.remove(&lit);
+			reason => {
+				let premises: &[View<bool>] = match &reason {
+					Reason::Simple(premise) => std::slice::from_ref(premise),
+					Reason::Eager(premises) => &premises[..],
+					Reason::Lazy(_) => unreachable!("handled above"),
+				};
+				let begin = self.trail.reason_len();
+				let mut lits = [None; 3];
+				let mut len = 0_usize;
+				let mut spilled = false;
+				for &view in premises {
+					// Drop vacuous `Const(true)` premises; `Const(false)` is invalid.
+					let Some(premise) = ReasonSink::into_raw_lit(view) else {
+						continue;
+					};
+					if !spilled && len < 3 {
+						lits[len] = Some(premise);
+					} else {
+						if !spilled {
+							for &held in lits.iter().flatten() {
+								self.trail.push_reason_lit(held);
+							}
+							spilled = true;
+						}
+						self.trail.push_reason_lit(premise);
+					}
+					len += 1;
+				}
+				if len == 0 {
+					// All premises were vacuous; no reason required.
+					let _ = self.reason_map.remove(&lit);
+				} else if spilled {
+					let _ = self.reason_map.insert(
+						lit,
+						EngineReason::Eager {
+							begin: begin as u64,
+							len: len as u32,
+						},
+					);
+				} else {
+					let _ = self.reason_map.insert(
+						lit,
+						EngineReason::Small {
+							len: len as u8,
+							lits,
+						},
+					);
+				}
 			}
-			Err(false) => unreachable!("invalid reason"),
 		}
 	}
 

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -38,7 +38,7 @@ use crate::{
 		BoolInspectionActions, IntEvent, ReasonActions, ReasoningContext, ReasoningEngine, Trailed,
 		TrailingActions,
 	},
-	constraints::{BoxedPropagator, Conflict, DeferredReason, Reason},
+	constraints::{BoxedPropagator, Conflict},
 	helpers::bytes::Bytes,
 	solver::{
 		IntLitMeaning, Polarity, SearchStrategy, SwitchTrigger,
@@ -89,7 +89,7 @@ pub struct Engine {
 /// A reason stored in [`State::reason_map`] explaining why a literal was
 /// propagated.
 ///
-/// Reasons of up to three premises are stored inline (`Small`); longer ones are
+/// Reasons of up to three literals are stored inline (`Small`); longer ones are
 /// a slice `begin..begin + len` of the [`Trail`]'s reason arena (`Eager`); a
 /// `Lazy` reason is recomputed by the propagator on demand.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -101,22 +101,28 @@ pub(crate) enum EngineReason {
 		/// Data passed back to the propagator to compute the reason.
 		data: u64,
 	},
-	/// 1–3 premise literals stored inline (no arena allocation).
+	/// 1–3 literals stored inline (no arena allocation).
 	Small {
-		/// Number of premise literals (1–3); only `lits[..len]` are populated.
+		/// Number of literals (1–3); only `lits[..len]` are populated.
 		len: u8,
-		/// The premise literals, padded with `None`.
+		/// The literals, padded with `None`.
 		lits: [Option<RawLit>; 3],
 	},
-	/// 4+ premise literals, stored as the `begin..begin + len` slice of the
+	/// 4+ literals, stored as the `begin..begin + len` slice of the
 	/// [`Trail`]'s reason arena.
 	Eager {
-		/// Start index of the premises in the trail's reason arena.
+		/// Start index in the trail's reason arena.
 		begin: u64,
-		/// Number of premise literals.
+		/// Number of literals.
 		len: u32,
 	},
 }
+
+/// The sink that captures the reason literals that imply the propagated
+/// literal, which the engine hands to [`Propagator::explain`]. The literals are
+/// stored in negated form, such that they are partial clauses.
+#[derive(Debug)]
+pub struct EngineReasonSink<'a>(pub(crate) ClauseBuilder<'a>);
 
 /// Statistical information about the execution of the propagation engine.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
@@ -145,21 +151,17 @@ pub(crate) struct EngineStatistics {
 pub(crate) struct LitPropagation {
 	/// The literal that was propagated.
 	pub(crate) lit: RawLit,
-	/// The reason for which the literal was propagated.
-	pub(crate) reason: Reason<View<bool>>,
+	/// The reason for which the literal was propagated, already stored on the
+	/// trail, or `None` if trivially true.
+	pub(crate) reason: Option<EngineReason>,
 	/// The underlying event on complex types that triggered the propagation.
 	///
-	/// This event should be used to schedule further propagators.
+	/// This event is used to schedule further propagators.
 	pub(crate) event: Option<(Decision<IntVal>, IntEvent)>,
 }
 /// Identifies an propagator in a [`Solver`]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct PropRef(u32);
-
-/// The sink that captures the reason literals that imply the propagated
-/// literal, which the engine hands to [`Propagator::explain`].
-#[derive(Debug)]
-pub struct ReasonSink<'a>(pub(crate) ClauseBuilder<'a>);
 
 /// Internal state representation of the propagation engine disconnected from
 /// the storage of the propagators and branchers.
@@ -167,7 +169,7 @@ pub struct ReasonSink<'a>(pub(crate) ClauseBuilder<'a>);
 /// Note that this structure is public to the user to allow the user to
 /// construct [`BoxedPropagator`], but it is not intended to be constructed by
 /// the user. It should merely be seen as the implementation of the
-/// [`ExplanationActions`] trait.
+/// [`ReasonActions`] trait.
 #[derive(Clone, Debug, Default)]
 pub struct State {
 	/// Search strategy to use during solving
@@ -533,7 +535,7 @@ impl PropagatorExtension for Engine {
 	fn explain_propagation(&mut self, propagated_lit: RawLit, mut clause: ClauseBuilder<'_>) {
 		// Find the stored reason, if any. When there is none, the reason clause is
 		// the unit clause `{propagated_lit}`; otherwise `EngineReason::explain`
-		// the full clause (head plus negated premises).
+		// the full clause.
 		let Some(r) = self.state.reason_map.remove(&propagated_lit) else {
 			clause.push(propagated_lit);
 			return;
@@ -841,7 +843,123 @@ impl ReasoningEngine for Engine {
 	type NotificationContext<'a> = State;
 	type PropagationContext<'a> = SolvingContext<'a>;
 
-	type ReasonSink<'a> = ReasonSink<'a>;
+	type ReasonSink<'a> = EngineReasonSink<'a>;
+}
+
+impl EngineReason {
+	/// `EngineReason` is designed to fit in 128 bits, i.e., 16 bytes.
+	const _SIZE_ASSERT: () = assert!(size_of::<EngineReason>() == 16);
+
+	/// Write the reason clause for the propagated literal `head` into `clause`:
+	/// `head` itself plus the reason's clause literals.
+	///
+	/// A `Small`/`Eager` reason is already stored in clausal form, so its
+	/// literals are directly emitted; a `Lazy` (conjunctive) reason is
+	/// recomputed by the propagator, directly negated using [`ReasonSink`].
+	fn explain(
+		self,
+		props: &mut [BoxedPropagator],
+		state: &mut State,
+		head: RawLit,
+		mut clause: ClauseBuilder<'_>,
+	) {
+		clause.push(head);
+		match self {
+			EngineReason::Small { len, lits } => {
+				clause.extend(lits.iter().take(len as usize).map(|lit| lit.unwrap()));
+			}
+			EngineReason::Eager { begin, len } => {
+				let (begin, len) = (begin as usize, len as usize);
+				debug_assert!(
+					begin + len <= state.trail.reason_trail.len(),
+					"stale reason range into the arena"
+				);
+				let slice = &state.trail.reason_trail[begin..begin + len];
+				clause.extend(slice.iter().copied());
+			}
+			EngineReason::Lazy { propagator, data } => {
+				let mut explanation = EngineReasonSink(clause);
+				props[propagator as usize].explain(
+					state,
+					Decision(head).into(),
+					data,
+					&mut explanation,
+				);
+			}
+		}
+	}
+
+	/// Process the partial reason clause a reason closure appended to the
+	/// reason trail, returning an [`EngineReason`].
+	///
+	/// This method returns `None` for a trivially true reason. Reasons of ≤3
+	/// literals are popped back off the trail and stored inline; a longer one
+	/// stays in the trail as an `Eager` slice.
+	pub(crate) fn finalize_reason(
+		deferred: Option<(u32, u64)>,
+		reason_trail: &mut Vec<RawLit>,
+		begin: usize,
+	) -> Option<EngineReason> {
+		match deferred {
+			Some((propagator, data)) => Some(EngineReason::Lazy { propagator, data }),
+			None => {
+				let len = reason_trail.len() - begin;
+				match len {
+					0 => None,
+					1..=3 => {
+						let mut lits = [None; 3];
+						for (slot, &lit) in lits.iter_mut().zip(&reason_trail[begin..]) {
+							*slot = Some(lit);
+						}
+						reason_trail.truncate(begin);
+						Some(EngineReason::Small {
+							len: len as u8,
+							lits,
+						})
+					}
+					_ => Some(EngineReason::Eager {
+						begin: begin as u64,
+						len: len as u32,
+					}),
+				}
+			}
+		}
+	}
+}
+
+impl<'a> EngineReasonSink<'a> {
+	/// Convert a [`View<bool>`] (that must currently holds) to its literal.
+	/// `true` constants are dropped and `false` constants indicate an invalid
+	/// reason.
+	pub(crate) fn into_raw_lit(atom: View<bool>) -> Option<RawLit> {
+		match atom.0 {
+			BoolView::Lit(decision) => Some(decision.0),
+			BoolView::Const(true) => None,
+			BoolView::Const(false) => panic!("invalid lazy reason"), // TODO: Better message.
+		}
+	}
+}
+
+impl Extend<View<bool>> for EngineReasonSink<'_> {
+	fn extend<T: IntoIterator<Item = View<bool>>>(&mut self, iter: T) {
+		self.0.extend(
+			iter.into_iter()
+				.filter_map(Self::into_raw_lit)
+				.map(|lit| !lit),
+		);
+	}
+}
+
+impl ReasonActions<View<bool>> for EngineReasonSink<'_> {
+	fn push(&mut self, atom: View<bool>) {
+		if let Some(lit) = Self::into_raw_lit(atom) {
+			self.0.push(!lit);
+		}
+	}
+
+	fn reserve(&mut self, additional: usize) {
+		self.0.reserve(additional);
+	}
 }
 
 impl PropRef {
@@ -868,79 +986,6 @@ impl PropRef {
 	/// Access the raw value of the propagator reference.
 	pub(crate) fn raw(&self) -> u32 {
 		self.0
-	}
-}
-
-impl EngineReason {
-	/// `EngineReason` is designed to fit in 128 bits, i.e., 16 bytes.
-	const _SIZE_ASSERT: () = assert!(size_of::<EngineReason>() == 16);
-
-	/// Write the reason clause for the propagated literal `head` into `clause`:
-	/// `head` itself plus the negated premises (an `Eager` reason's premises
-	/// are read from the trail's reason arena; a `Lazy` reason is recomputed by
-	/// its propagator).
-	fn explain(
-		self,
-		props: &mut [BoxedPropagator],
-		state: &mut State,
-		head: RawLit,
-		mut clause: ClauseBuilder<'_>,
-	) {
-		clause.push(head);
-		match self {
-			EngineReason::Small { len, lits } => {
-				for premise in lits.iter().take(len as usize).flatten() {
-					clause.push(!*premise);
-				}
-			}
-			EngineReason::Eager { begin, len } => {
-				let premises = state.trail.reason_lits(begin as usize, len as usize);
-				clause.extend(premises.iter().map(|&l| !l));
-			}
-			EngineReason::Lazy { propagator, data } => {
-				let mut explanation = ReasonSink(clause);
-				props[propagator as usize].explain(
-					state,
-					Decision(head).into(),
-					data,
-					&mut explanation,
-				);
-			}
-		}
-	}
-}
-
-impl<'a> ReasonSink<'a> {
-	/// Convert a premise atom (a [`View<bool>`] that currently holds) to its
-	/// literal. A constant `true` premise is vacuous and dropped; a constant
-	/// `false` premise indicates an invalid reason.
-	fn into_raw_lit(atom: View<bool>) -> Option<RawLit> {
-		match atom.0 {
-			BoolView::Lit(decision) => Some(decision.0),
-			BoolView::Const(true) => None,
-			BoolView::Const(false) => panic!("invalid lazy reason"), // TODO: Better message.
-		}
-	}
-}
-
-impl ReasonActions<View<bool>> for ReasonSink<'_> {
-	fn extend(&mut self, atoms: impl IntoIterator<Item = View<bool>>) {
-		self.0.extend(
-			atoms
-				.into_iter()
-				.filter_map(Self::into_raw_lit)
-				.map(|lit| !lit),
-		);
-	}
-
-	fn push(&mut self, atom: View<bool>) {
-		if let Some(lit) = Self::into_raw_lit(atom) {
-			self.0.push(!lit);
-		}
-	}
-
-	fn reserve(&mut self, additional: usize) {
-		self.0.reserve(additional);
 	}
 }
 
@@ -1066,69 +1111,17 @@ impl State {
 		self.trail.notify_new_decision_level();
 	}
 
-	/// Register the [`Reason`] to explain why `lit` has been assigned,
-	/// converting it into an [`EngineReason`].
+	/// Register the interned `reason` to explain why `lit` has been assigned.
 	///
-	/// The `View<bool>` premises are tightened to literals (dropping vacuous
-	/// `Const(true)` premises); reasons of ≤3 literals are stored inline,
-	/// longer ones are appended to the trail's reusable reason arena. Any
-	/// previous reason for `lit` (from an earlier search attempt) is
-	/// overwritten.
-	pub(crate) fn register_reason(&mut self, lit: RawLit, reason: Reason<View<bool>>) {
+	/// A `None` reason is trivially true; any previous reason for `lit` (from
+	/// an earlier search attempt) is then removed so it cannot be reused.
+	pub(crate) fn register_reason(&mut self, lit: RawLit, reason: Option<EngineReason>) {
 		match reason {
-			Reason::Lazy(DeferredReason { propagator, data }) => {
-				let _ = self
-					.reason_map
-					.insert(lit, EngineReason::Lazy { propagator, data });
+			Some(reason) => {
+				let _ = self.reason_map.insert(lit, reason);
 			}
-			reason => {
-				let premises: &[View<bool>] = match &reason {
-					Reason::Simple(premise) => std::slice::from_ref(premise),
-					Reason::Eager(premises) => &premises[..],
-					Reason::Lazy(_) => unreachable!("handled above"),
-				};
-				let begin = self.trail.reason_len();
-				let mut lits = [None; 3];
-				let mut len = 0_usize;
-				let mut spilled = false;
-				for &view in premises {
-					// Drop vacuous `Const(true)` premises; `Const(false)` is invalid.
-					let Some(premise) = ReasonSink::into_raw_lit(view) else {
-						continue;
-					};
-					if !spilled && len < 3 {
-						lits[len] = Some(premise);
-					} else {
-						if !spilled {
-							for &held in lits.iter().flatten() {
-								self.trail.push_reason_lit(held);
-							}
-							spilled = true;
-						}
-						self.trail.push_reason_lit(premise);
-					}
-					len += 1;
-				}
-				if len == 0 {
-					// All premises were vacuous; no reason required.
-					let _ = self.reason_map.remove(&lit);
-				} else if spilled {
-					let _ = self.reason_map.insert(
-						lit,
-						EngineReason::Eager {
-							begin: begin as u64,
-							len: len as u32,
-						},
-					);
-				} else {
-					let _ = self.reason_map.insert(
-						lit,
-						EngineReason::Small {
-							len: len as u8,
-							lits,
-						},
-					);
-				}
+			None => {
+				let _ = self.reason_map.remove(&lit);
 			}
 		}
 	}
@@ -1143,7 +1136,6 @@ impl State {
 
 impl ReasoningContext for State {
 	type Atom = <Engine as ReasoningEngine>::Atom;
-	type Conflict = <Engine as ReasoningEngine>::Conflict;
 }
 
 impl TrailingActions for State {
@@ -1166,7 +1158,7 @@ mod tests {
 			BoolPropagationActions, InitActions, IntDecisionActions, IntEvent, IntInitActions,
 			IntPropCond, IntPropagationActions, ReasoningEngine,
 		},
-		constraints::Propagator,
+		constraints::{NO_REASON, Propagator},
 		solver::{
 			BoolView, Decision, IntLitMeaning, LiteralStrategy, Solver, View, engine::Engine,
 		},
@@ -1225,8 +1217,8 @@ mod tests {
 			) -> Result<(), <Engine as ReasoningEngine>::Conflict> {
 				assert!(!self.done);
 				self.done = true;
-				self.req_first.require(ctx, [])?;
-				self.ge_1_second.tighten_min(ctx, 1, [])?;
+				self.req_first.require(ctx, NO_REASON)?;
+				self.ge_1_second.tighten_min(ctx, 1, NO_REASON)?;
 				Ok(())
 			}
 		}

--- a/crates/huub/src/solver/initialization_context.rs
+++ b/crates/huub/src/solver/initialization_context.rs
@@ -222,7 +222,6 @@ impl InitActions for InitializationContext<'_> {
 
 impl ReasoningContext for InitializationContext<'_> {
 	type Atom = <Engine as ReasoningEngine>::Atom;
-	type Conflict = <Engine as ReasoningEngine>::Conflict;
 }
 
 impl IntInitActions<InitializationContext<'_>> for IntVal {

--- a/crates/huub/src/solver/solving_context.rs
+++ b/crates/huub/src/solver/solving_context.rs
@@ -4,27 +4,33 @@
 //! This structure contains the implementation of the action traits that are
 //! exposed to propagators.
 
-use std::fmt::{self, Debug, Formatter};
+use std::{
+	fmt::{self, Debug, Formatter},
+	mem,
+};
 
 use pindakaas::{
 	Lit as RawLit,
 	solver::propagation::{ClauseBuilder, SolvingActions},
 };
-use tracing::trace;
+use tracing::{trace, warn};
 
 use crate::{
 	IntSet, IntVal,
 	actions::{
-		BoolInspectionActions, BoolPropagationActions, DecisionActions, IntDecisionActions,
-		IntEvent, IntInspectionActions, IntPropagationActions, PropagationActions,
-		ReasoningContext, ReasoningEngine, Trailed, TrailingActions,
+		BoolInspectionActions, BoolPropagationActions, DecisionActions, DeferReasonActions,
+		IntDecisionActions, IntEvent, IntInspectionActions, IntPropagationActions,
+		PropagationActions, PropagationContext, ReasonActions, ReasoningContext, ReasoningEngine,
+		Trailed, TrailingActions,
 	},
-	constraints::{Conflict, DeferredReason, Reason, ReasonBuilder},
+	constraints::{Conflict, ConflictInner},
 	helpers::bytes::Bytes,
 	solver::{
 		BoxedPropagator, IntLitMeaning, Polarity,
 		decision::{Decision, integer::LazyLitDef},
-		engine::{Engine, LitPropagation, PropRef, State, trace_new_lit},
+		engine::{
+			Engine, EngineReason, EngineReasonSink, LitPropagation, PropRef, State, trace_new_lit,
+		},
 		view::{View, boolean::BoolView},
 	},
 };
@@ -58,9 +64,8 @@ enum ChangeType {
 	Conflicting,
 }
 
-/// Helper struct that temporarily captures a built reason to print it for
-/// `tracing`.
-struct ReasonTracePrint<'a, A>(&'a Reason<A>);
+/// Helper struct that prints a [`Conflict`]'s nogood compactly for `tracing`.
+struct ConflictTracePrint<'a, A>(&'a Conflict<A>);
 
 /// Structure to hold the internal [`State`] of the propagation engine and the
 /// [`SolvingActions`] exposed by the SAT solver.
@@ -80,6 +85,28 @@ pub struct SolvingContext<'a> {
 	pub(crate) current_prop: PropRef,
 }
 
+/// The reason-build sink for the engine's [`SolvingContext`]: a reason closure
+/// either pushes the negated its reason atoms onto the reason trail (through
+/// the wrapped [`EngineReasonSink`]) or defers the reason to the current
+/// propagator with [`DeferReasonActions::defer`].
+#[derive(Debug)]
+pub struct SolvingReasonSink<'a> {
+	/// The sink that reason atoms are written to.
+	pub(crate) conditions: EngineReasonSink<'a>,
+	/// `Some(data)` once the reason has been deferred; the propagator index is
+	/// folded in by the caller (which owns the current-propagator reference).
+	pub(crate) deferred: Option<u64>,
+}
+
+impl<A: Debug> Debug for ConflictTracePrint<'_, A> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		match &self.0.0 {
+			ConflictInner::Clause(lits) => lits.fmt(f),
+			ConflictInner::Deferred { subject, .. } => write!(f, "deferred for {subject:?}"),
+		}
+	}
+}
+
 impl BoolInspectionActions<SolvingContext<'_>> for Decision<bool> {
 	fn val(&self, ctx: &SolvingContext<'_>) -> Option<bool> {
 		self.val(ctx.state)
@@ -91,7 +118,7 @@ impl<'a> BoolPropagationActions<SolvingContext<'a>> for Decision<bool> {
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: bool,
-		reason: impl ReasonBuilder<SolvingContext<'a>>,
+		reason: impl FnOnce(&mut SolvingContext<'a>, &mut SolvingReasonSink<'_>),
 	) -> Result<(), Conflict<Decision<bool>>> {
 		if val { *self } else { !(*self) }.require(ctx, reason)
 	}
@@ -99,11 +126,11 @@ impl<'a> BoolPropagationActions<SolvingContext<'a>> for Decision<bool> {
 	fn require(
 		&self,
 		ctx: &mut SolvingContext<'a>,
-		reason: impl ReasonBuilder<SolvingContext<'a>>,
+		reason: impl FnOnce(&mut SolvingContext<'a>, &mut SolvingReasonSink<'_>),
 	) -> Result<(), Conflict<Decision<bool>>> {
 		match self.val(&ctx.state.trail) {
 			Some(true) => Ok(()),
-			Some(false) => Err(Conflict::new(ctx, Some(*self), reason)),
+			Some(false) => Err(ctx.make_conflict(Some(*self), reason)),
 			None => {
 				ctx.propagate_lit(*self, reason, None);
 				Ok(())
@@ -195,7 +222,7 @@ impl<'a> IntPropagationActions<SolvingContext<'a>> for Decision<IntVal> {
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<SolvingContext<'a>>,
+		reason: impl FnOnce(&mut SolvingContext<'a>, &mut SolvingReasonSink<'_>),
 	) -> Result<(), Conflict<Decision<bool>>> {
 		ctx.propagate_int(*self, ChangeRequest::SetValue(val), reason)
 	}
@@ -204,7 +231,7 @@ impl<'a> IntPropagationActions<SolvingContext<'a>> for Decision<IntVal> {
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<SolvingContext<'a>>,
+		reason: impl FnOnce(&mut SolvingContext<'a>, &mut SolvingReasonSink<'_>),
 	) -> Result<(), Conflict<Decision<bool>>> {
 		ctx.propagate_int(*self, ChangeRequest::RemoveValue(val), reason)
 	}
@@ -213,7 +240,7 @@ impl<'a> IntPropagationActions<SolvingContext<'a>> for Decision<IntVal> {
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<SolvingContext<'a>>,
+		reason: impl FnOnce(&mut SolvingContext<'a>, &mut SolvingReasonSink<'_>),
 	) -> Result<(), Conflict<Decision<bool>>> {
 		ctx.propagate_int(*self, ChangeRequest::SetUpperBound(val), reason)
 	}
@@ -222,23 +249,52 @@ impl<'a> IntPropagationActions<SolvingContext<'a>> for Decision<IntVal> {
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: IntVal,
-		reason: impl ReasonBuilder<SolvingContext<'a>>,
+		reason: impl FnOnce(&mut SolvingContext<'a>, &mut SolvingReasonSink<'_>),
 	) -> Result<(), Conflict<Decision<bool>>> {
 		ctx.propagate_int(*self, ChangeRequest::SetLowerBound(val), reason)
 	}
 }
 
-impl<A: Debug> Debug for ReasonTracePrint<'_, A> {
-	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-		match self.0 {
-			Reason::Eager(conj) => conj.fmt(f),
-			Reason::Lazy(_) => write!(f, "lazy"),
-			Reason::Simple(l) => std::slice::from_ref(l).fmt(f),
+impl<'a> SolvingContext<'a> {
+	/// Build a [`Conflict`] from a reason closure, tightening the yielded
+	/// [`View<bool>`] into [`Decision<bool>`].
+	pub(crate) fn make_conflict(
+		&mut self,
+		subject: Option<Decision<bool>>,
+		reason: impl FnOnce(&mut Self, &mut SolvingReasonSink<'_>),
+	) -> Conflict<Decision<bool>> {
+		let mut clause = Vec::new();
+		let deferred = {
+			let mut sink = SolvingReasonSink {
+				conditions: EngineReasonSink(ClauseBuilder::new(&mut clause)),
+				deferred: None,
+			};
+			reason(self, &mut sink);
+			sink.deferred
+		};
+		match deferred {
+			Some(data) => Conflict(ConflictInner::Deferred {
+				subject,
+				propagator: self.current_prop.index() as u32,
+				data,
+			}),
+			None => {
+				// `clause` holds the reason in clausal form (already negated); just add
+				// the subject.
+				let mut lits: Vec<Decision<bool>> = clause.into_iter().map(Decision).collect();
+				match subject {
+					Some(subject) => lits.push(subject),
+					None if lits.is_empty() => warn!(
+						target: "solver",
+						"empty conflict detected; additional model simplification reasoning may be possible"
+					),
+					None => {}
+				}
+				Conflict(ConflictInner::Clause(lits.into_boxed_slice()))
+			}
 		}
 	}
-}
 
-impl<'a> SolvingContext<'a> {
 	/// Create a new SolvingContext given the solver actions exposed by the SAT
 	/// solver and the engine state.
 	pub(crate) fn new(slv: &'a mut dyn SolvingActions, state: &'a mut State) -> Self {
@@ -256,7 +312,7 @@ impl<'a> SolvingContext<'a> {
 		&mut self,
 		iv: Decision<IntVal>,
 		change_req: ChangeRequest,
-		reason: impl ReasonBuilder<Self>,
+		reason: impl FnOnce(&mut Self, &mut SolvingReasonSink<'_>),
 	) -> Result<(), Conflict<Decision<bool>>> {
 		let (lb, ub) = self.state.int_vars[iv.idx()].bounds(self);
 		// Check whether a change is redundant, conflicting, or new with respect to
@@ -309,17 +365,17 @@ impl<'a> SolvingContext<'a> {
 		// 1. Always false (and immediate return if always true).
 		let lit = match bv.0 {
 			BoolView::Const(true) => return Ok(()),
-			BoolView::Const(false) => return Err(Conflict::new(self, None, reason)),
+			BoolView::Const(false) => return Err(self.make_conflict(None, reason)),
 			BoolView::Lit(lit) => lit,
 		};
 		// 2. Bounds check is known to be false.
 		if check == ChangeType::Conflicting {
-			return Err(Conflict::new(self, lit.into(), reason));
+			return Err(self.make_conflict(lit.into(), reason));
 		}
 		// 3. Literal is assigned false (and immediate return if assigned true).
 		match lit.val(&self.state.trail) {
 			Some(true) => return Ok(()),
-			Some(false) => return Err(Conflict::new(self, lit.into(), reason)),
+			Some(false) => return Err(self.make_conflict(lit.into(), reason)),
 			None => {}
 		}
 
@@ -366,21 +422,27 @@ impl<'a> SolvingContext<'a> {
 	fn propagate_lit(
 		&mut self,
 		lit: Decision<bool>,
-		reason: impl ReasonBuilder<Self>,
+		reason: impl FnOnce(&mut Self, &mut SolvingReasonSink<'_>),
 		event: Option<(Decision<IntVal>, IntEvent)>,
 	) {
-		// Build the reason, folding the trivial/invalid markers into `View`
-		// constants so the propagation list carries a plain `Reason` (no
-		// `Result`); these are dropped/rejected when tightened at registration.
-		let reason = match reason.build_reason(self) {
-			Ok(reason) => reason,
-			Err(true) => Reason::Simple(true.into()),
-			Err(false) => Reason::Simple(false.into()),
-		};
+		// Build the reason directly onto the reason trail.
+		let reason = self.with_reason_trail(|ctx, reason_trail| {
+			let begin = reason_trail.len();
+			let deferred = {
+				let mut sink = SolvingReasonSink {
+					conditions: EngineReasonSink(ClauseBuilder::new(reason_trail)),
+					deferred: None,
+				};
+				reason(ctx, &mut sink);
+				sink.deferred
+			};
+			let deferred = deferred.map(|data| (ctx.current_prop.index() as u32, data));
+			EngineReason::finalize_reason(deferred, reason_trail, begin)
+		});
 		trace!(
 			target: "solver",
 			lit = i32::from(lit.0),
-			reason = ?ReasonTracePrint(&reason),
+			reason = ?reason,
 			prop = self.current_prop.index(),
 			"propagate"
 		);
@@ -434,29 +496,35 @@ impl<'a> SolvingContext<'a> {
 			if let Err(conflict) = res {
 				trace!(
 					target: "solver",
-					lit = conflict
-						.subject
-						.map(|s| i32::from(s.0))
-						.unwrap_or_default(),
-					reason = ?ReasonTracePrint(&conflict.reason),
+					conflict = ?ConflictTracePrint(&conflict),
 					"conflict detected"
 				);
 				debug_assert!(self.state.conflict.is_none());
 				self.state.failed = true;
 				// Convert the conflict object into a conflict clause.
 				let mut clause: Vec<RawLit> = Vec::new();
-				conflict.reason.explain(
-					propagators,
-					self.state,
-					conflict.subject,
-					ClauseBuilder::new(&mut clause),
-				);
+				conflict.explain(propagators, self.state, ClauseBuilder::new(&mut clause));
 				self.state.conflict = Some(clause.into_boxed_slice());
 			}
 			if self.state.conflict.is_some() || !self.state.propagation_queue.is_empty() {
 				return;
 			}
 		}
+	}
+
+	/// Run `build` with the reason trail temporarily taken out of the engine
+	/// state, restoring it unconditionally afterwards.
+	///
+	/// The trail is handed to `build` as a `&mut Vec<RawLit>`.
+	pub(crate) fn with_reason_trail<R>(
+		&mut self,
+		build: impl FnOnce(&mut Self, &mut Vec<RawLit>) -> R,
+	) -> R {
+		let mut reason_trail = mem::take(&mut self.state.trail.reason_trail);
+		let result = build(self, &mut reason_trail);
+		debug_assert!(self.state.trail.reason_trail.is_empty());
+		self.state.trail.reason_trail = reason_trail;
+		result
 	}
 }
 
@@ -476,21 +544,21 @@ impl DecisionActions for SolvingContext<'_> {
 }
 
 impl PropagationActions for SolvingContext<'_> {
-	fn declare_conflict(&mut self, reason: impl ReasonBuilder<Self>) -> Conflict<Decision<bool>> {
-		Conflict::new(self, None, reason)
+	fn declare_conflict(
+		&mut self,
+		reason: impl FnOnce(&mut Self, &mut SolvingReasonSink<'_>),
+	) -> Conflict<Decision<bool>> {
+		self.make_conflict(None, reason)
 	}
+}
 
-	fn deferred_reason(&self, data: u64) -> DeferredReason {
-		DeferredReason {
-			propagator: self.current_prop.index() as u32,
-			data,
-		}
-	}
+impl PropagationContext for SolvingContext<'_> {
+	type Conflict = <Engine as ReasoningEngine>::Conflict;
+	type ReasonSink<'a> = SolvingReasonSink<'a>;
 }
 
 impl ReasoningContext for SolvingContext<'_> {
 	type Atom = <Engine as ReasoningEngine>::Atom;
-	type Conflict = <Engine as ReasoningEngine>::Conflict;
 }
 
 impl TrailingActions for SolvingContext<'_> {
@@ -503,12 +571,34 @@ impl TrailingActions for SolvingContext<'_> {
 	}
 }
 
+impl DeferReasonActions<View<bool>> for SolvingReasonSink<'_> {
+	fn defer(&mut self, data: u64) {
+		self.deferred = Some(data);
+	}
+}
+
+impl Extend<View<bool>> for SolvingReasonSink<'_> {
+	fn extend<T: IntoIterator<Item = View<bool>>>(&mut self, iter: T) {
+		self.conditions.extend(iter);
+	}
+}
+
+impl ReasonActions<View<bool>> for SolvingReasonSink<'_> {
+	fn push(&mut self, atom: View<bool>) {
+		self.conditions.push(atom);
+	}
+
+	fn reserve(&mut self, additional: usize) {
+		self.conditions.reserve(additional);
+	}
+}
+
 impl<'a> BoolPropagationActions<SolvingContext<'a>> for View<bool> {
 	fn fix(
 		&self,
 		ctx: &mut SolvingContext<'a>,
 		val: bool,
-		reason: impl ReasonBuilder<SolvingContext<'a>>,
+		reason: impl FnOnce(&mut SolvingContext<'a>, &mut SolvingReasonSink<'_>),
 	) -> Result<(), Conflict<Decision<bool>>> {
 		if val { *self } else { !(*self) }.require(ctx, reason)
 	}
@@ -516,11 +606,11 @@ impl<'a> BoolPropagationActions<SolvingContext<'a>> for View<bool> {
 	fn require(
 		&self,
 		ctx: &mut SolvingContext<'a>,
-		reason: impl ReasonBuilder<SolvingContext<'a>>,
+		reason: impl FnOnce(&mut SolvingContext<'a>, &mut SolvingReasonSink<'_>),
 	) -> Result<(), Conflict<Decision<bool>>> {
 		match self.0 {
 			BoolView::Lit(lit) => lit.require(ctx, reason),
-			BoolView::Const(false) => Err(Conflict::new(ctx, None, reason)),
+			BoolView::Const(false) => Err(ctx.make_conflict(None, reason)),
 			BoolView::Const(true) => Ok(()),
 		}
 	}

--- a/crates/huub/src/solver/solving_context.rs
+++ b/crates/huub/src/solver/solving_context.rs
@@ -60,7 +60,7 @@ enum ChangeType {
 
 /// Helper struct that temporarily captures a built reason to print it for
 /// `tracing`.
-struct ReasonTracePrint<'a>(&'a Result<Reason<Decision<bool>>, bool>);
+struct ReasonTracePrint<'a, A>(&'a Reason<A>);
 
 /// Structure to hold the internal [`State`] of the propagation engine and the
 /// [`SolvingActions`] exposed by the SAT solver.
@@ -228,18 +228,12 @@ impl<'a> IntPropagationActions<SolvingContext<'a>> for Decision<IntVal> {
 	}
 }
 
-impl Debug for ReasonTracePrint<'_> {
+impl<A: Debug> Debug for ReasonTracePrint<'_, A> {
 	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
 		match self.0 {
-			Err(false) => write!(f, "false"),
-			Err(true) => write!(f, "[]"),
-			Ok(Reason::Eager(conj)) => conj
-				.iter()
-				.map(|&l| l.0.into())
-				.collect::<Vec<i32>>()
-				.fmt(f),
-			Ok(Reason::Lazy(_)) => write!(f, "lazy"),
-			&Ok(Reason::Simple(l)) => vec![i32::from(l.0)].fmt(f),
+			Reason::Eager(conj) => conj.fmt(f),
+			Reason::Lazy(_) => write!(f, "lazy"),
+			Reason::Simple(l) => std::slice::from_ref(l).fmt(f),
 		}
 	}
 }
@@ -375,7 +369,14 @@ impl<'a> SolvingContext<'a> {
 		reason: impl ReasonBuilder<Self>,
 		event: Option<(Decision<IntVal>, IntEvent)>,
 	) {
-		let reason = Reason::from_view(reason.build_reason(self));
+		// Build the reason, folding the trivial/invalid markers into `View`
+		// constants so the propagation list carries a plain `Reason` (no
+		// `Result`); these are dropped/rejected when tightened at registration.
+		let reason = match reason.build_reason(self) {
+			Ok(reason) => reason,
+			Err(true) => Reason::Simple(true.into()),
+			Err(false) => Reason::Simple(false.into()),
+		};
 		trace!(
 			target: "solver",
 			lit = i32::from(lit.0),
@@ -437,7 +438,7 @@ impl<'a> SolvingContext<'a> {
 						.subject
 						.map(|s| i32::from(s.0))
 						.unwrap_or_default(),
-					reason = ?ReasonTracePrint(&Ok(conflict.reason.clone())),
+					reason = ?ReasonTracePrint(&conflict.reason),
 					"conflict detected"
 				);
 				debug_assert!(self.state.conflict.is_none());

--- a/crates/huub/src/solver/trail.rs
+++ b/crates/huub/src/solver/trail.rs
@@ -23,6 +23,16 @@ struct BoolStore {
 	restore: Option<bool>,
 }
 
+/// The trail and reason-trail lengths recorded when a decision level was
+/// opened, so both can be truncated back to it on backtrack.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct LevelMark {
+	/// The reason-trail length (number of [`Trail::reason_trail`] literals).
+	reason: usize,
+	/// The trail length (number of trail integers).
+	trail: usize,
+}
+
 /// Storage structure that allows restoring tracked values to an earlier state.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Trail {
@@ -36,14 +46,19 @@ pub(crate) struct Trail {
 	/// This is used when undoing changes from the trail, any events after `pos`
 	/// have been transformed so they can be redone if required.
 	pos: usize,
-	/// The length of the trail when previous decisions were made.
-	prev_len: Vec<usize>,
+	/// The trail lengths when previous decisions were made.
+	prev_len: Vec<LevelMark>,
 
 	/// Stores the current value of trailed integer values.
 	int_value: Vec<[u8; 8]>,
 	/// Stores the current assigned values of Boolean variables, and "redo"
 	/// values when untrailing.
 	sat_store: Vec<BoolStore>,
+
+	/// Reason literals of eager reasons
+	/// ([`EngineReason::Eager`](crate::solver::engine::EngineReason::Eager)),
+	/// stored in propagation order, removable when (permanently) backtracking.
+	reason_trail: Vec<RawLit>,
 }
 
 /// An event that is recorded such that it can be undone.
@@ -83,6 +98,11 @@ impl Trail {
 			self.push_trail(TrailEvent::SatAssignment(var));
 			None
 		}
+	}
+
+	/// Clear the reason arena entirely.
+	pub(crate) fn clear_reason_trail(&mut self) {
+		self.reason_trail.clear();
 	}
 
 	/// Return the current decision level
@@ -151,30 +171,40 @@ impl Trail {
 			return;
 		}
 
-		let len = self.prev_len[level];
+		let mark = self.prev_len[level];
 		self.prev_len.truncate(level);
 		debug_assert!(
-			len <= self.trail.len(),
-			"backtracking to level {level} length {len}, but trail is already at length {}",
+			mark.trail <= self.trail.len(),
+			"backtracking to level {level} length {}, but trail is already at length {}",
+			mark.trail,
 			self.trail.len()
 		);
-		if len <= self.pos {
-			while self.pos > len {
+		if mark.trail <= self.pos {
+			while self.pos > mark.trail {
 				self.undo::<false>();
 			}
 		} else {
-			while self.pos < len {
+			while self.pos < mark.trail {
 				self.redo();
 			}
 		}
-		debug_assert_eq!(self.pos, len);
-		self.trail.truncate(len);
+		debug_assert_eq!(self.pos, mark.trail);
+		self.trail.truncate(mark.trail);
+		self.reason_trail.truncate(mark.reason);
 	}
 
 	/// Notify the Trail of a new decision level to which the trail can be
 	/// restored.
 	pub(crate) fn notify_new_decision_level(&mut self) {
-		self.prev_len.push(self.trail.len());
+		self.prev_len.push(LevelMark {
+			trail: self.trail.len(),
+			reason: self.reason_trail.len(),
+		});
+	}
+
+	/// Append a premise literal to the reason trail.
+	pub(crate) fn push_reason_lit(&mut self, lit: RawLit) {
+		self.reason_trail.push(lit);
 	}
 
 	/// Internal method to push a change to the trail
@@ -186,6 +216,22 @@ impl Trail {
 		}
 		event.write_trail(&mut self.trail[self.pos..]);
 		self.pos = self.trail.len();
+	}
+
+	/// The current number of literals in the reason arena, used as the `begin`
+	/// offset when recording a new eager reason before appending its premises.
+	pub(crate) fn reason_len(&self) -> usize {
+		self.reason_trail.len()
+	}
+
+	/// The premise literals of an eager reason stored at
+	/// `reason_trail[begin..begin + len]`.
+	pub(crate) fn reason_lits(&self, begin: usize, len: usize) -> &[RawLit] {
+		debug_assert!(
+			begin + len <= self.reason_trail.len(),
+			"stale reason range into the arena"
+		);
+		&self.reason_trail[begin..begin + len]
 	}
 
 	/// Internal method to redo the last undone change on the trail
@@ -319,6 +365,7 @@ impl Default for Trail {
 			prev_len: Vec::new(),
 			int_value: vec![0_u64.to_bytes()],
 			sat_store: Vec::new(),
+			reason_trail: Vec::new(),
 		}
 	}
 }

--- a/crates/huub/src/solver/trail.rs
+++ b/crates/huub/src/solver/trail.rs
@@ -58,7 +58,7 @@ pub(crate) struct Trail {
 	/// Reason literals of eager reasons
 	/// ([`EngineReason::Eager`](crate::solver::engine::EngineReason::Eager)),
 	/// stored in propagation order, removable when (permanently) backtracking.
-	reason_trail: Vec<RawLit>,
+	pub(crate) reason_trail: Vec<RawLit>,
 }
 
 /// An event that is recorded such that it can be undone.
@@ -202,11 +202,6 @@ impl Trail {
 		});
 	}
 
-	/// Append a premise literal to the reason trail.
-	pub(crate) fn push_reason_lit(&mut self, lit: RawLit) {
-		self.reason_trail.push(lit);
-	}
-
 	/// Internal method to push a change to the trail
 	fn push_trail(&mut self, event: TrailEvent) {
 		debug_assert_eq!(self.pos, self.trail.len());
@@ -216,22 +211,6 @@ impl Trail {
 		}
 		event.write_trail(&mut self.trail[self.pos..]);
 		self.pos = self.trail.len();
-	}
-
-	/// The current number of literals in the reason arena, used as the `begin`
-	/// offset when recording a new eager reason before appending its premises.
-	pub(crate) fn reason_len(&self) -> usize {
-		self.reason_trail.len()
-	}
-
-	/// The premise literals of an eager reason stored at
-	/// `reason_trail[begin..begin + len]`.
-	pub(crate) fn reason_lits(&self, begin: usize, len: usize) -> &[RawLit] {
-		debug_assert!(
-			begin + len <= self.reason_trail.len(),
-			"stale reason range into the arena"
-		);
-		&self.reason_trail[begin..begin + len]
 	}
 
 	/// Internal method to redo the last undone change on the trail

--- a/crates/huub/src/solver/view/integer.rs
+++ b/crates/huub/src/solver/view/integer.rs
@@ -12,7 +12,6 @@ use crate::{
 		BoolInspectionActions, BoolPropagationActions, IntDecisionActions, IntExplanationActions,
 		IntInspectionActions, IntPropagationActions, PropagationActions, ReasoningContext,
 	},
-	constraints::ReasonBuilder,
 	solver::{
 		Decision, IntLitMeaning, Solver, View,
 		decision::integer::{DirectStorage, OrderStorage},
@@ -286,7 +285,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		match self.0 {
 			IntView::Linear(lin) => lin.fix(ctx, val, reason),
@@ -299,7 +298,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		match self.0 {
 			IntView::Linear(lin) => lin.remove_val(ctx, val, reason),
@@ -312,7 +311,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		match self.0 {
 			IntView::Linear(lin) => lin.tighten_max(ctx, val, reason),
@@ -325,7 +324,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		match self.0 {
 			IntView::Linear(lin) => lin.tighten_min(ctx, val, reason),

--- a/crates/huub/src/views/linear_bool_view.rs
+++ b/crates/huub/src/views/linear_bool_view.rs
@@ -18,9 +18,9 @@ use crate::{
 		BoolAnalyzeActions, BoolInspectionActions, BoolOperations, BoolPropagationActions,
 		BoolSimplificationActions, IntAnalyzeActions, IntDecisionActions, IntExplanationActions,
 		IntInspectionActions, IntPropagationActions, IntSimplificationActions, PropagationActions,
-		ReasoningContext,
+		PropagationContext, ReasoningContext,
 	},
-	constraints::ReasonBuilder,
+	constraints::NO_REASON,
 	helpers::{div_ceil, div_floor},
 	solver::{
 		IntLitMeaning, Polarity,
@@ -327,7 +327,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		let Some(val) = self.try_reverse_val(val) else {
 			return Err(ctx.declare_conflict(reason));
@@ -343,7 +343,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		let Some(val) = self.try_reverse_val(val) else {
 			return Ok(());
@@ -359,7 +359,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		let val = self.reverse_val_floor(val);
 		if val < 0 {
@@ -375,7 +375,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		let val = self.reverse_val_ceil(val);
 		if val > 1 {
@@ -398,7 +398,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		values: &IntSet,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		let lb = values.contains(&self.offset);
 		let ub = values.contains(&(self.offset + self.scale.get()));
@@ -417,7 +417,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		domain: &IntSet,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		let lb = domain.contains(&self.offset);
 		let ub = domain.contains(&(self.offset + self.scale.get()));
@@ -436,7 +436,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		other: impl Into<Self>,
-	) -> Result<(), <Ctx as ReasoningContext>::Conflict> {
+	) -> Result<(), <Ctx as PropagationContext>::Conflict> {
 		let other = other.into();
 		let (self_lb, self_ub) = self.bounds(ctx);
 		let (other_lb, other_ub) = other.bounds(ctx);
@@ -444,22 +444,22 @@ where
 		match (self_lb == other_lb, self_ub == other_ub) {
 			(true, true) => self.var.unify(ctx, other.var),
 			(true, false) => {
-				self.var.fix(ctx, false, [])?;
-				other.var.fix(ctx, false, [])
+				self.var.fix(ctx, false, NO_REASON)?;
+				other.var.fix(ctx, false, NO_REASON)
 			}
 			(false, true) => {
-				self.var.fix(ctx, true, [])?;
-				other.var.fix(ctx, true, [])
+				self.var.fix(ctx, true, NO_REASON)?;
+				other.var.fix(ctx, true, NO_REASON)
 			}
 			(false, false) if self_lb == other_ub => {
-				self.var.fix(ctx, false, [])?;
-				other.var.fix(ctx, true, [])
+				self.var.fix(ctx, false, NO_REASON)?;
+				other.var.fix(ctx, true, NO_REASON)
 			}
 			(false, false) if self_ub == other_lb => {
-				self.var.fix(ctx, true, [])?;
-				other.var.fix(ctx, false, [])
+				self.var.fix(ctx, true, NO_REASON)?;
+				other.var.fix(ctx, false, NO_REASON)
 			}
-			(false, false) => Err(ctx.declare_conflict([])),
+			(false, false) => Err(ctx.declare_conflict(NO_REASON)),
 		}
 	}
 }

--- a/crates/huub/src/views/linear_view.rs
+++ b/crates/huub/src/views/linear_view.rs
@@ -14,9 +14,9 @@ use crate::{
 	IntSet, IntVal,
 	actions::{
 		IntAnalyzeActions, IntDecisionActions, IntExplanationActions, IntInspectionActions,
-		IntPropagationActions, IntSimplificationActions, PropagationActions, ReasoningContext,
+		IntPropagationActions, IntSimplificationActions, PropagationActions, PropagationContext,
+		ReasoningContext,
 	},
-	constraints::ReasonBuilder,
 	helpers::{div_ceil, div_floor},
 	solver::{
 		IntLitMeaning, Polarity,
@@ -337,7 +337,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		let Some(val) = self.try_reverse_val(val) else {
 			return Err(ctx.declare_conflict(reason));
@@ -349,7 +349,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		let Some(val) = self.try_reverse_val(val) else {
 			return Ok(());
@@ -361,7 +361,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		if self.scale.get() >= 0 {
 			self.var
@@ -376,7 +376,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		if self.scale.get() >= 0 {
 			self.var
@@ -398,7 +398,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		values: &IntSet,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		self.var.exclude(ctx, &self.reverse_intset(values), reason)
 	}
@@ -407,7 +407,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		domain: &IntSet,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		self.var
 			.restrict_domain(ctx, &self.reverse_intset(domain), reason)
@@ -417,7 +417,7 @@ where
 		&self,
 		_ctx: &mut Ctx,
 		_other: impl Into<Self>,
-	) -> Result<(), <Ctx as ReasoningContext>::Conflict> {
+	) -> Result<(), <Ctx as PropagationContext>::Conflict> {
 		panic!("unify cannot be defined for any generic LinearView")
 	}
 }

--- a/crates/huub/src/views/offset_view.rs
+++ b/crates/huub/src/views/offset_view.rs
@@ -11,9 +11,8 @@ use crate::{
 	IntSet, IntVal,
 	actions::{
 		IntAnalyzeActions, IntDecisionActions, IntExplanationActions, IntInspectionActions,
-		IntPropagationActions, ReasoningContext,
+		IntPropagationActions, PropagationContext, ReasoningContext,
 	},
-	constraints::ReasonBuilder,
 	solver::{
 		IntLitMeaning, Polarity,
 		solution::{Solution, Valuation},
@@ -208,14 +207,14 @@ where
 
 impl<Ctx, Var> IntPropagationActions<Ctx> for OffsetView<IntVal, Var>
 where
-	Ctx: ReasoningContext + ?Sized,
+	Ctx: PropagationContext + ?Sized,
 	Var: IntPropagationActions<Ctx>,
 {
 	fn fix(
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		self.var.fix(ctx, val - self.offset, reason)
 	}
@@ -224,7 +223,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		self.var.remove_val(ctx, val - self.offset, reason)
 	}
@@ -233,7 +232,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		self.var.tighten_max(ctx, val - self.offset, reason)
 	}
@@ -242,7 +241,7 @@ where
 		&self,
 		ctx: &mut Ctx,
 		val: IntVal,
-		reason: impl ReasonBuilder<Ctx>,
+		reason: impl FnOnce(&mut Ctx, &mut Ctx::ReasonSink<'_>),
 	) -> Result<(), Ctx::Conflict> {
 		self.var.tighten_min(ctx, val - self.offset, reason)
 	}


### PR DESCRIPTION
Reasons are now stored and built so that propagating a literal no longer
allocates a per-reason buffer.

### 1. Reasons live in a backtrack-truncated trail arena
*(`perf: store eager reasons in a backtrack-truncated trail arena`)*

- `reason_map` holds a 16-byte `EngineReason`: `Small` (≤3 premises, stored
  inline), `Eager` (4+ premises, a `begin..begin+len` slice of a reused
  arena on the trail), or `Lazy` (recomputed by the propagator on demand).
- The arena truncates on backtrack alongside the trail, reclaiming reasons
  as soon as their literals are unassigned — a reason is only ever read
  while its literal is assigned — instead of only at the level-0 restart.

### 2. Reasons build in place via `(ctx, sink)` closures
*(`perf!: reason closures allocate directly on the reason trail`)*

- `ReasonBuilder` is now a `(ctx, sink)` closure that pushes its premises
  straight into the engine's storage: small reasons never touch the arena,
  longer ones spill directly into it, and the transient boxes are gone.

Letting the sink build into the engine's own storage required breaking the
reason API, so on the back of that break the conflict/reason model is
reworked to match:

- The conflict type splits: `Conflict` is opaque and deferred-capable
  (engine-internal), and the new `Nogood` is the resolved clause returned
  at every user-facing boundary.
- Deferred reasons are lifetime-scoped: `deferred_reason` returns a
  `DeferredHandle` tied to the context borrow, so a propagator can use one
  in the current step but cannot store and replay it later.
