### PR TITLE
fix: consistency between `Nogood` and `Conflict`

### DIFF
--- a/crates/huub/src/constraints.rs
+++ b/crates/huub/src/constraints.rs
@@ -39,7 +39,6 @@ use crate::{
 	solver::{
 		self,
 		engine::{Engine, EngineReasonSink, State},
-		view::boolean::BoolView,
 	},
 };
 
@@ -74,7 +73,7 @@ pub(crate) type BoxedConstraint = Box<dyn Constraint<Model>>;
 /// by [`Engine`].
 pub(crate) type BoxedPropagator = Box<dyn Propagator<Engine>>;
 
-/// A conflict raised during propagation: the nogood clause the current state
+/// A conflict raised during propagation: the clause the current state
 /// falsifies, possibly still deferred to a propagator.
 ///
 /// This is the propagation-internal conflict type. It appears in the
@@ -162,10 +161,21 @@ where
 {
 }
 
-/// A resolved conflict clause (nogood) reported to the user.
+/// A conjunction of conditions that together make the problem infeasible.
 ///
-/// This is the form a [`Conflict`] takes once it leaves the propagation loop;
-/// unlike [`Conflict`] it never holds a deferred reason.
+/// This is a resolved conflict reported to the user, i.e. the falsifying
+/// assignment `¬x1 ∧ ¬x2 ∧ …` that no solution may satisfy.
+///
+/// # Unconditional infeasibility
+///
+/// A conflict can be unconditional. This means the instance is infeasible
+/// regardless of any search decision (for example a constraint that
+/// constant-folds to `false` while lowering, or a clause that is empty). Such a
+/// conflict has no conditions to provide as the cause.
+///
+/// This is not an absence of information: it is a proof that the instance is
+/// unconditionally infeasible, which is easy to overlook. Always test for it
+/// with [`Nogood::is_unconditional`] rather than inspecting the conditions.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Nogood<Atom>(pub(crate) Box<[Atom]>);
 
@@ -338,17 +348,17 @@ impl Clone for BoxedPropagator {
 	}
 }
 
-impl<Atom> Conflict<Atom> {
-	/// Resolve the conflict into its [`Nogood`] clause.
+impl Conflict<model::View<bool>> {
+	/// Resolve the conflict into its [`Nogood`].
 	///
-	/// A conflict is only ever handed to the user after the propagation loop
-	/// has resolved any deferred reason (the engine in
-	/// [`SolvingContext`](crate::solver::solving_context::SolvingContext), the
-	/// model in `Model::propagate_single`), so it must be a ready clause by
-	/// this point.
-	pub(crate) fn into_nogood(self) -> Nogood<Atom> {
+	/// A ready conflict stores the clause, so negating every literal recovers
+	/// the falsifying conjunction that a [`Nogood`] reports. A conflict is
+	/// only ever handed to the user after the propagation loop has resolved
+	/// any deferred reason (the model in `Model::propagate_single`), so it
+	/// must be ready by this point.
+	pub(crate) fn into_model_nogood(self) -> Nogood<model::View<bool>> {
 		match self.0 {
-			ConflictInner::Clause(lits) => Nogood(lits),
+			ConflictInner::Clause(lits) => Nogood::from_model_views(lits.iter().map(|lit| !*lit)),
 			ConflictInner::Deferred { .. } => {
 				unreachable!("a deferred conflict must be resolved before reaching the user")
 			}
@@ -357,12 +367,12 @@ impl<Atom> Conflict<Atom> {
 }
 
 impl Conflict<solver::Decision<bool>> {
-	/// Write the conflict's nogood clause into `clause`.
+	/// Write the conflict's clause into `clause`.
 	///
-	/// A ready clause already holds the nogood in clausal form, so its literals
-	/// are copied straight in; a deferred conflict pushes its `subject` as the
-	/// head and asks the propagator to compute the reason, which it negates
-	/// through the [`EngineReasonSink`] sink.
+	/// A ready conflict already stores the clause, so its literals are copied
+	/// straight in; a deferred conflict pushes its `subject` as the head and
+	/// asks the propagator to compute the reason, which it negates through the
+	/// [`EngineReasonSink`] sink.
 	pub(crate) fn explain(
 		&self,
 		props: &mut [BoxedPropagator],
@@ -382,6 +392,25 @@ impl Conflict<solver::Decision<bool>> {
 				let mut explanation = EngineReasonSink(clause);
 				let head = subject.map(|s| s.into()).unwrap_or(true.into());
 				props[propagator as usize].explain(actions, head, data, &mut explanation);
+			}
+		}
+	}
+
+	/// Resolve the conflict into its [`Nogood`].
+	///
+	/// A ready conflict stores the clause, so negating every literal recovers
+	/// the falsifying conjunction that a [`Nogood`] reports. A conflict is
+	/// only ever handed to the user after the propagation loop has resolved
+	/// any deferred reason (the engine in
+	/// [`SolvingContext`](crate::solver::solving_context::SolvingContext)), so
+	/// it must be ready by this point.
+	pub(crate) fn into_solver_nogood(self) -> Nogood<solver::Decision<bool>> {
+		match self.0 {
+			ConflictInner::Clause(lits) => {
+				Nogood::from_solver_views(lits.iter().map(|lit| (!*lit).into()))
+			}
+			ConflictInner::Deferred { .. } => {
+				unreachable!("a deferred conflict must be resolved before reaching the user")
 			}
 		}
 	}
@@ -407,26 +436,88 @@ where
 {
 }
 
+#[expect(
+	clippy::len_without_is_empty,
+	reason = "a conflict with no conditions is unconditionally infeasible; `is_unconditional` is the named check for it, which a bare `is_empty` would obscure"
+)]
 impl<Atom> Nogood<Atom> {
-	/// Returns an non-consuming iterator over the atom in the nogood clause.
+	/// Returns `true` if the conflict is *unconditional*: the instance is
+	/// infeasible regardless of any search decision.
+	///
+	/// A nogood is the conjunction of conditions that make the problem
+	/// infeasible; when it holds no conditions that conjunction is trivially
+	/// satisfied, so the conflict cannot be pinned on any literal and no
+	/// assignment can avoid it. This method names that case so it is not
+	/// overlooked: it is a proof of unconditional infeasibility, not an absence
+	/// of information.
+	///
+	/// Such a conflict arises when it carries no reason (e.g. a constraint that
+	/// constant-folds to `false` while lowering, or an empty clause added to
+	/// the solver).
+	pub fn is_unconditional(&self) -> bool {
+		self.0.is_empty()
+	}
+
+	/// Returns a non-consuming iterator over the conditions in the nogood.
+	///
+	/// The returned iterator is an [`ExactSizeIterator`], as is the one
+	/// produced by [`IntoIterator::into_iter`].
 	pub fn iter(&self) -> slice::Iter<'_, Atom> {
 		self.0.iter()
+	}
+
+	/// Returns the number of conditions in the nogood.
+	///
+	/// A length of zero denotes an unconditionally infeasible instance; prefer
+	/// the named [`Nogood::is_unconditional`] to check for it.
+	pub fn len(&self) -> usize {
+		self.0.len()
+	}
+}
+
+impl Nogood<model::View<bool>> {
+	/// Build the reported [`Nogood`] from the model Boolean views that make up
+	/// the falsifying conjunction, resolving any constant views.
+	///
+	/// This is the model counterpart of [`Nogood::from_solver_views`] and
+	/// applies the identical constant convention, so a [`Nogood`] behaves the
+	/// same whether it comes from the model or the solver.
+	pub(crate) fn from_model_views(iter: impl IntoIterator<Item = model::View<bool>>) -> Self {
+		use crate::model::view::boolean::BoolView;
+
+		let mut conditions = Vec::new();
+		for atom in iter {
+			match atom.0 {
+				BoolView::Const(true) => {}
+				BoolView::Const(false) => return Self(Box::default()),
+				_ => conditions.push(atom),
+			}
+		}
+		Self(conditions.into_boxed_slice())
 	}
 }
 
 impl Nogood<solver::Decision<bool>> {
-	/// Build the reported [`Nogood`] from the Boolean views that make up a
-	/// conflict clause, resolving any constant views.
-	pub(crate) fn from_view_iter(iter: impl IntoIterator<Item = solver::View<bool>>) -> Self {
-		Self(
-			iter.into_iter()
-				.filter_map(|atom| match atom.0 {
-					BoolView::Lit(lit) => Some(lit),
-					BoolView::Const(true) => unreachable!("invalid nogood: contains `true`"),
-					BoolView::Const(false) => None,
-				})
-				.collect(),
-		)
+	/// Build the reported [`Nogood`] from the solver Boolean views that make up
+	/// the falsifying conjunction, resolving any constant views.
+	///
+	/// A `true` condition holds trivially and is dropped. A `false` condition
+	/// can never actually hold, so its presence means the conflict does not
+	/// depend on the search state at all: the whole nogood collapses to the
+	/// unconditional form (see [`Nogood::is_unconditional`]). A conflict that
+	/// resolves to no conditions is unconditional for the same reason.
+	pub(crate) fn from_solver_views(iter: impl IntoIterator<Item = solver::View<bool>>) -> Self {
+		use crate::solver::view::boolean::BoolView;
+
+		let mut conditions = Vec::new();
+		for atom in iter {
+			match atom.0 {
+				BoolView::Lit(lit) => conditions.push(lit),
+				BoolView::Const(true) => {}
+				BoolView::Const(false) => return Self(Box::default()),
+			}
+		}
+		Self(conditions.into_boxed_slice())
 	}
 }
 
@@ -445,5 +536,54 @@ impl<Atom> IntoIterator for Nogood<Atom> {
 impl<Atom: Debug> fmt::Display for Nogood<Atom> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "conflict detected: nogood {:?}", self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{
+		constraints::{Conflict, ConflictInner, Nogood},
+		solver::{Solver, View},
+	};
+
+	/// A reported [`Nogood`] is the conjunction of falsifying conditions, so a
+	/// trivially-true condition holds and drops out while the literals remain.
+	#[test]
+	fn test_from_solver_views_drops_true() {
+		let mut slv: Solver = Solver::default();
+		let x = slv.new_bool_decision();
+		let y = slv.new_bool_decision();
+		let nogood = Nogood::from_solver_views([View::from(x), View::from(true), View::from(y)]);
+		assert!(!nogood.is_unconditional());
+		assert_eq!(nogood.iter().copied().collect::<Vec<_>>(), vec![x, y]);
+	}
+
+	/// A `false` condition can never hold, so it proves the conflict is
+	/// unconditional: the whole nogood collapses to the unconditional form.
+	#[test]
+	fn test_from_solver_views_false_is_unconditional() {
+		let mut slv: Solver = Solver::default();
+		let x = slv.new_bool_decision();
+		let y = slv.new_bool_decision();
+		let nogood = Nogood::from_solver_views([View::from(x), View::from(false), View::from(y)]);
+		assert!(nogood.is_unconditional());
+		assert_eq!(nogood.len(), 0);
+	}
+
+	/// A [`Conflict`] stores the clause, and the [`Nogood`] it resolves into is
+	/// that clause with every literal negated. Pins the two negations together
+	/// so they cannot drift apart.
+	#[test]
+	fn test_solver_nogood_negates_stored_clause() {
+		let mut slv: Solver = Solver::default();
+		let x = slv.new_bool_decision();
+		let y = slv.new_bool_decision();
+		// The conflict for reason `x` with failing head `y`: clause `¬x ∨ y`.
+		let clause = [!x, y];
+		let nogood = Conflict(ConflictInner::Clause(Box::from(clause))).into_solver_nogood();
+		assert_eq!(
+			nogood.iter().copied().collect::<Vec<_>>(),
+			clause.iter().map(|lit| !*lit).collect::<Vec<_>>()
+		);
 	}
 }

--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -8,7 +8,6 @@ use std::{
 	fmt::{self, Debug, Display},
 	marker::PhantomData,
 	num::NonZeroI32,
-	ops::Not,
 };
 
 use bon::Builder;
@@ -859,7 +858,7 @@ impl<'a> LoweringContext<'a> {
 	) -> <Self as PropagationContext>::Conflict {
 		let mut sink = Vec::new();
 		reason(self, &mut sink);
-		Nogood::from_view_iter(sink.into_iter().map(Not::not))
+		Nogood::from_solver_views(sink)
 	}
 
 	/// Read a trailed value from the [`Model`] trail.
@@ -980,13 +979,13 @@ impl Error for LoweringError {}
 
 impl From<<Engine as ReasoningEngine>::Conflict> for LoweringError {
 	fn from(value: <Engine as ReasoningEngine>::Conflict) -> Self {
-		Self::Lowering(value.into_nogood())
+		Self::Lowering(value.into_solver_nogood())
 	}
 }
 
 impl From<<Model as ReasoningEngine>::Conflict> for LoweringError {
 	fn from(value: <Model as ReasoningEngine>::Conflict) -> Self {
-		Self::Simplification(value.into_nogood())
+		Self::Simplification(value.into_model_nogood())
 	}
 }
 

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -556,16 +556,19 @@ impl Model {
 		})) = status
 		{
 			debug_assert_eq!(ConRef::new(propagator as usize), con);
-			let mut conj = Vec::new();
-			con_obj.explain(self, subject.unwrap_or(false.into()), data, &mut conj);
-			// Fold the subject in as the clause head.
-			if let Some(subject) = subject {
-				conj.push(subject);
-			}
-			status = Err(Conflict(ConflictInner::Clause(conj.into_boxed_slice())));
+			status = Err(
+				SimplificationContext(&mut *self).make_conflict(subject, |ctx, sink| {
+					con_obj.explain(
+						ctx.0,
+						subject.unwrap_or(false.into()),
+						data,
+						&mut sink.conditions,
+					);
+				}),
+			);
 		};
 
-		match status.map_err(Conflict::into_nogood)? {
+		match status.map_err(Conflict::into_model_nogood)? {
 			SimplificationStatus::Subsumed => {
 				// Constraint is known to be satisfied, no need to place back.
 			}
@@ -617,7 +620,7 @@ impl PropagationActions for Model {
 	) -> Nogood<View<bool>> {
 		let mut sink = Vec::new();
 		reason(&mut *self, &mut sink);
-		Nogood(sink.into())
+		Nogood::from_model_views(sink)
 	}
 }
 
@@ -663,25 +666,31 @@ impl TrailingActions for Model {
 }
 
 impl SimplificationContext<'_> {
-	/// Create a conflict from the failure to set `subject` (folded in as the
-	/// clause head), required by `reason`.
-	pub(crate) fn create_conflict(
+	/// Build a [`Conflict`] from a reason closure, folding the failing head (if
+	/// any) in as the clause head.
+	pub(crate) fn make_conflict(
 		&mut self,
-		subject: View<bool>,
+		subject: Option<View<bool>>,
 		reason: impl FnOnce(&mut Self, &mut SimplificationReasonSink),
 	) -> Conflict<View<bool>> {
 		let mut sink = SimplificationReasonSink::default();
 		reason(&mut *self, &mut sink);
 		match sink.deferred {
 			Some(data) => Conflict(ConflictInner::Deferred {
-				subject: Some(subject),
+				subject,
 				propagator: self.0.cur_prop.unwrap().index() as u32,
 				data,
 			}),
 			None => {
-				// Fold the subject in as the clause head.
-				sink.conditions.push(subject);
-				Conflict(ConflictInner::Clause(sink.conditions.into_boxed_slice()))
+				let mut clause: Vec<View<bool>> = sink
+					.conditions
+					.into_iter()
+					.map(|condition| !condition)
+					.collect();
+				if let Some(subject) = subject {
+					clause.push(subject);
+				}
+				Conflict(ConflictInner::Clause(clause.into_boxed_slice()))
 			}
 		}
 	}
@@ -704,16 +713,7 @@ impl PropagationActions for SimplificationContext<'_> {
 		&mut self,
 		reason: impl FnOnce(&mut Self, &mut Self::ReasonSink<'_>),
 	) -> Conflict<View<bool>> {
-		let mut sink = SimplificationReasonSink::default();
-		reason(&mut *self, &mut sink);
-		match sink.deferred {
-			Some(data) => Conflict(ConflictInner::Deferred {
-				subject: None,
-				propagator: self.0.cur_prop.unwrap().index() as u32,
-				data,
-			}),
-			None => Conflict(ConflictInner::Clause(sink.conditions.into_boxed_slice())),
-		}
+		self.make_conflict(None, reason)
 	}
 }
 
@@ -776,14 +776,14 @@ mod tests {
 		actions::{
 			BoolInitActions, BoolInspectionActions, ConstructionActions, IntEvent, IntInitActions,
 			IntInspectionActions, IntPropCond, IntPropagationActions, IntSimplificationActions,
-			ReasoningEngine, Trailed, TrailingActions,
+			PropagationActions, ReasoningEngine, Trailed, TrailingActions,
 		},
 		constraints::{
 			BoolModelActions, Constraint, IntModelActions, NO_REASON, Propagator,
 			SimplificationStatus,
 		},
 		lower::{LoweringContext, LoweringError},
-		model::{Model, View, deserialize::AnyView},
+		model::{Model, View, deserialize::AnyView, view::boolean::BoolView},
 		solver::Solver,
 	};
 
@@ -793,6 +793,39 @@ mod tests {
 		i: View<IntVal>,
 		bool_check: Trailed<IntVal>,
 		int_check: Trailed<IntVal>,
+	}
+
+	/// A reported conflict is the conjunction of conditions that hold, so the
+	/// failing head is negated into it: fixing an integer decision outside its
+	/// domain yields the condition `x ≠ v` that holds, not the impossible
+	/// `x = v`.
+	#[test]
+	fn test_conflict_negates_subject() {
+		let mut prb = Model::default();
+		let x = prb.new_int_decision(1..=2);
+		let nogood =
+			<View<IntVal> as IntPropagationActions<Model>>::fix(&x, &mut prb, 5, NO_REASON)
+				.unwrap_err();
+		let atoms: Vec<_> = nogood.iter().copied().collect();
+		assert_eq!(atoms.len(), 1);
+		assert!(matches!(atoms[0].0, BoolView::IntNotEq(_, 5)));
+	}
+
+	/// A model [`Nogood`](crate::constraints::Nogood) obeys the same constant
+	/// convention as a solver one: a trivially-true condition is dropped, and a
+	/// `false` condition collapses the nogood to the unconditional form.
+	#[test]
+	fn test_conflict_resolves_constants() {
+		let mut prb = Model::default();
+		let x = prb.new_bool_decision();
+
+		let dropped_true = prb.declare_conflict(|_, reason| reason.extend([x, true.into()]));
+		assert!(!dropped_true.is_unconditional());
+		assert_eq!(dropped_true.iter().copied().collect::<Vec<_>>(), vec![x]);
+
+		let collapsed = prb.declare_conflict(|_, reason| reason.extend([x, false.into()]));
+		assert!(collapsed.is_unconditional());
+		assert_eq!(collapsed.len(), 0);
 	}
 
 	#[test]

--- a/crates/huub/src/model/decision/boolean.rs
+++ b/crates/huub/src/model/decision/boolean.rs
@@ -71,7 +71,7 @@ impl BoolPropagationActions<Model> for Decision<bool> {
 			val,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 }
 
@@ -93,7 +93,7 @@ impl BoolSimplificationActions<Model> for Decision<bool> {
 		other: impl Into<View<bool>>,
 	) -> Result<(), Nogood<View<bool>>> {
 		self.unify(&mut SimplificationContext(ctx), other)
-			.map_err(Conflict::into_nogood)
+			.map_err(Conflict::into_model_nogood)
 	}
 }
 

--- a/crates/huub/src/model/decision/integer.rs
+++ b/crates/huub/src/model/decision/integer.rs
@@ -198,7 +198,7 @@ impl IntPropagationActions<Model> for Decision<IntVal> {
 			val,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn remove_val(
@@ -212,7 +212,7 @@ impl IntPropagationActions<Model> for Decision<IntVal> {
 			val,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn tighten_max(
@@ -226,7 +226,7 @@ impl IntPropagationActions<Model> for Decision<IntVal> {
 			val,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn tighten_min(
@@ -240,7 +240,7 @@ impl IntPropagationActions<Model> for Decision<IntVal> {
 			val,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 }
 
@@ -294,7 +294,7 @@ impl IntSimplificationActions<Model> for Decision<IntVal> {
 			values,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn restrict_domain(
@@ -308,12 +308,12 @@ impl IntSimplificationActions<Model> for Decision<IntVal> {
 			domain,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Nogood<View<bool>>> {
 		self.unify(&mut SimplificationContext(ctx), other)
-			.map_err(Conflict::into_nogood)
+			.map_err(Conflict::into_model_nogood)
 	}
 }
 
@@ -474,8 +474,8 @@ impl Resolved<Decision<IntVal>> {
 		};
 		let diff: IntSet = dom.diff(values);
 		if diff.is_empty() {
-			return Err(ctx.create_conflict(
-				View(BoolView::IntNotEq(self.0, *values.min().unwrap())),
+			return Err(ctx.make_conflict(
+				Some(View(BoolView::IntNotEq(self.0, *values.min().unwrap()))),
 				reason,
 			));
 		}
@@ -521,7 +521,7 @@ impl Resolved<Decision<IntVal>> {
 			model.int_events.insert(self.0.0, IntEvent::Fixed);
 			Ok(())
 		} else {
-			Err(ctx.create_conflict(View(BoolView::IntEq(self.0, val)), reason))
+			Err(ctx.make_conflict(Some(View(BoolView::IntEq(self.0, val))), reason))
 		}
 	}
 
@@ -550,7 +550,7 @@ impl Resolved<Decision<IntVal>> {
 		let intersect: IntSet = dom.intersect(domain);
 		if intersect.is_empty() {
 			let subject = View(BoolView::IntNotEq(self.0, *dom.min().unwrap()));
-			return Err(ctx.create_conflict(subject, reason));
+			return Err(ctx.make_conflict(Some(subject), reason));
 		} else if *dom == intersect {
 			return Ok(());
 		}
@@ -591,7 +591,9 @@ impl Resolved<Decision<IntVal>> {
 			if val >= *dom.max().unwrap() {
 				return Ok(());
 			} else if val < *dom.min().unwrap() {
-				return Err(ctx.create_conflict(View(BoolView::IntLess(self.0, val + 1)), reason));
+				return Err(
+					ctx.make_conflict(Some(View(BoolView::IntLess(self.0, val + 1))), reason)
+				);
 			}
 		}
 		let model = &mut *ctx.0;
@@ -629,7 +631,9 @@ impl Resolved<Decision<IntVal>> {
 			if val <= *dom.min().unwrap() {
 				return Ok(());
 			} else if val > *dom.max().unwrap() {
-				return Err(ctx.create_conflict(View(BoolView::IntGreaterEq(self.0, val)), reason));
+				return Err(
+					ctx.make_conflict(Some(View(BoolView::IntGreaterEq(self.0, val))), reason)
+				);
 			}
 		}
 		let model = &mut *ctx.0;

--- a/crates/huub/src/model/view/boolean.rs
+++ b/crates/huub/src/model/view/boolean.rs
@@ -252,7 +252,7 @@ impl BoolPropagationActions<Model> for View<bool> {
 			val,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn require(
@@ -261,7 +261,7 @@ impl BoolPropagationActions<Model> for View<bool> {
 		reason: impl FnOnce(&mut Model, &mut Vec<View<bool>>),
 	) -> Result<(), Nogood<View<bool>>> {
 		self.require(&mut SimplificationContext(ctx), Model::adapt_reason(reason))
-			.map_err(Conflict::into_nogood)
+			.map_err(Conflict::into_model_nogood)
 	}
 }
 
@@ -287,7 +287,7 @@ impl<'a> BoolPropagationActions<SimplificationContext<'a>> for View<bool> {
 impl BoolSimplificationActions<Model> for View<bool> {
 	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Nogood<View<bool>>> {
 		self.unify(&mut SimplificationContext(ctx), other)
-			.map_err(Conflict::into_nogood)
+			.map_err(Conflict::into_model_nogood)
 	}
 }
 

--- a/crates/huub/src/model/view/integer.rs
+++ b/crates/huub/src/model/view/integer.rs
@@ -859,7 +859,7 @@ impl IntPropagationActions<Model> for View<IntVal> {
 			val,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn remove_val(
@@ -873,7 +873,7 @@ impl IntPropagationActions<Model> for View<IntVal> {
 			val,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn tighten_max(
@@ -887,7 +887,7 @@ impl IntPropagationActions<Model> for View<IntVal> {
 			ub,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn tighten_min(
@@ -901,7 +901,7 @@ impl IntPropagationActions<Model> for View<IntVal> {
 			val,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 }
 
@@ -955,7 +955,7 @@ impl IntSimplificationActions<Model> for View<IntVal> {
 			values,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn restrict_domain(
@@ -969,12 +969,12 @@ impl IntSimplificationActions<Model> for View<IntVal> {
 			values,
 			Model::adapt_reason(reason),
 		)
-		.map_err(Conflict::into_nogood)
+		.map_err(Conflict::into_model_nogood)
 	}
 
 	fn unify(&self, ctx: &mut Model, other: impl Into<Self>) -> Result<(), Nogood<View<bool>>> {
 		self.unify(&mut SimplificationContext(ctx), other)
-			.map_err(Conflict::into_nogood)
+			.map_err(Conflict::into_model_nogood)
 	}
 }
 

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -897,6 +897,10 @@ where
 impl<Sat: ExternalPropagation + ClauseDatabase> Solver<Sat> {
 	/// Add a clause to the solver, returning the resolved conflict [`Nogood`]
 	/// if the clause makes the problem unsatisfiable.
+	///
+	/// A clause that is empty (or reduces to one) makes the problem
+	/// unconditionally infeasible, reported as an unconditional [`Nogood`] (see
+	/// [`Nogood::is_unconditional`]).
 	pub fn add_clause<Iter>(&mut self, clause: Iter) -> Result<(), Nogood<Decision<bool>>>
 	where
 		Iter: IntoIterator,
@@ -905,7 +909,7 @@ impl<Sat: ExternalPropagation + ClauseDatabase> Solver<Sat> {
 		let clause = clause.into_iter().map(Into::into).collect_vec();
 		match ClauseDatabaseTools::add_clause(&mut self.sat, clause.iter().cloned()) {
 			Ok(()) => Ok(()),
-			Err(Unsatisfiable) => Err(Nogood::from_view_iter(clause)),
+			Err(Unsatisfiable) => Err(Nogood::from_solver_views(clause.into_iter().map(Not::not))),
 		}
 	}
 }
@@ -1519,7 +1523,7 @@ impl<Sat: ExternalPropagation> PropagationActions for Solver<Sat> {
 	) -> Self::Conflict {
 		let mut sink = Vec::new();
 		reason(self, &mut sink);
-		Nogood::from_view_iter(sink.into_iter().map(Not::not))
+		Nogood::from_solver_views(sink)
 	}
 }
 
@@ -1587,5 +1591,22 @@ impl AddAssign for SolverStatistics {
 		self.user_search_directives += other.user_search_directives;
 		self.eager_literals = self.eager_literals.max(other.eager_literals);
 		self.lazy_literals = self.lazy_literals.max(other.lazy_literals);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::solver::{Solver, view::View};
+
+	/// The empty clause is unconditionally unsatisfiable, reported as an
+	/// unconditional nogood.
+	#[test]
+	fn test_add_clause_empty_is_unconditional() {
+		let mut slv: Solver = Solver::default();
+		let nogood = slv
+			.add_clause(std::iter::empty::<View<bool>>())
+			.unwrap_err();
+		assert!(nogood.is_unconditional());
+		assert_eq!(nogood.len(), 0);
 	}
 }

--- a/crates/huub/src/solver/solving_context.rs
+++ b/crates/huub/src/solver/solving_context.rs
@@ -279,7 +279,7 @@ impl<'a> SolvingContext<'a> {
 				data,
 			}),
 			None => {
-				// `clause` holds the reason in clausal form (already negated); just add
+				// `clause` holds the reason in (partial) clausal form; just add
 				// the subject.
 				let mut lits: Vec<Decision<bool>> = clause.into_iter().map(Decision).collect();
 				match subject {


### PR DESCRIPTION
Ensure that `Nogood` is reported as a conjunction that implies the failure, and that the (internal) `Conflict` is represented as a clause, independent of whether it is Model or Solver level