### PR TITLE
feat!: allow propagators to update their initialization after posting

### DIFF
--- a/crates/huub-cli/src/trace.rs
+++ b/crates/huub-cli/src/trace.rs
@@ -556,7 +556,7 @@ impl ReverseMap {
 				};
 				// `dom` is a flat list of inclusive range bounds; the domain values
 				// in ascending order are the concatenation of those ranges.
-				let values = || dom.chunks_exact(2).flat_map(|c| c[0]..=c[1]);
+				let values = || dom.as_chunks::<2>().0.iter().flat_map(|c| c[0]..=c[1]);
 				// The order literal at `order + k` means `< values[k + 1]`, so one is
 				// created for every domain value except the first.
 				if let Some(order) = event.order.filter(|&o| o != 0) {

--- a/crates/huub/src/actions.rs
+++ b/crates/huub/src/actions.rs
@@ -6,7 +6,7 @@ mod boolean;
 mod initialization;
 mod integer;
 
-use std::{marker::PhantomData, ops::Not};
+use std::{fmt::Debug, marker::PhantomData, ops::Not};
 
 pub use crate::actions::{
 	analyze::{BoolAnalyzeActions, IntAnalyzeActions},
@@ -56,6 +56,9 @@ pub trait DeferReasonActions<Atom>: ReasonActions<Atom> {
 /// Actions that can be performed when posting propagators to the
 /// [`Solver`](crate::solver::Solver).
 pub trait PostingActions: ConstructionActions + PropagationContext {
+	/// Type used to identify a propagator that has been added.
+	type PropagatorId: Copy + Debug + Eq;
+
 	/// Add a new clause to be enforced by the solver.
 	fn add_clause(
 		&mut self,
@@ -63,7 +66,19 @@ pub trait PostingActions: ConstructionActions + PropagationContext {
 	) -> Result<(), Self::Conflict>;
 
 	/// Add a new propagator to be initialized and propagated by the solver.
-	fn add_propagator(&mut self, propagator: BoxedPropagator);
+	///
+	/// The returned identifier can be used to update the initialization of the
+	/// propagator using [`Self::update_initialization`].
+	fn add_propagator(&mut self, propagator: BoxedPropagator) -> Self::PropagatorId;
+
+	/// Ask the propagator identified by `prop` to update its initialization,
+	/// calling
+	/// [`Propagator::update_initialization`](crate::constraints::Propagator::update_initialization).
+	///
+	/// This must be called by the code that gives a propagator that has already
+	/// been posted additional information about the decision variables it
+	/// constrains.
+	fn update_initialization(&mut self, prop: Self::PropagatorId);
 }
 
 /// General actions that can be performed in
@@ -159,6 +174,8 @@ pub trait ReasoningEngine {
 /// Actions that can be performed to simplify a [`Model`](crate::model::Model)
 /// considering a given constraint.
 pub trait SimplificationActions {
+	/// Type used to identify a constraint that has been posted.
+	type ConstraintId: Copy + Debug + Eq;
 	/// The type of the reasoning engine that is used when adding new
 	/// constraints.
 	type Target: ReasoningEngine;
@@ -171,7 +188,12 @@ pub trait SimplificationActions {
 	/// constraints, and then returns
 	/// [`SimplificationStatus::Subsumed`](crate::constraints::SimplificationStatus::Subsumed) to
 	/// indicate that the current constraint can be removed.
-	fn post_constraint<C: Constraint<Self::Target>>(&mut self, constraint: C);
+	///
+	/// The returned identifier can be used to update the initialization of the
+	/// constraint using
+	/// [`Model::update_initialization`](crate::model::Model::update_initialization).
+	fn post_constraint<C: Constraint<Self::Target>>(&mut self, constraint: C)
+	-> Self::ConstraintId;
 }
 
 /// A typed handle to a value tracked by the trail.

--- a/crates/huub/src/actions/initialization.rs
+++ b/crates/huub/src/actions/initialization.rs
@@ -27,6 +27,16 @@ pub trait BoolInitActions<Context>: BoolInspectionActions<Context> {
 	/// on the propagator.
 	fn advise_when_fixed(&self, ctx: &mut Context, data: u64);
 
+	/// Remove the advisor that [`Self::advise_when_fixed`] registered with the
+	/// given data, if it is still registered.
+	///
+	/// Note that the storage reserved for the advisor is not reclaimed.
+	fn cancel_advise_when_fixed(&self, ctx: &mut Context, data: u64);
+
+	/// Remove the subscription that [`Self::enqueue_when_fixed`] registered, if
+	/// it is still registered.
+	fn cancel_enqueue_when_fixed(&self, ctx: &mut Context);
+
 	/// Enqueue the propagator when `self` is assigned.
 	fn enqueue_when_fixed(&self, ctx: &mut Context);
 }
@@ -82,6 +92,21 @@ where
 	/// [`Propagator::advise_of_int_change`](crate::constraints::Propagator::advise_of_int_change)
 	/// on the propagator.
 	fn advise_when(&self, ctx: &mut Context, condition: IntPropCond, data: u64);
+
+	/// Remove the advisor that [`Self::advise_when`] registered for the given
+	/// propagation condition and data, if it is still registered.
+	///
+	/// The propagation condition must be the one with which the advisor was
+	/// registered, since an advisor is only found under its own condition.
+	/// Note that the storage reserved for the advisor is not reclaimed.
+	fn cancel_advise_when(&self, ctx: &mut Context, condition: IntPropCond, data: u64);
+
+	/// Remove the subscription that [`Self::enqueue_when`] registered for the
+	/// given propagation condition, if it is still registered.
+	///
+	/// The propagation condition must be the one with which the propagator
+	/// subscribed, since a subscription is only found under its own condition.
+	fn cancel_enqueue_when(&self, ctx: &mut Context, condition: IntPropCond);
 
 	/// Enqueue the propagator when `self` is changed according to the given
 	/// propagation condition.

--- a/crates/huub/src/constraints.rs
+++ b/crates/huub/src/constraints.rs
@@ -191,7 +191,7 @@ pub struct Nogood<Atom>(pub(crate) Box<[Atom]>);
 /// If the explanation is needed, then the propagation engine will revert the
 /// state of the solver and call [`Propagator::explain`] to receive the
 /// explanation.
-pub trait Propagator<E: ReasoningEngine + ?Sized>: Debug + DynClone + 'static {
+pub trait Propagator<E: ReasoningEngine + ?Sized>: Any + Debug + DynClone {
 	/// Advises the propagator that the solver is backtracking.
 	fn advise_of_backtrack(&mut self, context: &mut E::NotificationContext<'_>) {
 		let _ = context;
@@ -262,6 +262,31 @@ pub trait Propagator<E: ReasoningEngine + ?Sized>: Debug + DynClone + 'static {
 	/// The propagate method is called during the search process to allow the
 	/// propagator to enforce its constraint.
 	fn propagate(&mut self, context: &mut E::PropagationContext<'_>) -> Result<(), E::Conflict>;
+
+	/// Update what [`Propagator::initialize`] declared, after the propagator
+	/// has acquired additional information about the problem.
+	///
+	/// The propagator receives the same context as during initialization, so it
+	/// can subscribe to the decision variables it has acquired, cancel the
+	/// subscriptions it no longer needs, and change the priority at which it is
+	/// enqueued.
+	///
+	/// This method applies the *difference* with what the propagator has
+	/// already declared; it does not start from a clean slate. In particular,
+	/// the propagator must only subscribe to the decision variables that it is
+	/// not already subscribed to, since subscribing twice advises it twice. A
+	/// propagator that wants a single implementation for its initial and its
+	/// later declarations can call this method from
+	/// [`Propagator::initialize`].
+	///
+	/// This method is never called by the reasoning engine itself. The code
+	/// that gives the propagator additional information is responsible for
+	/// calling
+	/// [`PostingActions::update_initialization`](crate::actions::PostingActions::update_initialization)
+	/// or [`Model::update_initialization`] afterwards.
+	fn update_initialization(&mut self, context: &mut E::InitializationContext<'_>) {
+		let _ = context;
+	}
 }
 
 /// Status returned by the [`Constraint::simplify`] method,

--- a/crates/huub/src/constraints/circuit.rs
+++ b/crates/huub/src/constraints/circuit.rs
@@ -377,10 +377,10 @@ mod tests {
 	fn test_circuit_sparse_both() {
 		let mut prb = Model::default();
 		let vars = [
-			IntSet::from_iter([2..=3]),
+			IntSet::from(2..=3),
 			IntSet::from_iter([1..=1, 3..=4]),
 			IntSet::from_iter([1..=1, 4..=4]),
-			IntSet::from_iter([1..=3]),
+			IntSet::from(1..=3),
 		]
 		.map(|dom| prb.new_int_decision(dom));
 		prb.circuit(vars.iter().copied())
@@ -407,10 +407,10 @@ mod tests {
 	fn test_circuit_sparse_no_cycle() {
 		let mut prb = Model::default();
 		let vars = [
-			IntSet::from_iter([2..=3]),
+			IntSet::from(2..=3),
 			IntSet::from_iter([1..=1, 3..=4]),
 			IntSet::from_iter([1..=1, 4..=4]),
-			IntSet::from_iter([1..=3]),
+			IntSet::from(1..=3),
 		]
 		.map(|dom| prb.new_int_decision(dom));
 		prb.circuit(vars.iter().copied())
@@ -437,10 +437,10 @@ mod tests {
 	fn test_circuit_sparse_scc() {
 		let mut prb = Model::default();
 		let vars = [
-			IntSet::from_iter([2..=3]),
+			IntSet::from(2..=3),
 			IntSet::from_iter([1..=1, 3..=4]),
 			IntSet::from_iter([1..=1, 4..=4]),
-			IntSet::from_iter([1..=3]),
+			IntSet::from(1..=3),
 		]
 		.map(|dom| prb.new_int_decision(dom));
 		prb.circuit(vars.iter().copied())
@@ -586,10 +586,10 @@ mod tests {
 	fn test_subcircuit_sparse_both() {
 		let mut prb = Model::default();
 		let vars = [
-			IntSet::from_iter([1..=3]),
+			IntSet::from(1..=3),
 			IntSet::from_iter([1..=2, 4..=4]),
 			IntSet::from_iter([1..=1, 3..=4]),
-			IntSet::from_iter([2..=4]),
+			IntSet::from(2..=4),
 		]
 		.map(|dom| prb.new_int_decision(dom));
 		prb.circuit(vars.iter().copied())
@@ -620,10 +620,10 @@ mod tests {
 	fn test_subcircuit_sparse_no_cycle() {
 		let mut prb = Model::default();
 		let vars = [
-			IntSet::from_iter([1..=3]),
+			IntSet::from(1..=3),
 			IntSet::from_iter([1..=2, 4..=4]),
 			IntSet::from_iter([1..=1, 3..=4]),
-			IntSet::from_iter([2..=4]),
+			IntSet::from(2..=4),
 		]
 		.map(|dom| prb.new_int_decision(dom));
 		prb.circuit(vars.iter().copied())
@@ -654,10 +654,10 @@ mod tests {
 	fn test_subcircuit_sparse_scc() {
 		let mut prb = Model::default();
 		let vars = [
-			IntSet::from_iter([1..=3]),
+			IntSet::from(1..=3),
 			IntSet::from_iter([1..=2, 4..=4]),
 			IntSet::from_iter([1..=1, 3..=4]),
-			IntSet::from_iter([2..=4]),
+			IntSet::from(2..=4),
 		]
 		.map(|dom| prb.new_int_decision(dom));
 		prb.circuit(vars.iter().copied())

--- a/crates/huub/src/constraints/circuit/scc.rs
+++ b/crates/huub/src/constraints/circuit/scc.rs
@@ -726,8 +726,8 @@ mod tests {
 		// 1-based values; only node 0 points to value 1 (=node 0), so {1,2,3} has
 		// no edge out.
 		let vars = [
-			IntSet::from_iter([2..=4]),        // 0 -> nodes 1,2,3
-			IntSet::from_iter([3..=4]),        // 1 -> nodes 2,3
+			IntSet::from(2..=4),               // 0 -> nodes 1,2,3
+			IntSet::from(3..=4),               // 1 -> nodes 2,3
 			IntSet::from_iter([2..=2, 4..=4]), // 2 -> nodes 1,3
 			IntSet::from_iter([2..=2, 3..=3]), // 3 -> nodes 1,2
 		]

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -660,7 +660,7 @@ mod tests {
 		IntVal,
 		actions::IntInspectionActions,
 		constraints::cumulative::Cumulative,
-		model::{ConRef, Model},
+		model::{ConstraintId, Model},
 		solver::Solver,
 	};
 
@@ -810,7 +810,7 @@ mod tests {
 			.post()
 			.unwrap();
 
-		let _ = prb.propagate_single(ConRef::from_raw(0));
+		let _ = prb.propagate_single(ConstraintId::from_raw(0));
 		assert_eq!(start_time_a.bounds(&prb), (0, 2));
 		assert_eq!(usages[0].bounds(&prb), (1, 1));
 		assert_eq!(start_time_b.bounds(&prb), (0, 2));

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -395,10 +395,12 @@ where
 					(LinComparator::NotEqual, Err(_)) => false.into(),
 				};
 				match self.reif.unwrap() {
-					Reification::ImpliedBy(r) => ctx.post_constraint(BoolFormula::Implies(
-						Box::new(BoolFormula::Atom(r)),
-						Box::new(BoolFormula::Atom(lit)),
-					)),
+					Reification::ImpliedBy(r) => {
+						let _ = ctx.post_constraint(BoolFormula::Implies(
+							Box::new(BoolFormula::Atom(r)),
+							Box::new(BoolFormula::Atom(lit)),
+						));
+					}
 					Reification::ReifiedBy(r) => r.unify(ctx, lit)?,
 				}
 				return Ok(SimplificationStatus::Subsumed);

--- a/crates/huub/src/constraints/int_unique.rs
+++ b/crates/huub/src/constraints/int_unique.rs
@@ -231,7 +231,7 @@ mod tests {
 			IntSet::from_iter([1..=1, 3..=4, 6..=6]),
 			IntSet::from_iter([2..=2, 5..=5]),
 			IntSet::from_iter([3..=3, 5..=5]),
-			IntSet::from_iter([3..=6]),
+			IntSet::from(3..=6),
 			(2..=2).into(),
 		]
 		.into_iter()

--- a/crates/huub/src/helpers/true_type.rs
+++ b/crates/huub/src/helpers/true_type.rs
@@ -22,6 +22,14 @@ where
 		true.advise_when_fixed(ctx, data);
 	}
 
+	fn cancel_advise_when_fixed(&self, ctx: &mut Ctx, data: u64) {
+		true.cancel_advise_when_fixed(ctx, data);
+	}
+
+	fn cancel_enqueue_when_fixed(&self, ctx: &mut Ctx) {
+		true.cancel_enqueue_when_fixed(ctx);
+	}
+
 	fn enqueue_when_fixed(&self, ctx: &mut Ctx) {
 		true.enqueue_when_fixed(ctx);
 	}

--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -43,7 +43,7 @@ use crate::{
 		overflow::{OverflowImpossible, OverflowMode, OverflowPossible},
 	},
 	model::{
-		self, ConRef, Model,
+		self, ConstraintId, Model,
 		decision::{Tier, integer::Domain},
 		deserialize::Goal,
 		initilization_context::ModelInitContext,
@@ -51,7 +51,7 @@ use crate::{
 		view::integer::IntView,
 	},
 	solver::{
-		self, IntLitMeaning, LiteralStrategy, Polarity, Solver, engine::Engine,
+		self, IntLitMeaning, LiteralStrategy, Polarity, PropagatorId, Solver, engine::Engine,
 		view::boolean::BoolView,
 	},
 	views::LinearBoolView,
@@ -62,11 +62,15 @@ use crate::{
 #[derive(Debug, Default)]
 struct GoalPolarity {
 	/// The constraint currently being processed.
-	current_con: Option<ConRef>,
+	current_con: Option<ConstraintId>,
 	/// The queue of decisions still to be processed: the decision, the desired
 	/// direction, and the constraint that enqueued it or `None` for the goal
 	/// itself.
-	queue: VecDeque<(Resolved<model::Decision<IntVal>>, Polarity, Option<ConRef>)>,
+	queue: VecDeque<(
+		Resolved<model::Decision<IntVal>>,
+		Polarity,
+		Option<ConstraintId>,
+	)>,
 	/// The (decision, direction) pairs already enqueued.
 	visited: FxHashSet<(Resolved<model::Decision<IntVal>>, Polarity)>,
 }
@@ -155,7 +159,7 @@ trait LoweringActions {
 	) -> Result<(), Nogood<solver::Decision<bool>>>;
 
 	/// Add a propagator to the solver.
-	fn add_propagator(&mut self, propagator: BoxedPropagator);
+	fn add_propagator(&mut self, propagator: BoxedPropagator) -> PropagatorId;
 
 	/// Get the current value of a [`BoolView`], if it has been assigned.
 	fn bool_val(&self, bv: solver::Decision<bool>) -> Option<bool>;
@@ -211,6 +215,9 @@ trait LoweringActions {
 
 	/// Create a fresh range of Boolean variables in the underlying SAT solver.
 	fn new_var_range(&mut self, len: usize) -> pindakaas::VarRange;
+
+	/// Ask a propagator to revise its subscriptions.
+	fn update_initialization(&mut self, prop: PropagatorId);
 }
 
 /// Context object used during the lowering process that creates a
@@ -318,14 +325,14 @@ impl GoalPolarity {
 		let _ = walk.visited.insert((start.clone(), start_dir));
 		walk.queue.push_back((start, start_dir, None));
 
-		let mut con_refs: Vec<ConRef> = Vec::new();
+		let mut constraint_ids: Vec<ConstraintId> = Vec::new();
 		while let Some((input, input_polarity, discovering)) = walk.queue.pop_front() {
 			// Collect the constraints the decision is involved in
-			con_refs.clear();
-			model.subscribed_constraints(input.0, |con| con_refs.push(con));
-			con_refs.sort_unstable_by_key(|con| con.index());
-			con_refs.dedup();
-			for &con in &con_refs {
+			constraint_ids.clear();
+			model.subscribed_constraints(input.0, |con| constraint_ids.push(con));
+			constraint_ids.sort_unstable_by_key(|con| con.index());
+			constraint_ids.dedup();
+			for &con in &constraint_ids {
 				// Never enqueue decisions from the constraint that enqueued this
 				// decision
 				if discovering == Some(con) {
@@ -766,7 +773,7 @@ impl LowererComplete<&mut Model> {
 		let constraints = std::mem::take(&mut model.constraints);
 		for (idx, c) in constraints.iter().enumerate() {
 			if let Some(c) = c {
-				let mut ctx = ModelInitContext::new(model, ConRef::new(idx));
+				let mut ctx = ModelInitContext::new(model, ConstraintId::new(idx));
 				c.analyze(&mut ctx);
 			}
 		}
@@ -940,6 +947,8 @@ impl Debug for LoweringContext<'_> {
 }
 
 impl PostingActions for LoweringContext<'_> {
+	type PropagatorId = PropagatorId;
+
 	fn add_clause(
 		&mut self,
 		clause: impl IntoIterator<Item = Self::Atom>,
@@ -948,8 +957,12 @@ impl PostingActions for LoweringContext<'_> {
 		self.slv.add_clause(clause)
 	}
 
-	fn add_propagator(&mut self, propagator: BoxedPropagator) {
-		self.slv.add_propagator(propagator);
+	fn add_propagator(&mut self, propagator: BoxedPropagator) -> PropagatorId {
+		self.slv.add_propagator(propagator)
+	}
+
+	fn update_initialization(&mut self, prop: PropagatorId) {
+		self.slv.update_initialization(prop);
 	}
 }
 
@@ -1303,8 +1316,8 @@ impl<Sat: ExternalPropagation> LoweringActions for Solver<Sat> {
 		self.add_clause(clause)
 	}
 
-	fn add_propagator(&mut self, propagator: BoxedPropagator) {
-		self.add_propagator(propagator, true);
+	fn add_propagator(&mut self, propagator: BoxedPropagator) -> PropagatorId {
+		self.add_propagator(propagator, true)
 	}
 
 	fn bool_val(&self, bv: solver::Decision<bool>) -> Option<bool> {
@@ -1365,6 +1378,10 @@ impl<Sat: ExternalPropagation> LoweringActions for Solver<Sat> {
 
 	fn new_var_range(&mut self, len: usize) -> pindakaas::VarRange {
 		self.sat.new_var_range(len)
+	}
+
+	fn update_initialization(&mut self, prop: PropagatorId) {
+		self.update_initialization(prop);
 	}
 }
 

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -48,16 +48,12 @@ use crate::{
 	},
 };
 
-/// Identifies an advisor in the [`Model`].
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct AdvRef(u32);
-
 /// Definition of how a constraint has requested to be advised at the model
 /// level.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct Advisor {
 	/// Reference to the constraint that has requested to be advised.
-	con: ConRef,
+	con: ConstraintId,
 	/// The data associated by the constraint with the advisor.
 	data: u64,
 	/// Whether lower and upper bound events must be swapped.
@@ -69,9 +65,18 @@ struct Advisor {
 	condition: Option<IntLitMeaning>,
 }
 
-/// Identifies a constraint in the [`Model`].
+/// Identifies an advisor in the [`Model`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct ConRef(u32);
+pub(crate) struct AdvisorId(u32);
+
+/// Identifies a constraint in the [`Model`].
+///
+/// An identifier is returned when a constraint is posted, and can be used to
+/// inspect the constraint using [`Model::constraint`], or to refresh its
+/// subscriptions using
+/// [`Model::update_initialization`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ConstraintId(u32);
 
 /// A formulation of a problem instance in terms of decisions and constraints.
 ///
@@ -126,7 +131,7 @@ pub struct Model {
 	/// Fake trailed storage
 	pub(crate) trail: Vec<[u8; 8]>,
 	/// Reference for the current propagator being executed.
-	cur_prop: Option<ConRef>,
+	cur_prop: Option<ConstraintId>,
 	/// Integer variable changes that occurred during the execution of the
 	/// current propagator.
 	int_events: FxHashMap<u32, IntEvent>,
@@ -158,8 +163,8 @@ pub struct SimplificationReasonSink {
 	pub(crate) deferred: Option<u64>,
 }
 
-impl AdvRef {
-	/// Recreate the advisor reference from a raw value.
+impl AdvisorId {
+	/// Recreate the advisor identifier from a raw value.
 	pub(crate) fn from_raw(raw: u32) -> Self {
 		debug_assert!(raw <= i32::MAX as u32);
 		Self(raw)
@@ -170,20 +175,20 @@ impl AdvRef {
 		self.0 as usize
 	}
 
-	/// Create a new advisor reference from an index.
+	/// Create a new advisor identifier from an index.
 	pub(crate) fn new(index: usize) -> Self {
 		debug_assert!(index < i32::MAX as usize);
 		Self(index as u32)
 	}
 
-	/// Access the raw value of the advisor reference.
+	/// Access the raw value of the advisor identifier.
 	pub(crate) fn raw(&self) -> u32 {
 		self.0
 	}
 }
 
-impl ConRef {
-	/// Recreate the constraint reference from a raw value.
+impl ConstraintId {
+	/// Recreate the constraint identifier from a raw value.
 	pub(crate) fn from_raw(raw: u32) -> Self {
 		debug_assert!(raw <= i32::MAX as u32);
 		Self(raw)
@@ -194,13 +199,13 @@ impl ConRef {
 		self.0 as usize
 	}
 
-	/// Create a new constraint reference from an index.
+	/// Create a new constraint identifier from an index.
 	pub(crate) fn new(index: usize) -> Self {
 		debug_assert!(index < i32::MAX as usize);
 		Self(index as u32)
 	}
 
-	/// Access the raw value of the constraint reference.
+	/// Access the raw value of the constraint identifier.
 	pub(crate) fn raw(&self) -> u32 {
 		self.0
 	}
@@ -217,7 +222,7 @@ impl Model {
 	}
 
 	/// Notify a single boolean advisor or propagator.
-	fn advise_of_bool_change(&mut self, con: ConRef, data: u64) -> bool {
+	fn advise_of_bool_change(&mut self, con: ConstraintId, data: u64) -> bool {
 		if let Some(mut c) = self.constraints[con.index()].take() {
 			let ret = c.advise_of_bool_change(self, data);
 			self.constraints[con.index()] = Some(c);
@@ -228,7 +233,7 @@ impl Model {
 	}
 
 	/// Notify a single integer advisor or propagator.
-	fn advise_of_int_change(&mut self, con: ConRef, data: u64, event: IntEvent) -> bool {
+	fn advise_of_int_change(&mut self, con: ConstraintId, data: u64, event: IntEvent) -> bool {
 		if let Some(mut c) = self.constraints[con.index()].take() {
 			let ret = c.advise_of_int_change(self, data, event);
 			self.constraints[con.index()] = Some(c);
@@ -238,21 +243,44 @@ impl Model {
 		}
 	}
 
+	/// Returns the constraint with the given identifier.
+	///
+	/// This returns `None` when the constraint is unavailable because it is
+	/// currently being simplified or advised, or because it has been subsumed.
+	pub fn constraint(&self, con: ConstraintId) -> Option<&dyn Constraint<Model>> {
+		self.constraints[con.index()].as_deref()
+	}
+
+	/// Returns the constraint with the given identifier, allowing it to
+	/// be given additional information about the problem.
+	///
+	/// Any decision variables that the constraint acquires this way are only
+	/// subscribed to once [`Model::update_initialization`] is called.
+	///
+	/// This returns `None` when the constraint is unavailable because it is
+	/// currently being simplified or advised, or because it has been subsumed.
+	pub fn constraint_mut(&mut self, con: ConstraintId) -> Option<&mut dyn Constraint<Model>> {
+		self.constraints[con.index()].as_deref_mut()
+	}
+
 	/// Initialize a constraint and register its subscriptions without
 	/// propagating it yet.
 	///
 	/// This is used by [`Model::post_constraint`] and by internal rewriting
 	/// paths that need to add a constraint before deciding whether to
 	/// propagate it immediately.
-	fn initialize_constraint<C: Constraint<Self>>(&mut self, constraint: C) -> (ConRef, bool) {
-		let con = ConRef::new(self.constraints.len());
+	fn initialize_constraint<C: Constraint<Self>>(
+		&mut self,
+		constraint: C,
+	) -> (ConstraintId, bool) {
+		let con = ConstraintId::new(self.constraints.len());
 		let mut ctx = ModelInitContext::new(self, con);
 		let mut constraint = constraint;
 		constraint.initialize(&mut ctx);
 		let priority = ctx.priority;
 		let enqueue = ctx.enqueue();
 		self.constraints.push(Some(Box::new(constraint)));
-		let r = ConRef::new(self.constraints.len() - 1);
+		let r = ConstraintId::new(self.constraints.len() - 1);
 		debug_assert_eq!(r, con);
 		self.propagator_queue.info.push(PropagatorInfo {
 			enqueued: false,
@@ -368,7 +396,7 @@ impl Model {
 		debug_assert!(!bv.is_negated());
 		for &act in self.bool_vars[bv.idx()].constraints.clone().iter() {
 			match act.into() {
-				ActivationAction::Advise::<AdvRef, _>(adv) => {
+				ActivationAction::Advise::<AdvisorId, _>(adv) => {
 					let x: &Advisor = &self.advisors[adv.index()];
 					let Advisor {
 						con,
@@ -397,7 +425,7 @@ impl Model {
 		let constraints = mem::take(&mut self.int_vars[i as usize].constraints);
 		let iv = Decision(i);
 		constraints.for_each_activated_by(event, |act| match act {
-			ActivationAction::Advise::<AdvRef, _>(adv) => {
+			ActivationAction::Advise::<AdvisorId, _>(adv) => {
 				let x: &Advisor = &self.advisors[adv.index()];
 				let Advisor {
 					con,
@@ -499,12 +527,12 @@ impl Model {
 	pub fn post_constraint<C: Constraint<Self>>(
 		&mut self,
 		constraint: C,
-	) -> Result<(), Nogood<View<bool>>> {
+	) -> Result<ConstraintId, Nogood<View<bool>>> {
 		let (con, enqueue) = self.initialize_constraint(constraint);
 		if enqueue {
 			self.propagate_single(con)?;
 		}
-		Ok(())
+		Ok(con)
 	}
 
 	/// Internal implementation of [`Model::post_constraint`] that does not yet
@@ -512,11 +540,15 @@ impl Model {
 	///
 	/// This function is used internally by [`Model::post_constraint`] and when
 	/// rewriting constraints within the propagation loop.
-	pub(crate) fn post_constraint_internal<C: Constraint<Self>>(&mut self, constraint: C) {
+	pub(crate) fn post_constraint_internal<C: Constraint<Self>>(
+		&mut self,
+		constraint: C,
+	) -> ConstraintId {
 		let (con, enqueue) = self.initialize_constraint(constraint);
 		if enqueue {
 			self.propagator_queue.enqueue_propagator(con.raw());
 		}
+		con
 	}
 
 	/// Propagate all constraints until the propagator queue is empty.
@@ -533,14 +565,14 @@ impl Model {
 	pub fn propagate(&mut self) -> Result<(), Nogood<View<bool>>> {
 		self.notify_advisors();
 		while let Some(con) = self.propagator_queue.pop() {
-			self.propagate_single(ConRef::from_raw(con))?;
+			self.propagate_single(ConstraintId::from_raw(con))?;
 		}
 		Ok(())
 	}
 
 	/// Propagate the constraint at index `con`, updating the domains of the
 	/// variables and rewriting the constraint if necessary.
-	pub(crate) fn propagate_single(&mut self, con: ConRef) -> Result<(), Nogood<View<bool>>> {
+	pub(crate) fn propagate_single(&mut self, con: ConstraintId) -> Result<(), Nogood<View<bool>>> {
 		let Some(mut con_obj) = self.constraints[con.index()].take() else {
 			return Ok(());
 		};
@@ -555,7 +587,7 @@ impl Model {
 			data,
 		})) = status
 		{
-			debug_assert_eq!(ConRef::new(propagator as usize), con);
+			debug_assert_eq!(ConstraintId::new(propagator as usize), con);
 			status = Err(
 				SimplificationContext(&mut *self).make_conflict(subject, |ctx, sink| {
 					con_obj.explain(
@@ -580,13 +612,17 @@ impl Model {
 		Ok(())
 	}
 
-	/// Invoke `f` with a [`ConRef`] for each constraint that the given integer
-	/// decision is subscribed to (i.e. that may involve it). The same
+	/// Invoke `f` with a [`ConstraintId`] for each constraint that the given
+	/// integer decision is subscribed to (i.e. that may involve it). The same
 	/// constraint may be reported more than once.
-	pub(crate) fn subscribed_constraints(&self, dec: Decision<IntVal>, mut f: impl FnMut(ConRef)) {
+	pub(crate) fn subscribed_constraints(
+		&self,
+		dec: Decision<IntVal>,
+		mut f: impl FnMut(ConstraintId),
+	) {
 		self.int_vars[dec.idx()].constraints.for_each_activated_by(
 			IntEvent::Fixed,
-			|act: ActivationAction<AdvRef, ConRef>| {
+			|act: ActivationAction<AdvisorId, ConstraintId>| {
 				let con = match act {
 					ActivationAction::Enqueue(con) => con,
 					ActivationAction::Advise(adv) => self.advisors[adv.index()].con,
@@ -594,6 +630,27 @@ impl Model {
 				f(con);
 			},
 		);
+	}
+
+	/// Ask the constraint to update what it declared during initialization,
+	/// calling
+	/// [`Propagator::update_initialization`](crate::constraints::Propagator::update_initialization).
+	///
+	/// The call is ignored when the constraint is unavailable because it is
+	/// currently being simplified or advised, or because it has been subsumed.
+	pub fn update_initialization(&mut self, con: ConstraintId) {
+		let Some(mut con_obj) = self.constraints[con.index()].take() else {
+			return;
+		};
+		let mut ctx = ModelInitContext::update(self, con);
+		con_obj.update_initialization(&mut ctx);
+		let priority = ctx.priority;
+		let enqueue = ctx.enqueue();
+		self.constraints[con.index()] = Some(con_obj);
+		self.propagator_queue.info[con.index()].priority = priority;
+		if enqueue {
+			self.propagator_queue.enqueue_propagator(con.raw());
+		}
 	}
 }
 
@@ -645,10 +702,11 @@ impl ReasoningEngine for Model {
 }
 
 impl SimplificationActions for Model {
+	type ConstraintId = ConstraintId;
 	type Target = Model;
 
-	fn post_constraint<C: Constraint<Model>>(&mut self, constraint: C) {
-		self.post_constraint_internal(constraint);
+	fn post_constraint<C: Constraint<Model>>(&mut self, constraint: C) -> ConstraintId {
+		self.post_constraint_internal(constraint)
 	}
 }
 
@@ -727,10 +785,11 @@ impl ReasoningContext for SimplificationContext<'_> {
 }
 
 impl SimplificationActions for SimplificationContext<'_> {
+	type ConstraintId = ConstraintId;
 	type Target = Model;
 
-	fn post_constraint<C: Constraint<Model>>(&mut self, constraint: C) {
-		self.0.post_constraint_internal(constraint);
+	fn post_constraint<C: Constraint<Model>>(&mut self, constraint: C) -> ConstraintId {
+		self.0.post_constraint_internal(constraint)
 	}
 }
 
@@ -768,6 +827,8 @@ impl ReasonActions<View<bool>> for SimplificationReasonSink {
 
 #[cfg(test)]
 mod tests {
+	use std::any::Any;
+
 	use expect_test::expect;
 	use tracing_test::traced_test;
 
@@ -786,6 +847,18 @@ mod tests {
 		model::{Model, View, deserialize::AnyView, view::boolean::BoolView},
 		solver::Solver,
 	};
+
+	/// A constraint that acquires the decisions it constrains after it has been
+	/// posted, and only ever subscribes to the ones it has not seen before.
+	#[derive(Clone, Debug)]
+	struct GrowingModel {
+		/// The decisions the constraint has been given so far.
+		decisions: Vec<View<IntVal>>,
+		/// The number of decisions that have already been subscribed to.
+		subscribed: usize,
+		/// Counts how often the constraint has been advised.
+		advised: Trailed<IntVal>,
+	}
 
 	#[derive(Clone, Debug)]
 	struct TestModel {
@@ -845,6 +918,43 @@ mod tests {
 			false, 0
 			true, -1"#]],
 		);
+	}
+
+	/// A constraint that gains a decision after it was posted is only advised
+	/// of that decision once its subscriptions have been refreshed.
+	#[test]
+	#[traced_test]
+	fn test_model_acquired_decision_subscription() {
+		let mut prb = Model::default();
+		let i = prb.new_int_decision(0..=10);
+		let advised = prb.new_trailed(0);
+		let con = prb
+			.post_constraint(GrowingModel {
+				decisions: Vec::new(),
+				subscribed: 0,
+				advised,
+			})
+			.unwrap();
+
+		// The constraint is given a decision, but has not subscribed to it yet.
+		let constraint = prb.constraint_mut(con).expect("constraint is available");
+		let constraint: &mut dyn Any = constraint;
+		constraint
+			.downcast_mut::<GrowingModel>()
+			.expect("constraint is a GrowingModel")
+			.decisions
+			.push(i);
+		i.tighten_min(&mut prb, 1, NO_REASON)
+			.expect("tighten_min failed");
+		prb.propagate().expect("propagate failed");
+		assert_eq!(prb.trailed(advised), 0);
+
+		// After refreshing its subscriptions, the constraint is advised.
+		prb.update_initialization(con);
+		i.tighten_min(&mut prb, 2, NO_REASON)
+			.expect("tighten_min failed");
+		prb.propagate().expect("propagate failed");
+		assert_eq!(prb.trailed(advised), 1);
 	}
 
 	#[test]
@@ -914,6 +1024,83 @@ mod tests {
 		let (min, max) = i_slv.bounds(&slv);
 		assert_eq!(min, 1);
 		assert_eq!(max, 2);
+	}
+
+	/// Refreshing the subscriptions of a constraint that has already subscribed
+	/// to all its decisions does not subscribe to them a second time.
+	#[test]
+	#[traced_test]
+	fn test_model_repeated_subscription_update() {
+		let mut prb = Model::default();
+		let i = prb.new_int_decision(0..=10);
+		let advised = prb.new_trailed(0);
+		let con = prb
+			.post_constraint(GrowingModel {
+				decisions: vec![i],
+				subscribed: 0,
+				advised,
+			})
+			.unwrap();
+
+		for _ in 0..3 {
+			prb.update_initialization(con);
+		}
+		i.tighten_min(&mut prb, 1, NO_REASON)
+			.expect("tighten_min failed");
+		prb.propagate().expect("propagate failed");
+		assert_eq!(prb.trailed(advised), 1);
+	}
+
+	impl<E> Constraint<E> for GrowingModel
+	where
+		E: ReasoningEngine,
+		View<IntVal>: IntModelActions<E>,
+	{
+		fn simplify(
+			&mut self,
+			_context: &mut E::PropagationContext<'_>,
+		) -> Result<SimplificationStatus, E::Conflict> {
+			Ok(SimplificationStatus::NoFixpoint)
+		}
+
+		fn to_solver(&self, _context: &mut LoweringContext<'_>) -> Result<(), LoweringError> {
+			Ok(())
+		}
+	}
+
+	impl<E> Propagator<E> for GrowingModel
+	where
+		E: ReasoningEngine,
+		View<IntVal>: IntModelActions<E>,
+	{
+		fn advise_of_int_change(
+			&mut self,
+			context: &mut E::NotificationContext<'_>,
+			_data: u64,
+			_event: IntEvent,
+		) -> bool {
+			context.set_trailed(self.advised, context.trailed(self.advised) + 1);
+			false
+		}
+
+		fn initialize(&mut self, _context: &mut E::InitializationContext<'_>) {
+			// All subscriptions are made in `update_initialization`, which the
+			// code that grows this constraint is expected to trigger.
+		}
+
+		fn propagate(
+			&mut self,
+			_context: &mut E::PropagationContext<'_>,
+		) -> Result<(), E::Conflict> {
+			Ok(())
+		}
+
+		fn update_initialization(&mut self, context: &mut E::InitializationContext<'_>) {
+			for (i, dec) in self.decisions.iter().enumerate().skip(self.subscribed) {
+				dec.advise_when(context, IntPropCond::Bounds, i as u64);
+			}
+			self.subscribed = self.decisions.len();
+		}
 	}
 
 	impl<E> Constraint<E> for TestModel

--- a/crates/huub/src/model/decision/integer.rs
+++ b/crates/huub/src/model/decision/integer.rs
@@ -12,7 +12,7 @@ use crate::{
 	},
 	constraints::{Conflict, NO_REASON, Nogood},
 	model::{
-		AdvRef, ConRef, Decision, Model, SimplificationContext, SimplificationReasonSink,
+		AdvisorId, ConstraintId, Decision, Model, SimplificationContext, SimplificationReasonSink,
 		decision::{DecisionReference, PolarityScore, private},
 		resolved::Resolved,
 		view::{View, boolean::BoolView, integer::IntView},
@@ -411,7 +411,7 @@ impl Resolved<Decision<IntVal>> {
 					let model = &mut *ctx.0;
 					constraints.for_each_activated_by(
 						IntEvent::Fixed,
-						|act: ActivationAction<AdvRef, ConRef>| {
+						|act: ActivationAction<AdvisorId, ConstraintId>| {
 							if let ActivationAction::Advise(adv) = act {
 								let def = &mut model.advisors[adv.index()];
 								def.bool2int = true;
@@ -442,7 +442,7 @@ impl Resolved<Decision<IntVal>> {
 					let model = &mut *ctx.0;
 					constraints.for_each_activated_by(
 						IntEvent::Fixed,
-						|act: ActivationAction<AdvRef, ConRef>| {
+						|act: ActivationAction<AdvisorId, ConstraintId>| {
 							if let ActivationAction::Advise(adv) = act {
 								let def = &mut model.advisors[adv.index()];
 								def.bool2int = true;

--- a/crates/huub/src/model/expressions.rs
+++ b/crates/huub/src/model/expressions.rs
@@ -61,6 +61,7 @@ impl Model {
 			abs: result,
 			origin_positive: origin.geq(0),
 		})
+		.map(|_| ())
 	}
 
 	/// Create a `circuit` constraint that enforces that the values of the given
@@ -100,6 +101,7 @@ impl Model {
 				no_cycle_propagation,
 				scc_propagation,
 			))
+			.map(|_| ())
 		} else {
 			self.post_constraint(Circuit::<false>::new(
 				vars,
@@ -107,6 +109,7 @@ impl Model {
 				no_cycle_propagation,
 				scc_propagation,
 			))
+			.map(|_| ())
 		}
 	}
 
@@ -125,6 +128,7 @@ impl Model {
 			set: collection,
 			reif: result,
 		})
+		.map(|_| ())
 	}
 
 	/// Create a constraint that enforces that the given a list of integer
@@ -190,6 +194,7 @@ impl Model {
 			opportunistic_edge_finding_propagation,
 			strengthened: false,
 		})
+		.map(|_| ())
 	}
 
 	/// Create a constraint that enforces that the given a list of integer
@@ -224,6 +229,7 @@ impl Model {
 			not_last_propagation,
 			detectable_precedence_propagation,
 		})
+		.map(|_| ())
 	}
 
 	/// Create a constraint that enforces that a numerator integer decision
@@ -241,6 +247,7 @@ impl Model {
 			denominator,
 			result,
 		})
+		.map(|_| ())
 	}
 
 	/// Create a constraint that enforces that a result decision variable takes
@@ -375,6 +382,7 @@ impl Model {
 				reif,
 				comparator,
 			})
+			.map(|_| ())
 		} else {
 			self.post_constraint(IntLinear::<OverflowImpossible> {
 				terms,
@@ -382,6 +390,7 @@ impl Model {
 				reif,
 				comparator,
 			})
+			.map(|_| ())
 		}
 	}
 
@@ -410,6 +419,7 @@ impl Model {
 			vars: vars.into_iter().collect(),
 			min: result,
 		})
+		.map(|_| ())
 	}
 
 	/// Create a constraint that enforces that the product of the two integer
@@ -428,6 +438,7 @@ impl Model {
 				product: result,
 				overflow_mode: PhantomData,
 			})
+			.map(|_| ())
 		} else {
 			self.post_constraint(IntMulBounds::<OverflowImpossible, _, _, _> {
 				factor1,
@@ -435,6 +446,7 @@ impl Model {
 				product: result,
 				overflow_mode: PhantomData,
 			})
+			.map(|_| ())
 		}
 	}
 
@@ -467,10 +479,10 @@ impl Model {
 	) -> Result<(), Nogood<View<bool>>> {
 		if strict {
 			let prop = IntNoOverlapSweep::<true, _, _>::new(self, origins, sizes);
-			self.post_constraint(prop)
+			self.post_constraint(prop).map(|_| ())
 		} else {
 			let prop = IntNoOverlapSweep::<false, _, _>::new(self, origins, sizes);
-			self.post_constraint(prop)
+			self.post_constraint(prop).map(|_| ())
 		}
 	}
 
@@ -491,6 +503,7 @@ impl Model {
 				result,
 				overflow_mode: PhantomData,
 			})
+			.map(|_| ())
 		} else {
 			self.post_constraint(IntPowBounds::<OverflowImpossible, _, _, _> {
 				base,
@@ -498,6 +511,7 @@ impl Model {
 				result,
 				overflow_mode: PhantomData,
 			})
+			.map(|_| ())
 		}
 	}
 
@@ -518,7 +532,7 @@ impl Model {
 			}
 			None => {}
 		}
-		self.post_constraint(formula)
+		self.post_constraint(formula).map(|_| ())
 	}
 
 	/// Create a `table` constraint that enforces that given list of integer
@@ -536,7 +550,7 @@ impl Model {
 			table.iter().all(|tup| tup.len() == vars.len()),
 			"The number of values in each row of the table must be equal to the number of decision variables."
 		);
-		self.post_constraint(IntTable { vars, table })
+		self.post_constraint(IntTable { vars, table }).map(|_| ())
 	}
 
 	/// Create a constraint that enforces that all the given integer decisions
@@ -586,6 +600,7 @@ impl Model {
 			value_propagation,
 			domain_propagation,
 		})
+		.map(|_| ())
 	}
 
 	/// Create a value precede (chain) constraint that enforces that the first
@@ -624,7 +639,7 @@ impl Model {
 				vars[0].exclude(self, &RangeList::from_elements(values.clone()), NO_REASON)?;
 
 				let con = IntValuePrecedeChainValue::new(self, values.into_iter().collect(), vars);
-				return self.post_constraint(con);
+				return self.post_constraint(con).map(|_| ());
 			}
 			// Otherwise this is a sequential precede chain constraint, and we can
 			// normalize it to start at 1. The `values` array might not have started
@@ -641,7 +656,7 @@ impl Model {
 			1 => Ok(()),
 			_ => {
 				let con = IntSeqPrecedeChainBounds::new(self, vars);
-				self.post_constraint(con)
+				self.post_constraint(con).map(|_| ())
 			}
 		}
 	}

--- a/crates/huub/src/model/expressions/element.rs
+++ b/crates/huub/src/model/expressions/element.rs
@@ -57,7 +57,7 @@ impl ElementConstraint for IntVal {
 		result: Self::Result,
 	) -> Result<(), Nogood<View<bool>>> {
 		let con = IntValArrayElement(IntArrayElementBounds::new(prb, array, index, result));
-		prb.post_constraint(con)
+		prb.post_constraint(con).map(|_| ())
 	}
 }
 
@@ -86,7 +86,7 @@ impl ElementConstraint for View<IntVal> {
 		result: Self::Result,
 	) -> Result<(), Nogood<View<bool>>> {
 		let con = IntArrayElementBounds::new(prb, array, index, result);
-		prb.post_constraint(con)
+		prb.post_constraint(con).map(|_| ())
 	}
 }
 
@@ -109,6 +109,7 @@ impl ElementConstraint for View<bool> {
 			array,
 			result,
 		})
+		.map(|_| ())
 	}
 }
 
@@ -150,5 +151,6 @@ impl ElementConstraint for bool {
 			set: IntSet::from_iter(ranges),
 			reif: result,
 		})
+		.map(|_| ())
 	}
 }

--- a/crates/huub/src/model/initilization_context.rs
+++ b/crates/huub/src/model/initilization_context.rs
@@ -7,12 +7,16 @@ use crate::{
 		IntInitActions, IntInspectionActions, IntPropCond, ReasoningContext, ReasoningEngine,
 	},
 	model::{
-		AdvRef, Advisor, ConRef, Decision, Model,
+		Advisor, AdvisorId, ConstraintId, Decision, Model,
 		decision::Tier,
 		resolved::Resolved,
 		view::{View, boolean::BoolView, integer::IntView},
 	},
-	solver::{IntLitMeaning, Polarity, activation_list::ActivationAction, queue::PriorityLevel},
+	solver::{
+		IntLitMeaning, Polarity,
+		activation_list::{ActivationAction, ActivationActionS},
+		queue::PriorityLevel,
+	},
 };
 
 /// Wrapper around [`Model`] that knows the constraint being
@@ -20,7 +24,7 @@ use crate::{
 #[derive(Debug)]
 pub struct ModelInitContext<'a> {
 	/// Index of the constraint being initialized.
-	con: ConRef,
+	con: ConstraintId,
 	/// Reference to the Model in which the constraint exists.
 	model: &'a mut Model,
 	/// The priority level at which the constraint will be enqueued.
@@ -33,6 +37,23 @@ pub struct ModelInitContext<'a> {
 	decision_enqueue: Option<bool>,
 }
 
+/// Whether the activation is an advisor of `con` that was registered with the
+/// given data.
+fn is_advisor_of(
+	advisors: &[Advisor],
+	act: ActivationActionS,
+	con: ConstraintId,
+	data: u64,
+) -> bool {
+	match act.into() {
+		ActivationAction::<AdvisorId, ConstraintId>::Advise(adv) => {
+			let advisor = &advisors[adv.index()];
+			advisor.con == con && advisor.data == data
+		}
+		ActivationAction::Enqueue(_) => false,
+	}
+}
+
 impl BoolAnalyzeActions<ModelInitContext<'_>> for Decision<bool> {
 	fn polarity(&self, ctx: &mut ModelInitContext<'_>, polarity: Polarity) {
 		ctx.model
@@ -43,6 +64,15 @@ impl BoolAnalyzeActions<ModelInitContext<'_>> for Decision<bool> {
 impl BoolInitActions<ModelInitContext<'_>> for Decision<bool> {
 	fn advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
 		self.resolve_alias(ctx.model).advise_when_fixed(ctx, data);
+	}
+
+	fn cancel_advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
+		self.resolve_alias(ctx.model)
+			.cancel_advise_when_fixed(ctx, data);
+	}
+
+	fn cancel_enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
+		self.resolve_alias(ctx.model).cancel_enqueue_when_fixed(ctx);
 	}
 
 	fn enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
@@ -78,6 +108,16 @@ impl IntAnalyzeActions<ModelInitContext<'_>> for Decision<IntVal> {
 impl IntInitActions<ModelInitContext<'_>> for Decision<IntVal> {
 	fn advise_when(&self, ctx: &mut ModelInitContext<'_>, cond: IntPropCond, data: u64) {
 		self.resolve_alias(ctx.model).advise_when(ctx, cond, data);
+	}
+
+	fn cancel_advise_when(&self, ctx: &mut ModelInitContext<'_>, cond: IntPropCond, data: u64) {
+		self.resolve_alias(ctx.model)
+			.cancel_advise_when(ctx, cond, data);
+	}
+
+	fn cancel_enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
+		self.resolve_alias(ctx.model)
+			.cancel_enqueue_when(ctx, condition);
 	}
 
 	fn enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
@@ -132,12 +172,66 @@ impl IntInitActions<ModelInitContext<'_>> for IntVal {
 		// Value will never change, so no advisor will ever be called
 	}
 
+	fn cancel_advise_when(&self, _: &mut ModelInitContext<'_>, _: IntPropCond, _: u64) {
+		// A constant never subscribed, so there is nothing to cancel.
+	}
+
+	fn cancel_enqueue_when(&self, _: &mut ModelInitContext<'_>, _: IntPropCond) {
+		// A constant never subscribed, so there is nothing to cancel.
+	}
+
 	fn enqueue_when(&self, ctx: &mut ModelInitContext<'_>, _: IntPropCond) {
 		ctx.semantic_enqueue();
 	}
 }
 
 impl<'a> ModelInitContext<'a> {
+	/// Internal method used to remove an advisor of the constraint being
+	/// initialized from the activation list of a Boolean decision variable.
+	fn cancel_bool_advisor(&mut self, idx: usize, data: u64) {
+		let con = self.con;
+		let advisors = &self.model.advisors;
+		let activations = &self.model.bool_vars[idx].constraints;
+		let Some(pos) = activations
+			.iter()
+			.position(|&act| is_advisor_of(advisors, act, con, data))
+		else {
+			return;
+		};
+		let _ = self.model.bool_vars[idx].constraints.swap_remove(pos);
+	}
+
+	/// Internal method used to remove the enqueue subscription of the
+	/// constraint being initialized from the activation list of a Boolean
+	/// decision variable.
+	fn cancel_bool_enqueue(&mut self, idx: usize) {
+		let target = ActivationActionS::from(ActivationAction::<AdvisorId, _>::Enqueue(self.con));
+		let activations = &mut self.model.bool_vars[idx].constraints;
+		if let Some(pos) = activations.iter().position(|&act| act == target) {
+			let _ = activations.swap_remove(pos);
+		}
+	}
+
+	/// Internal method used to remove an advisor of the constraint being
+	/// initialized from the activation list of an integer decision variable.
+	fn cancel_int_advisor(&mut self, idx: usize, condition: IntPropCond, data: u64) {
+		let con = self.con;
+		let advisors = &self.model.advisors;
+		let _ = self.model.int_vars[idx]
+			.constraints
+			.remove(condition, |act| is_advisor_of(advisors, act, con, data));
+	}
+
+	/// Internal method used to remove the enqueue subscription of the
+	/// constraint being initialized from the activation list of an integer
+	/// decision variable.
+	fn cancel_int_enqueue(&mut self, idx: usize, condition: IntPropCond) {
+		let target = ActivationActionS::from(ActivationAction::<AdvisorId, _>::Enqueue(self.con));
+		let _ = self.model.int_vars[idx]
+			.constraints
+			.remove(condition, |act| act == target);
+	}
+
 	/// Returns whether to enqueue the propagator based on its explicit requests
 	/// or otherwise the semantics of its subscriptions.
 	pub(crate) fn enqueue(&self) -> bool {
@@ -149,7 +243,7 @@ impl<'a> ModelInitContext<'a> {
 	}
 	/// Creates a new [`ModelPostingContext`] for the given constraint
 	/// reference.
-	pub(crate) fn new(model: &'a mut Model, con: ConRef) -> Self {
+	pub(crate) fn new(model: &'a mut Model, con: ConstraintId) -> Self {
 		ModelInitContext {
 			con,
 			model,
@@ -162,6 +256,23 @@ impl<'a> ModelInitContext<'a> {
 	/// Mark that subscriptions imply the propagator should be enqueued now.
 	pub(crate) fn semantic_enqueue(&mut self) {
 		self.semantic_enqueue = true;
+	}
+
+	/// Creates a new [`ModelInitContext`] to revise the subscriptions of a
+	/// constraint that has already been posted.
+	///
+	/// Unlike [`Self::new`], the context starts from the priority the
+	/// constraint was given when it was posted, so that a constraint that does
+	/// not set its priority again keeps the one it has.
+	pub(crate) fn update(model: &'a mut Model, con: ConstraintId) -> Self {
+		let priority = model.propagator_queue.info[con.index()].priority;
+		ModelInitContext {
+			con,
+			model,
+			priority,
+			semantic_enqueue: false,
+			decision_enqueue: None,
+		}
 	}
 }
 
@@ -192,10 +303,18 @@ impl BoolInitActions<ModelInitContext<'_>> for Resolved<Decision<bool>> {
 			bool2int: false,
 			condition: None,
 		});
-		let adv = AdvRef::new(ctx.model.advisors.len() - 1);
+		let adv = AdvisorId::new(ctx.model.advisors.len() - 1);
 		ctx.model.bool_vars[self.0.idx()]
 			.constraints
 			.push(ActivationAction::Advise(adv).into());
+	}
+
+	fn cancel_advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
+		ctx.cancel_bool_advisor(self.0.idx(), data);
+	}
+
+	fn cancel_enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
+		ctx.cancel_bool_enqueue(self.0.idx());
 	}
 
 	fn enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
@@ -225,10 +344,40 @@ impl BoolInitActions<ModelInitContext<'_>> for Resolved<View<bool>> {
 			bool2int: false,
 			condition: Some(cond),
 		});
-		let adv = AdvRef::new(ctx.model.advisors.len() - 1);
+		let adv = AdvisorId::new(ctx.model.advisors.len() - 1);
 		ctx.model.int_vars[iv.idx()]
 			.constraints
 			.add(ActivationAction::Advise(adv), event);
+	}
+
+	fn cancel_advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
+		let (iv, event) = match self.0.0 {
+			BoolView::Decision(lit) => {
+				return Resolved(lit).cancel_advise_when_fixed(ctx, data);
+			}
+			BoolView::Const(_) => {
+				// A constant never subscribed, so there is nothing to cancel.
+				return;
+			}
+			BoolView::IntEq(iv, _) | BoolView::IntNotEq(iv, _) => (iv, IntPropCond::Domain),
+			BoolView::IntGreaterEq(iv, _) | BoolView::IntLess(iv, _) => (iv, IntPropCond::Bounds),
+		};
+		ctx.cancel_int_advisor(iv.idx(), event, data);
+	}
+
+	fn cancel_enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
+		match self.0.0 {
+			BoolView::Decision(lit) => Resolved(lit).cancel_enqueue_when_fixed(ctx),
+			BoolView::Const(_) => {
+				// A constant never subscribed, so there is nothing to cancel.
+			}
+			BoolView::IntEq(iv, _) | BoolView::IntNotEq(iv, _) => {
+				iv.cancel_enqueue_when(ctx, IntPropCond::Domain);
+			}
+			BoolView::IntGreaterEq(iv, _) | BoolView::IntLess(iv, _) => {
+				iv.cancel_enqueue_when(ctx, IntPropCond::Bounds);
+			}
+		}
 	}
 
 	fn enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
@@ -268,10 +417,18 @@ impl IntInitActions<ModelInitContext<'_>> for Resolved<Decision<IntVal>> {
 			bool2int: false,
 			condition: None,
 		});
-		let adv = AdvRef::new(ctx.model.advisors.len() - 1);
+		let adv = AdvisorId::new(ctx.model.advisors.len() - 1);
 		ctx.model.int_vars[self.idx()]
 			.constraints
 			.add(ActivationAction::Advise(adv), cond);
+	}
+
+	fn cancel_advise_when(&self, ctx: &mut ModelInitContext<'_>, cond: IntPropCond, data: u64) {
+		ctx.cancel_int_advisor(self.idx(), cond, data);
+	}
+
+	fn cancel_enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
+		ctx.cancel_int_enqueue(self.idx(), condition);
 	}
 
 	fn enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
@@ -296,7 +453,7 @@ impl IntInitActions<ModelInitContext<'_>> for Resolved<View<IntVal>> {
 					bool2int: false,
 					condition: None,
 				});
-				let adv = AdvRef::new(ctx.model.advisors.len() - 1);
+				let adv = AdvisorId::new(ctx.model.advisors.len() - 1);
 				ctx.model.int_vars[lin.var.idx()]
 					.constraints
 					.add(ActivationAction::Advise(adv), cond);
@@ -313,7 +470,7 @@ impl IntInitActions<ModelInitContext<'_>> for Resolved<View<IntVal>> {
 							bool2int: true,
 							condition: None,
 						});
-						let adv = AdvRef::new(ctx.model.advisors.len() - 1);
+						let adv = AdvisorId::new(ctx.model.advisors.len() - 1);
 						ctx.model.bool_vars[lit.idx()]
 							.constraints
 							.push(ActivationAction::Advise(adv).into());
@@ -337,7 +494,7 @@ impl IntInitActions<ModelInitContext<'_>> for Resolved<View<IntVal>> {
 					bool2int: true,
 					condition: Some(cond),
 				});
-				let adv = AdvRef::new(ctx.model.advisors.len() - 1);
+				let adv = AdvisorId::new(ctx.model.advisors.len() - 1);
 				ctx.model.int_vars[iv.idx()]
 					.constraints
 					.add(ActivationAction::Advise(adv), event);
@@ -345,15 +502,48 @@ impl IntInitActions<ModelInitContext<'_>> for Resolved<View<IntVal>> {
 		}
 	}
 
+	fn cancel_advise_when(&self, ctx: &mut ModelInitContext<'_>, cond: IntPropCond, data: u64) {
+		match self.0.0 {
+			IntView::Linear(lin) => ctx.cancel_int_advisor(lin.var.idx(), cond, data),
+			IntView::Const(_) => {
+				// A constant never subscribed, so there is nothing to cancel.
+			}
+			IntView::Bool(lin) => {
+				let var = lin.var.resolve_alias(ctx.model);
+				let (iv, event) = match var.into_inner().0 {
+					BoolView::Decision(lit) => {
+						return ctx.cancel_bool_advisor(lit.idx(), data);
+					}
+					BoolView::Const(_) => {
+						// A constant never subscribed, so there is nothing to cancel.
+						return;
+					}
+					BoolView::IntEq(iv, _) | BoolView::IntNotEq(iv, _) => (iv, IntPropCond::Domain),
+					BoolView::IntGreaterEq(iv, _) | BoolView::IntLess(iv, _) => {
+						(iv, IntPropCond::Bounds)
+					}
+				};
+				ctx.cancel_int_advisor(iv.idx(), event, data);
+			}
+		}
+	}
+
+	fn cancel_enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
+		match self.0.0 {
+			IntView::Linear(lin) => {
+				Resolved(lin.var).cancel_enqueue_when(ctx, lin.scale_condition(condition));
+			}
+			IntView::Const(_) => {
+				// A constant never subscribed, so there is nothing to cancel.
+			}
+			IntView::Bool(lin) => lin.var.cancel_enqueue_when_fixed(ctx),
+		}
+	}
+
 	fn enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
 		match self.0.0 {
 			IntView::Linear(lin) => {
-				let condition = match condition {
-					IntPropCond::LowerBound if lin.scale.is_negative() => IntPropCond::UpperBound,
-					IntPropCond::UpperBound if lin.scale.is_negative() => IntPropCond::LowerBound,
-					_ => condition,
-				};
-				Resolved(lin.var).enqueue_when(ctx, condition);
+				Resolved(lin.var).enqueue_when(ctx, lin.scale_condition(condition));
 			}
 			IntView::Const(_) => ctx.semantic_enqueue(),
 			IntView::Bool(lin) => {
@@ -454,6 +644,13 @@ impl BoolInitActions<ModelInitContext<'_>> for View<bool> {
 	fn advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
 		self.resolve_alias(ctx.model).advise_when_fixed(ctx, data);
 	}
+	fn cancel_advise_when_fixed(&self, ctx: &mut ModelInitContext<'_>, data: u64) {
+		self.resolve_alias(ctx.model)
+			.cancel_advise_when_fixed(ctx, data);
+	}
+	fn cancel_enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
+		self.resolve_alias(ctx.model).cancel_enqueue_when_fixed(ctx);
+	}
 	fn enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
 		self.resolve_alias(ctx.model).enqueue_when_fixed(ctx);
 	}
@@ -468,6 +665,16 @@ impl BoolInspectionActions<ModelInitContext<'_>> for View<bool> {
 impl IntInitActions<ModelInitContext<'_>> for View<IntVal> {
 	fn advise_when(&self, ctx: &mut ModelInitContext<'_>, cond: IntPropCond, data: u64) {
 		self.resolve_alias(ctx.model).advise_when(ctx, cond, data);
+	}
+
+	fn cancel_advise_when(&self, ctx: &mut ModelInitContext<'_>, cond: IntPropCond, data: u64) {
+		self.resolve_alias(ctx.model)
+			.cancel_advise_when(ctx, cond, data);
+	}
+
+	fn cancel_enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
+		self.resolve_alias(ctx.model)
+			.cancel_enqueue_when(ctx, condition);
 	}
 
 	fn enqueue_when(&self, ctx: &mut ModelInitContext<'_>, condition: IntPropCond) {
@@ -520,6 +727,12 @@ impl IntInspectionActions<ModelInitContext<'_>> for View<IntVal> {
 impl BoolInitActions<ModelInitContext<'_>> for bool {
 	fn advise_when_fixed(&self, _: &mut ModelInitContext<'_>, _: u64) {
 		// Value does not change, so no advisor will ever be called
+	}
+	fn cancel_advise_when_fixed(&self, _: &mut ModelInitContext<'_>, _: u64) {
+		// A constant never subscribed, so there is nothing to cancel.
+	}
+	fn cancel_enqueue_when_fixed(&self, _: &mut ModelInitContext<'_>) {
+		// A constant never subscribed, so there is nothing to cancel.
 	}
 	fn enqueue_when_fixed(&self, ctx: &mut ModelInitContext<'_>) {
 		ctx.semantic_enqueue();

--- a/crates/huub/src/model/view/boolean.rs
+++ b/crates/huub/src/model/view/boolean.rs
@@ -16,7 +16,7 @@ use crate::{
 	},
 	constraints::{Conflict, NO_REASON, Nogood},
 	model::{
-		AdvRef, Advisor, ConRef, Model, SimplificationContext, SimplificationReasonSink,
+		Advisor, AdvisorId, ConstraintId, Model, SimplificationContext, SimplificationReasonSink,
 		decision::Decision,
 		expressions::BoolFormula,
 		resolved::Resolved,
@@ -134,7 +134,7 @@ impl Resolved<View<bool>> {
 							} else {
 								IntPropCond::Bounds
 							};
-							match ActivationAction::<AdvRef, ConRef>::from(act) {
+							match ActivationAction::<AdvisorId, ConstraintId>::from(act) {
 								ActivationAction::Advise(adv) => {
 									let def: &mut Advisor = &mut model.advisors[adv.index()];
 									def.condition = Some(match y.0 {

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -14,7 +14,7 @@ pub(crate) mod view;
 
 use std::{
 	any::Any,
-	cell::{RefCell, RefMut},
+	cell::{Ref, RefCell, RefMut},
 	fmt::Debug,
 	hash::Hash,
 	mem,
@@ -27,7 +27,7 @@ use bon::{Builder, bon};
 use itertools::Itertools;
 pub use pindakaas::solver::cadical::Cadical;
 use pindakaas::{
-	ClauseDatabase, ClauseDatabaseTools, Lit as RawLit, Unsatisfiable, VarRange,
+	ClauseDatabase, ClauseDatabaseTools, Lit as RawLit, Unsatisfiable, Var as RawVar, VarRange,
 	solver::{
 		Assumptions, FailedAssumptions, LearnCallback, SolveResult as SatSolveResult,
 		TerminateCallback,
@@ -40,6 +40,7 @@ use tracing::{debug, warn};
 
 pub use crate::solver::{
 	decision::{Decision, DecisionReference},
+	engine::{Engine, PropagatorId},
 	solution::{AnyView, Solution, Valuation, Value},
 	view::{DefaultView, View, boolean::BoolView, integer::IntView},
 };
@@ -50,12 +51,11 @@ use crate::{
 		IntInspectionActions, PostingActions, PropagationActions, PropagationContext,
 		ReasoningContext, ReasoningEngine, Trailed, TrailingActions,
 	},
-	constraints::{BoxedPropagator, Nogood},
+	constraints::{BoxedPropagator, Nogood, Propagator},
 	helpers::bytes::Bytes,
 	solver::{
 		branchers::BoxedBrancher,
 		decision::integer::{DirectStorage, IntDecision, LazyOrderStorage, OrderStorage},
-		engine::{Engine, PropRef},
 		initialization_context::InitializationContext,
 		queue::PropagatorInfo,
 	},
@@ -308,7 +308,7 @@ pub struct SolverStatistics {
 	pub sat_search_directives: u64,
 	/// Peak depth of the search tree.
 	pub peak_depth: u32,
-	/// Number of times a [`Propagator`](crate::constraints::Propagator)
+	/// Number of times a [`Propagator`]
 	/// instance was called.
 	pub cp_propagator_calls: u64,
 	/// Number of times the search was restarted from the root (as signalled by
@@ -1045,13 +1045,17 @@ impl<Sat: ExternalPropagation + Assumptions> Solver<Sat> {
 #[bon]
 impl<Sat: ExternalPropagation> Solver<Sat> {
 	/// Add a constraint propagator to the solver to enforce a constraint.
-	pub(crate) fn add_propagator(&mut self, propagator: BoxedPropagator, from_model: bool) {
+	pub(crate) fn add_propagator(
+		&mut self,
+		propagator: BoxedPropagator,
+		from_model: bool,
+	) -> PropagatorId {
 		let mut handle = self.engine.borrow_mut();
 		let engine = &mut *handle;
 		engine.propagators.push(propagator);
-		let prop_ref = PropRef::new(engine.propagators.len() - 1);
-		let mut ctx = InitializationContext::new(&mut engine.state, prop_ref);
-		engine.propagators[prop_ref.index()].initialize(&mut ctx);
+		let propagator_id = PropagatorId::new(engine.propagators.len() - 1);
+		let mut ctx = InitializationContext::new(&mut engine.state, propagator_id);
+		engine.propagators[propagator_id.index()].initialize(&mut ctx);
 		let priority = ctx.priority();
 		let enqueue = ctx.enqueue(from_model);
 		let new_observed = mem::take(&mut ctx.observed_variables);
@@ -1060,24 +1064,18 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 			priority,
 		});
 		debug_assert_eq!(
-			prop_ref.index(),
+			propagator_id.index(),
 			engine.state.propagator_queue.info.len() - 1
 		);
 		if enqueue {
 			engine
 				.state
 				.propagator_queue
-				.enqueue_propagator(prop_ref.raw());
+				.enqueue_propagator(propagator_id.raw());
 		}
 		drop(handle);
-		for v in new_observed {
-			// Ensure that the trail has a space to track the literal
-			{
-				self.engine.borrow_mut().state.trail.grow_to_boolvar(v);
-			}
-			// Ensure the SAT solver knows the literal is observed.
-			self.sat.add_observed_var(v);
-		}
+		self.observe_variables(new_observed);
+		propagator_id
 	}
 
 	/// Method used to add a no-good clause from a solution. This clause can be
@@ -1340,6 +1338,106 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 		iv.into()
 	}
 
+	/// Ensure that the trail and the SAT solver track the Boolean variables
+	/// that a propagator has just subscribed to.
+	fn observe_variables(&mut self, variables: Vec<RawVar>) {
+		for v in variables {
+			// Ensure that the trail has a space to track the literal
+			{
+				self.engine.borrow_mut().state.trail.grow_to_boolvar(v);
+			}
+			// Ensure the SAT solver knows the literal is observed.
+			self.sat.add_observed_var(v);
+		}
+	}
+
+	/// Returns the propagator with the given identifier, if it is of type `P`.
+	pub fn propagator<P: Propagator<Engine>>(&self, prop: PropagatorId) -> Option<Ref<'_, P>> {
+		Ref::filter_map(self.engine.borrow(), |engine| {
+			let propagator: &dyn Any = &*engine.propagators[prop.index()];
+			propagator.downcast_ref()
+		})
+		.ok()
+	}
+
+	/// Returns the propagator with the given identifier, if it is of type `P`,
+	/// allowing it to be given additional information about the problem.
+	///
+	/// Any decision variables that the propagator acquires this way are only
+	/// subscribed to once [`Solver::update_initialization`] is called.
+	///
+	/// # Warning
+	///
+	/// The returned guard borrows the propagation engine. It must be dropped
+	/// before any other method of the solver is called, or the solver will
+	/// panic.
+	///
+	/// ```
+	/// # use huub::{
+	/// # 	actions::{IntInitActions, IntPropCond, PostingActions, ReasoningEngine},
+	/// # 	constraints::Propagator,
+	/// # 	solver::{Engine, Solver, View},
+	/// # };
+	/// /// A propagator that is told which decisions to watch after it is posted.
+	/// #[derive(Clone, Debug)]
+	/// struct Watcher {
+	/// 	decisions: Vec<View<i64>>,
+	/// 	subscribed: usize,
+	/// }
+	///
+	/// impl Propagator<Engine> for Watcher {
+	/// 	fn initialize(
+	/// 		&mut self,
+	/// 		_ctx: &mut <Engine as ReasoningEngine>::InitializationContext<'_>,
+	/// 	) {
+	/// 	}
+	///
+	/// 	fn propagate(
+	/// 		&mut self,
+	/// 		_ctx: &mut <Engine as ReasoningEngine>::PropagationContext<'_>,
+	/// 	) -> Result<(), <Engine as ReasoningEngine>::Conflict> {
+	/// 		Ok(())
+	/// 	}
+	///
+	/// 	fn update_initialization(
+	/// 		&mut self,
+	/// 		ctx: &mut <Engine as ReasoningEngine>::InitializationContext<'_>,
+	/// 	) {
+	/// 		// Only the decisions that have not been subscribed to yet.
+	/// 		for dec in self.decisions.iter().skip(self.subscribed) {
+	/// 			dec.enqueue_when(ctx, IntPropCond::Bounds);
+	/// 		}
+	/// 		self.subscribed = self.decisions.len();
+	/// 	}
+	/// }
+	///
+	/// let mut solver: Solver = Solver::default();
+	/// let x = solver.new_int_decision(1..=10).view();
+	/// let watcher = solver.add_propagator(Box::new(Watcher {
+	/// 	decisions: Vec::new(),
+	/// 	subscribed: 0,
+	/// }));
+	///
+	/// // The guard is dropped at the end of the statement, so the solver can be
+	/// // asked to update the initialization on the next one.
+	/// solver
+	/// 	.propagator_mut::<Watcher>(watcher)
+	/// 	.unwrap()
+	/// 	.decisions
+	/// 	.push(x);
+	/// solver.update_initialization(watcher);
+	/// ```
+	pub fn propagator_mut<P: Propagator<Engine>>(
+		&mut self,
+		prop: PropagatorId,
+	) -> Option<RefMut<'_, P>> {
+		RefMut::filter_map(self.engine.borrow_mut(), |engine| {
+			let propagator: &mut dyn Any = &mut *engine.propagators[prop.index()];
+			propagator.downcast_mut()
+		})
+		.ok()
+	}
+
 	/// Set the overarching search strategy to use during solving.
 	pub fn set_search_strategy(&mut self, strategy: SearchStrategy) {
 		self.engine.borrow_mut().state.set_search_strategy(strategy);
@@ -1358,6 +1456,24 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 			eager_literals: cp_stats.eager_literals,
 			lazy_literals: cp_stats.lazy_literals,
 		}
+	}
+
+	/// Ask the propagator to subscribe to the decision variables it has
+	/// acquired since it was posted.
+	pub fn update_initialization(&mut self, prop: PropagatorId) {
+		let mut handle = self.engine.borrow_mut();
+		let engine = &mut *handle;
+		let mut ctx = InitializationContext::update(&mut engine.state, prop);
+		engine.propagators[prop.index()].update_initialization(&mut ctx);
+		let priority = ctx.priority();
+		let enqueue = ctx.enqueue(false);
+		let new_observed = mem::take(&mut ctx.observed_variables);
+		engine.state.propagator_queue.info[prop.index()].priority = priority;
+		if enqueue {
+			engine.state.propagator_queue.enqueue_propagator(prop.raw());
+		}
+		drop(handle);
+		self.observe_variables(new_observed);
 	}
 }
 
@@ -1504,6 +1620,8 @@ impl<Sat: Default + ExternalPropagation + LearnCallback> Default for Solver<Sat>
 }
 
 impl<Sat: ExternalPropagation> PostingActions for Solver<Sat> {
+	type PropagatorId = PropagatorId;
+
 	fn add_clause(
 		&mut self,
 		clause: impl IntoIterator<Item = Self::Atom>,
@@ -1511,8 +1629,12 @@ impl<Sat: ExternalPropagation> PostingActions for Solver<Sat> {
 		self.add_clause(clause)
 	}
 
-	fn add_propagator(&mut self, propagator: BoxedPropagator) {
-		self.add_propagator(propagator, false);
+	fn add_propagator(&mut self, propagator: BoxedPropagator) -> PropagatorId {
+		self.add_propagator(propagator, false)
+	}
+
+	fn update_initialization(&mut self, prop: PropagatorId) {
+		Solver::update_initialization(self, prop);
 	}
 }
 
@@ -1596,7 +1718,64 @@ impl AddAssign for SolverStatistics {
 
 #[cfg(test)]
 mod tests {
-	use crate::solver::{Solver, view::View};
+	use std::{cell::RefCell, rc::Rc};
+
+	use crate::{
+		IntVal,
+		actions::{
+			BrancherInitActions, IntDecisionActions, IntEvent, IntInitActions, IntPropCond,
+			ReasoningEngine,
+		},
+		constraints::Propagator,
+		solver::{
+			IntLitMeaning, Solver,
+			engine::{Engine, PropagatorId},
+			view::View,
+		},
+	};
+
+	/// A propagator that acquires the decisions it constrains after it has been
+	/// posted, and only ever subscribes to the ones it has not seen before.
+	#[derive(Clone, Debug)]
+	struct GrowingPropagator {
+		/// The decisions the propagator has been given so far.
+		decisions: Vec<View<IntVal>>,
+		/// The number of decisions that have already been subscribed to.
+		subscribed: usize,
+		/// Whether the next subscription update should cancel every
+		/// subscription instead of adding the missing ones.
+		cancel: bool,
+		/// Counts how often the propagator has been advised.
+		advised: Rc<RefCell<usize>>,
+	}
+
+	/// Give the propagator an additional decision to constrain.
+	fn grow(slv: &mut Solver, prop: PropagatorId, dec: View<IntVal>) {
+		slv.propagator_mut::<GrowingPropagator>(prop)
+			.expect("propagator is a GrowingPropagator")
+			.decisions
+			.push(dec);
+	}
+
+	/// Create a solver with a single integer decision that is forced to take a
+	/// value above its lower bound, alongside a propagator watching nothing.
+	fn growing_solver() -> (Solver, View<IntVal>, PropagatorId, Rc<RefCell<usize>>) {
+		let mut slv: Solver = Solver::default();
+		let x = slv.new_int_decision(0..=10).view();
+		let advised = Rc::new(RefCell::new(0));
+		let prop = slv.add_propagator(
+			Box::new(GrowingPropagator {
+				decisions: Vec::new(),
+				subscribed: 0,
+				cancel: false,
+				advised: Rc::clone(&advised),
+			}),
+			false,
+		);
+		let above = x.lit(&mut slv, IntLitMeaning::GreaterEq(5));
+		slv.add_clause([above]).expect("add_clause failed");
+		(slv, x, prop, advised)
+	}
 
 	/// The empty clause is unconditionally unsatisfiable, reported as an
 	/// unconditional nogood.
@@ -1608,5 +1787,96 @@ mod tests {
 			.unwrap_err();
 		assert!(nogood.is_unconditional());
 		assert_eq!(nogood.len(), 0);
+	}
+
+	/// A propagator that gains a decision after it was posted is only advised
+	/// of that decision once its subscriptions have been refreshed.
+	#[test]
+	fn test_solver_acquired_decision_subscription() {
+		let (mut slv, x, prop, advised) = growing_solver();
+		assert_eq!(slv.num_subscribers(x), 0);
+
+		grow(&mut slv, prop, x);
+		assert_eq!(slv.num_subscribers(x), 0);
+
+		slv.update_initialization(prop);
+		assert_eq!(slv.num_subscribers(x), 1);
+
+		let _ = slv.solve().satisfy();
+		assert!(*advised.borrow() > 0);
+	}
+
+	/// A propagator that has not refreshed its subscriptions is never advised
+	/// of the decisions it acquired.
+	#[test]
+	fn test_solver_acquired_decision_without_update() {
+		let (mut slv, x, prop, advised) = growing_solver();
+		grow(&mut slv, prop, x);
+
+		let _ = slv.solve().satisfy();
+		assert_eq!(*advised.borrow(), 0);
+	}
+
+	/// A propagator that cancels its subscriptions is no longer advised.
+	#[test]
+	fn test_solver_cancelled_subscription() {
+		let (mut slv, x, prop, advised) = growing_solver();
+		grow(&mut slv, prop, x);
+		slv.update_initialization(prop);
+		assert_eq!(slv.num_subscribers(x), 1);
+
+		slv.propagator_mut::<GrowingPropagator>(prop)
+			.expect("propagator is a GrowingPropagator")
+			.cancel = true;
+		slv.update_initialization(prop);
+		assert_eq!(slv.num_subscribers(x), 0);
+
+		let _ = slv.solve().satisfy();
+		assert_eq!(*advised.borrow(), 0);
+	}
+
+	impl Propagator<Engine> for GrowingPropagator {
+		fn advise_of_int_change(
+			&mut self,
+			_context: &mut <Engine as ReasoningEngine>::NotificationContext<'_>,
+			_data: u64,
+			_event: IntEvent,
+		) -> bool {
+			*self.advised.borrow_mut() += 1;
+			false
+		}
+
+		fn initialize(
+			&mut self,
+			_context: &mut <Engine as ReasoningEngine>::InitializationContext<'_>,
+		) {
+			// All subscriptions are made in `update_initialization`, which the
+			// code that grows this propagator is expected to trigger.
+		}
+
+		fn propagate(
+			&mut self,
+			_context: &mut <Engine as ReasoningEngine>::PropagationContext<'_>,
+		) -> Result<(), <Engine as ReasoningEngine>::Conflict> {
+			Ok(())
+		}
+
+		fn update_initialization(
+			&mut self,
+			context: &mut <Engine as ReasoningEngine>::InitializationContext<'_>,
+		) {
+			if self.cancel {
+				for (i, dec) in self.decisions.iter().enumerate().take(self.subscribed) {
+					dec.cancel_advise_when(context, IntPropCond::Bounds, i as u64);
+				}
+				self.subscribed = 0;
+				self.cancel = false;
+				return;
+			}
+			for (i, dec) in self.decisions.iter().enumerate().skip(self.subscribed) {
+				dec.advise_when(context, IntPropCond::Bounds, i as u64);
+			}
+			self.subscribed = self.decisions.len();
+		}
 	}
 }

--- a/crates/huub/src/solver/activation_list.rs
+++ b/crates/huub/src/solver/activation_list.rs
@@ -8,19 +8,20 @@ use std::{
 
 use crate::{
 	actions::{IntEvent, IntPropCond},
-	model::{self, ConRef},
-	solver::engine::{self, PropRef},
+	model::{self, ConstraintId},
+	solver::engine::{self, PropagatorId},
 };
 
 /// Possible actions to be triggered by the activation list.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum ActivationAction<A, P> {
-	/// When activated, advise the propagator with the given [`PropRef`] of the
-	/// event that triggered the activation. If the advisor method returns
+	/// When activated, advise the propagator with the given [`PropagatorId`] of
+	/// the event that triggered the activation. If the advisor method returns
 	/// `true`, then enqueue the propagator if it is not already in the queue.
 	Advise(A),
-	/// When activated, simply add the propagator with the given [`PropRef`] to
-	/// the propagator queue if it is not already in the queue.
+	/// When activated, simply add the propagator with the given
+	/// [`PropagatorId`] to the propagator queue if it is not already in the
+	/// queue.
 	Enqueue(P),
 }
 
@@ -59,28 +60,28 @@ pub(crate) struct ActivationList {
 	domain_idx: u32,
 }
 
-impl From<ActivationActionS> for ActivationAction<engine::AdvRef, PropRef> {
+impl From<ActivationActionS> for ActivationAction<engine::AdvisorId, PropagatorId> {
 	fn from(value: ActivationActionS) -> Self {
 		if (value.0 & 0b1) == 1 {
-			Self::Advise(engine::AdvRef::from_raw(value.0 >> 1))
+			Self::Advise(engine::AdvisorId::from_raw(value.0 >> 1))
 		} else {
-			Self::Enqueue(PropRef::from_raw(value.0 >> 1))
+			Self::Enqueue(PropagatorId::from_raw(value.0 >> 1))
 		}
 	}
 }
 
-impl From<ActivationActionS> for ActivationAction<model::AdvRef, ConRef> {
+impl From<ActivationActionS> for ActivationAction<model::AdvisorId, ConstraintId> {
 	fn from(value: ActivationActionS) -> Self {
 		if (value.0 & 0b1) == 1 {
-			Self::Advise(model::AdvRef::from_raw(value.0 >> 1))
+			Self::Advise(model::AdvisorId::from_raw(value.0 >> 1))
 		} else {
-			Self::Enqueue(ConRef::from_raw(value.0 >> 1))
+			Self::Enqueue(ConstraintId::from_raw(value.0 >> 1))
 		}
 	}
 }
 
-impl From<ActivationAction<engine::AdvRef, PropRef>> for ActivationActionS {
-	fn from(value: ActivationAction<engine::AdvRef, PropRef>) -> Self {
+impl From<ActivationAction<engine::AdvisorId, PropagatorId>> for ActivationActionS {
+	fn from(value: ActivationAction<engine::AdvisorId, PropagatorId>) -> Self {
 		Self(match value {
 			ActivationAction::Advise(advisor) => (advisor.raw() << 1) | 0b1,
 			ActivationAction::Enqueue(prop) => prop.raw() << 1,
@@ -88,8 +89,8 @@ impl From<ActivationAction<engine::AdvRef, PropRef>> for ActivationActionS {
 	}
 }
 
-impl From<ActivationAction<model::AdvRef, ConRef>> for ActivationActionS {
-	fn from(value: ActivationAction<model::AdvRef, ConRef>) -> Self {
+impl From<ActivationAction<model::AdvisorId, ConstraintId>> for ActivationActionS {
+	fn from(value: ActivationAction<model::AdvisorId, ConstraintId>) -> Self {
 		Self(match value {
 			ActivationAction::Advise(advisor) => (advisor.raw() << 1) | 0b1,
 			ActivationAction::Enqueue(prop) => prop.raw() << 1,
@@ -168,7 +169,7 @@ impl ActivationList {
 	pub(crate) fn extend(&mut self, other: Self) {
 		for (i, act) in other.activations.into_iter().enumerate() {
 			let i = i as u32;
-			let act: ActivationAction<engine::AdvRef, PropRef> = act.into();
+			let act: ActivationAction<engine::AdvisorId, PropagatorId> = act.into();
 			self.add(
 				act,
 				if i < other.lower_bound_idx {
@@ -219,6 +220,68 @@ impl ActivationList {
 		}
 	}
 
+	/// Remove the first activation subscribed with the given propagation
+	/// condition for which `matches` returns `true`, and return whether such an
+	/// activation was found.
+	///
+	/// An activation must be removed using the same [`IntPropCond`] with which
+	/// it was added, since an activation only ever lives in the block of the
+	/// condition it subscribed with.
+	pub(crate) fn remove(
+		&mut self,
+		condition: IntPropCond,
+		mut matches: impl FnMut(ActivationActionS) -> bool,
+	) -> bool {
+		// The index just past the last activation of each block, in the order in
+		// which the blocks are stored.
+		let ends = [
+			self.lower_bound_idx,
+			self.upper_bound_idx,
+			self.bounds_idx,
+			self.domain_idx,
+			self.activations.len() as u32,
+		];
+		let block = match condition {
+			IntPropCond::Fixed => 0,
+			IntPropCond::LowerBound => 1,
+			IntPropCond::UpperBound => 2,
+			IntPropCond::Bounds => 3,
+			IntPropCond::Domain => 4,
+		};
+		let start = if block == 0 { 0 } else { ends[block - 1] };
+		let Some(pos) = (start..ends[block]).find(|&i| matches(self.activations[i as usize]))
+		else {
+			return false;
+		};
+
+		// The activations within a block are unordered, so the activation can be
+		// swapped with the last one of its own block. That leaves it at the end
+		// of the block, from where the same swap with the next block moves it
+		// along, until it reaches the end of the list and can be removed.
+		let mut hole = pos as usize;
+		for &end in &ends[block..] {
+			let last = end as usize - 1;
+			self.activations.swap(hole, last);
+			hole = last;
+		}
+		debug_assert_eq!(hole, self.activations.len() - 1);
+		let _ = self.activations.pop();
+
+		// Every boundary from the end of the block onwards moves down by one.
+		for idx in [
+			&mut self.lower_bound_idx,
+			&mut self.upper_bound_idx,
+			&mut self.bounds_idx,
+			&mut self.domain_idx,
+		]
+		.into_iter()
+		.skip(block)
+		{
+			*idx -= 1;
+		}
+		true
+	}
+
 	/// Return the number of subscriptions to the decision variable.
 	pub(crate) fn subscription_count(&self) -> u32 {
 		self.activations.len() as u32
@@ -255,19 +318,57 @@ mod tests {
 	use crate::{
 		actions::{IntEvent, IntPropCond},
 		solver::{
-			activation_list::{ActivationAction, ActivationList},
-			engine::PropRef,
+			activation_list::{ActivationAction, ActivationActionS, ActivationList},
+			engine::{AdvisorId, PropagatorId},
 		},
 	};
+
+	/// Assert that `list` reports exactly the propagators of `present` for
+	/// every integer event, based on the propagation condition each subscribed
+	/// with.
+	fn assert_activations(list: &ActivationList, present: &[(PropagatorId, IntPropCond)]) {
+		let triggers = |cond: IntPropCond, event: IntEvent| match event {
+			IntEvent::Fixed => true,
+			IntEvent::Bounds => cond != IntPropCond::Fixed,
+			IntEvent::LowerBound => matches!(
+				cond,
+				IntPropCond::LowerBound | IntPropCond::Bounds | IntPropCond::Domain
+			),
+			IntEvent::UpperBound => matches!(
+				cond,
+				IntPropCond::UpperBound | IntPropCond::Bounds | IntPropCond::Domain
+			),
+			IntEvent::Domain => cond == IntPropCond::Domain,
+		};
+		assert_eq!(list.subscription_count() as usize, present.len());
+		for event in [
+			IntEvent::Fixed,
+			IntEvent::Bounds,
+			IntEvent::LowerBound,
+			IntEvent::UpperBound,
+			IntEvent::Domain,
+		] {
+			let mut actual = FxHashSet::default();
+			list.for_each_activated_by(event, |a: ActivationAction<AdvisorId, PropagatorId>| {
+				let _ = actual.insert(a);
+			});
+			let expected: FxHashSet<ActivationAction<AdvisorId, PropagatorId>> = present
+				.iter()
+				.filter(|&&(_, cond)| triggers(cond, event))
+				.map(|&(prop, _)| ActivationAction::Enqueue(prop))
+				.collect();
+			assert_eq!(actual, expected, "activations of {event:?} for {present:?}");
+		}
+	}
 
 	#[test]
 	fn test_activation_list() {
 		let props = [
-			(PropRef::new(0), IntPropCond::Fixed),
-			(PropRef::new(1), IntPropCond::LowerBound),
-			(PropRef::new(2), IntPropCond::UpperBound),
-			(PropRef::new(3), IntPropCond::Bounds),
-			(PropRef::new(4), IntPropCond::Domain),
+			(PropagatorId::new(0), IntPropCond::Fixed),
+			(PropagatorId::new(1), IntPropCond::LowerBound),
+			(PropagatorId::new(2), IntPropCond::UpperBound),
+			(PropagatorId::new(3), IntPropCond::Bounds),
+			(PropagatorId::new(4), IntPropCond::Domain),
 		];
 
 		for list in props.iter().permutations(5) {
@@ -282,11 +383,11 @@ mod tests {
 			assert_eq!(
 				fixed,
 				FxHashSet::from_iter([
-					ActivationAction::Enqueue(PropRef::new(0)),
-					ActivationAction::Enqueue(PropRef::new(1)),
-					ActivationAction::Enqueue(PropRef::new(2)),
-					ActivationAction::Enqueue(PropRef::new(3)),
-					ActivationAction::Enqueue(PropRef::new(4))
+					ActivationAction::Enqueue(PropagatorId::new(0)),
+					ActivationAction::Enqueue(PropagatorId::new(1)),
+					ActivationAction::Enqueue(PropagatorId::new(2)),
+					ActivationAction::Enqueue(PropagatorId::new(3)),
+					ActivationAction::Enqueue(PropagatorId::new(4))
 				])
 			);
 			let mut bounds = FxHashSet::default();
@@ -296,10 +397,10 @@ mod tests {
 			assert_eq!(
 				bounds,
 				FxHashSet::from_iter([
-					ActivationAction::Enqueue(PropRef::new(1)),
-					ActivationAction::Enqueue(PropRef::new(2)),
-					ActivationAction::Enqueue(PropRef::new(3)),
-					ActivationAction::Enqueue(PropRef::new(4))
+					ActivationAction::Enqueue(PropagatorId::new(1)),
+					ActivationAction::Enqueue(PropagatorId::new(2)),
+					ActivationAction::Enqueue(PropagatorId::new(3)),
+					ActivationAction::Enqueue(PropagatorId::new(4))
 				])
 			);
 			let mut lower_bound = FxHashSet::default();
@@ -312,9 +413,9 @@ mod tests {
 			assert_eq!(
 				lower_bound,
 				FxHashSet::from_iter([
-					ActivationAction::Enqueue(PropRef::new(1)),
-					ActivationAction::Enqueue(PropRef::new(3)),
-					ActivationAction::Enqueue(PropRef::new(4))
+					ActivationAction::Enqueue(PropagatorId::new(1)),
+					ActivationAction::Enqueue(PropagatorId::new(3)),
+					ActivationAction::Enqueue(PropagatorId::new(4))
 				])
 			);
 			let mut upper_bound = FxHashSet::default();
@@ -327,9 +428,9 @@ mod tests {
 			assert_eq!(
 				upper_bound,
 				FxHashSet::from_iter([
-					ActivationAction::Enqueue(PropRef::new(2)),
-					ActivationAction::Enqueue(PropRef::new(3)),
-					ActivationAction::Enqueue(PropRef::new(4))
+					ActivationAction::Enqueue(PropagatorId::new(2)),
+					ActivationAction::Enqueue(PropagatorId::new(3)),
+					ActivationAction::Enqueue(PropagatorId::new(4))
 				])
 			);
 			let mut domain = FxHashSet::default();
@@ -338,8 +439,55 @@ mod tests {
 			});
 			assert_eq!(
 				domain,
-				FxHashSet::from_iter([ActivationAction::Enqueue(PropRef::new(4))])
+				FxHashSet::from_iter([ActivationAction::Enqueue(PropagatorId::new(4))])
 			);
+		}
+	}
+
+	#[test]
+	fn test_activation_list_remove() {
+		let props = [
+			(PropagatorId::new(0), IntPropCond::Fixed),
+			(PropagatorId::new(1), IntPropCond::LowerBound),
+			(PropagatorId::new(2), IntPropCond::UpperBound),
+			(PropagatorId::new(3), IntPropCond::Bounds),
+			(PropagatorId::new(4), IntPropCond::Domain),
+		];
+		let target =
+			|prop| ActivationActionS::from(ActivationAction::<AdvisorId, _>::Enqueue(prop));
+
+		for order in props.iter().permutations(props.len()) {
+			let mut full = ActivationList::default();
+			for &&(prop, cond) in &order {
+				full.add(ActivationAction::<AdvisorId, _>::Enqueue(prop), cond);
+			}
+
+			for &&(prop, cond) in &order {
+				// An activation is only ever found in the block of the condition
+				// it subscribed with.
+				for &(_, other) in props.iter().filter(|&&(_, c)| c != cond) {
+					assert!(!full.clone().remove(other, |a| a == target(prop)));
+				}
+
+				let mut list = full.clone();
+				assert!(list.remove(cond, |a| a == target(prop)));
+				assert!(
+					!list.remove(cond, |a| a == target(prop)),
+					"{prop:?} was still subscribed after being removed"
+				);
+				let present = props
+					.iter()
+					.filter(|&&(p, _)| p != prop)
+					.copied()
+					.collect_vec();
+				assert_activations(&list, &present);
+			}
+
+			// Removing every subscription empties the list.
+			for &&(prop, cond) in &order {
+				assert!(full.remove(cond, |a| a == target(prop)));
+			}
+			assert_activations(&full, &[]);
 		}
 	}
 }

--- a/crates/huub/src/solver/branchers.rs
+++ b/crates/huub/src/solver/branchers.rs
@@ -636,9 +636,9 @@ mod tests {
 	#[test]
 	fn test_domain_median() {
 		// Odd number of values: the single middle value.
-		assert_eq!(domain_median(&IntSet::from_iter([1..=5])), 3);
+		assert_eq!(domain_median(&IntSet::from(1..=5)), 3);
 		// Even number of values: the smaller of the two middle values.
-		assert_eq!(domain_median(&IntSet::from_iter([1..=4])), 2);
+		assert_eq!(domain_median(&IntSet::from(1..=4)), 2);
 		// Holes are skipped: the median is the middle element, not the bound
 		// midpoint (which would be `4` and `3` respectively here).
 		assert_eq!(domain_median(&IntSet::from_iter([1..=3, 7..=8])), 3);
@@ -649,9 +649,9 @@ mod tests {
 	#[test]
 	fn test_domain_middle() {
 		// Mean of the bounds is in the domain.
-		assert_eq!(domain_middle(&IntSet::from_iter([0..=10])), 5);
+		assert_eq!(domain_middle(&IntSet::from(0..=10)), 5);
 		// Mean falls between two values: the smaller is preferred.
-		assert_eq!(domain_middle(&IntSet::from_iter([0..=9])), 4);
+		assert_eq!(domain_middle(&IntSet::from(0..=9)), 4);
 		// The value closest to the mean of the bounds, regardless of element
 		// counts: the mean `4.5` is nearest to `3` (not the median `7`).
 		assert_eq!(domain_middle(&IntSet::from_iter([0..=3, 7..=9])), 3);

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -57,10 +57,6 @@ use crate::{
 	},
 };
 
-/// Identifies an advisor in the [`State`]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct AdvRef(u32);
-
 /// Definition of an [`Advisor`] giving the information about the [`View`]
 /// subscribed to and the way in which to advise the propagator.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -72,10 +68,15 @@ pub(crate) struct AdvisorDef {
 	/// Whether the advice is on an [`IntView`] with a negative coefficient.
 	pub(crate) negated: bool,
 	/// The propagator being advised.
-	pub(crate) propagator: PropRef,
+	pub(crate) propagator: PropagatorId,
 }
 
-/// A propagation engine implementing the [`Propagator`] trait.
+/// Identifies an advisor in the [`State`]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct AdvisorId(u32);
+
+/// A propagation engine implementing the
+/// [`Propagator`](crate::constraints::Propagator) trait.
 #[derive(Clone, Debug, Default)]
 pub struct Engine {
 	/// Storage of the propagators.
@@ -159,9 +160,16 @@ pub(crate) struct LitPropagation {
 	/// This event is used to schedule further propagators.
 	pub(crate) event: Option<(Decision<IntVal>, IntEvent)>,
 }
-/// Identifies an propagator in a [`Solver`]
+
+/// Identifies a propagator in a [`Solver`](crate::solver::Solver).
+///
+/// An identifier is returned when a propagator is posted, and can be used to
+/// inspect the propagator using
+/// [`Solver::propagator`](crate::solver::Solver::propagator), or to refresh its
+/// subscriptions using
+/// [`crate::actions::PostingActions::update_initialization`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct PropRef(u32);
+pub struct PropagatorId(u32);
 
 /// Internal state representation of the propagation engine disconnected from
 /// the storage of the propagators and branchers.
@@ -214,7 +222,7 @@ pub struct State {
 	/// Advisor data storage.
 	pub(crate) advisors: Vec<AdvisorDef>,
 	/// List of propagators to advise of backtracking.
-	pub(crate) notify_of_backtrack: Vec<PropRef>,
+	pub(crate) notify_of_backtrack: Vec<PropagatorId>,
 	/// Boolean variable enqueueing information.
 	pub(crate) bool_activation: FxHashMap<RawVar, Vec<ActivationActionS>>,
 	/// Integer variable enqueueing information.
@@ -231,7 +239,7 @@ pub struct State {
 	pub(crate) check_int_fixed: Vec<(Decision<IntVal>, IntVal)>,
 }
 
-impl AdvRef {
+impl AdvisorId {
 	/// Recreate the advisor reference from a raw value.
 	pub(crate) fn from_raw(raw: u32) -> Self {
 		debug_assert!(raw <= i32::MAX as u32);
@@ -355,7 +363,7 @@ impl Engine {
 	/// If `negated` is true, then the event is negated.
 	pub(crate) fn notify_int_advisor(
 		&mut self,
-		prop: PropRef,
+		prop: PropagatorId,
 		event: IntEvent,
 		data: u64,
 		negated: bool,
@@ -373,7 +381,12 @@ impl Engine {
 	///
 	/// If `bool2int` is true, then the literal is transformed into an integer
 	/// view.
-	pub(crate) fn notify_lit_advisor(&mut self, prop: PropRef, data: u64, bool2int: bool) -> bool {
+	pub(crate) fn notify_lit_advisor(
+		&mut self,
+		prop: PropagatorId,
+		data: u64,
+		bool2int: bool,
+	) -> bool {
 		if bool2int {
 			self.propagators[prop.index()].advise_of_int_change(
 				&mut self.state,
@@ -443,7 +456,7 @@ impl PropagatorExtension for Engine {
 				let activation = mem::take(&mut ctx.state.int_activation[r.idx()]);
 				activation.for_each_activated_by(IntEvent::Fixed, |action| {
 					let prop = match action {
-						ActivationAction::Advise::<AdvRef, _>(adv) => {
+						ActivationAction::Advise::<AdvisorId, _>(adv) => {
 							let &AdvisorDef {
 								data, propagator, ..
 							} = &ctx.state.advisors[adv.index()];
@@ -595,7 +608,7 @@ impl PropagatorExtension for Engine {
 			{
 				for &action in &activations {
 					let prop = match action.into() {
-						ActivationAction::Advise::<AdvRef, _>(adv) => {
+						ActivationAction::Advise::<AdvisorId, _>(adv) => {
 							let &AdvisorDef {
 								bool2int,
 								data,
@@ -698,7 +711,7 @@ impl PropagatorExtension for Engine {
 				let activations = mem::take(&mut self.state.int_activation[iv.idx()]);
 				activations.for_each_activated_by(event, |action| {
 					let prop = match action {
-						ActivationAction::Advise::<AdvRef, _>(adv) => {
+						ActivationAction::Advise::<AdvisorId, _>(adv) => {
 							let &AdvisorDef {
 								negated,
 								data,
@@ -962,9 +975,9 @@ impl ReasonActions<View<bool>> for EngineReasonSink<'_> {
 	}
 }
 
-impl PropRef {
+impl PropagatorId {
 	/// Invalid propagator reference to be used as a placeholder.
-	pub(crate) const INVALID: PropRef = PropRef(i32::MAX as u32);
+	pub(crate) const INVALID: PropagatorId = PropagatorId(i32::MAX as u32);
 
 	/// Recreate the propagator reference from a raw value.
 	pub(crate) fn from_raw(raw: u32) -> Self {

--- a/crates/huub/src/solver/initialization_context.rs
+++ b/crates/huub/src/solver/initialization_context.rs
@@ -15,9 +15,9 @@ use crate::{
 	},
 	solver::{
 		IntLitMeaning,
-		activation_list::ActivationAction,
+		activation_list::{ActivationAction, ActivationActionS},
 		decision::Decision,
-		engine::{AdvRef, AdvisorDef, Engine, PropRef, State},
+		engine::{AdvisorDef, AdvisorId, Engine, PropagatorId, State},
 		queue::PriorityLevel,
 		view::{View, boolean::BoolView, integer::IntView},
 	},
@@ -32,7 +32,7 @@ pub struct InitializationContext<'a> {
 	state: &'a mut State,
 	/// Internal propagator reference used to add propagator to activations
 	/// lists.
-	prop: PropRef,
+	prop: PropagatorId,
 	/// The priority level at which the propagator will be enqueued.
 	priority: PriorityLevel,
 	/// Whether to enqueue `on_change` subscriptions of the propagator would
@@ -45,6 +45,23 @@ pub struct InitializationContext<'a> {
 	pub(crate) observed_variables: Vec<RawVar>,
 }
 
+/// Whether the activation is an advisor of `prop` that was registered with the
+/// given data.
+fn is_advisor_of(
+	advisors: &[AdvisorDef],
+	act: ActivationActionS,
+	prop: PropagatorId,
+	data: u64,
+) -> bool {
+	match act.into() {
+		ActivationAction::<AdvisorId, PropagatorId>::Advise(adv) => {
+			let advisor = &advisors[adv.index()];
+			advisor.propagator == prop && advisor.data == data
+		}
+		ActivationAction::Enqueue(_) => false,
+	}
+}
+
 impl BoolInitActions<InitializationContext<'_>> for Decision<bool> {
 	fn advise_when_fixed(&self, ctx: &mut InitializationContext<'_>, data: u64) {
 		if self.val(ctx.state).is_some() {
@@ -54,6 +71,14 @@ impl BoolInitActions<InitializationContext<'_>> for Decision<bool> {
 		// Otherwise, add the advisor to the engine
 		ctx.add_lit_advisor(*self, data, false);
 	}
+	fn cancel_advise_when_fixed(&self, ctx: &mut InitializationContext<'_>, data: u64) {
+		ctx.cancel_lit_advisor(*self, data);
+	}
+
+	fn cancel_enqueue_when_fixed(&self, ctx: &mut InitializationContext<'_>) {
+		ctx.cancel_lit_enqueue(*self);
+	}
+
 	fn enqueue_when_fixed(&self, ctx: &mut InitializationContext<'_>) {
 		if self.val(ctx.state).is_some() {
 			ctx.semantic_enqueue = true;
@@ -79,6 +104,20 @@ impl BoolInspectionActions<InitializationContext<'_>> for Decision<bool> {
 impl IntInitActions<InitializationContext<'_>> for Decision<IntVal> {
 	fn advise_when(&self, ctx: &mut InitializationContext<'_>, condition: IntPropCond, data: u64) {
 		View::from(*self).advise_when(ctx, condition, data);
+	}
+
+	fn cancel_advise_when(
+		&self,
+		ctx: &mut InitializationContext<'_>,
+		condition: IntPropCond,
+		data: u64,
+	) {
+		View::from(*self).cancel_advise_when(ctx, condition, data);
+	}
+
+	fn cancel_enqueue_when(&self, ctx: &mut InitializationContext<'_>, condition: IntPropCond) {
+		let target = ActivationActionS::from(ActivationAction::<AdvisorId, _>::Enqueue(ctx.prop));
+		let _ = ctx.state.int_activation[self.idx()].remove(condition, |act| act == target);
 	}
 
 	fn enqueue_when(&self, ctx: &mut InitializationContext<'_>, condition: IntPropCond) {
@@ -159,7 +198,7 @@ impl InitializationContext<'_> {
 			negated: false,
 			propagator: self.prop,
 		});
-		let adv = AdvRef::new(self.state.advisors.len() - 1);
+		let adv = AdvisorId::new(self.state.advisors.len() - 1);
 		self.state
 			.bool_activation
 			.entry(lit.0.var())
@@ -167,7 +206,44 @@ impl InitializationContext<'_> {
 				self.observed_variables.push(lit.0.var());
 				Vec::new()
 			})
-			.push(ActivationAction::<_, PropRef>::Advise(adv).into());
+			.push(ActivationAction::<_, PropagatorId>::Advise(adv).into());
+	}
+
+	/// Internal method used to remove an advisor of the propagator being
+	/// initialized from the activation list of an integer decision variable.
+	fn cancel_int_advisor(&mut self, var: Decision<IntVal>, condition: IntPropCond, data: u64) {
+		let prop = self.prop;
+		let advisors = &self.state.advisors;
+		let _ = self.state.int_activation[var.idx()]
+			.remove(condition, |act| is_advisor_of(advisors, act, prop, data));
+	}
+
+	/// Internal method used to remove an advisor of the propagator being
+	/// initialized from the activation list of a [`RawLit`].
+	fn cancel_lit_advisor(&mut self, lit: Decision<bool>, data: u64) {
+		let prop = self.prop;
+		let advisors = &self.state.advisors;
+		let Some(activations) = self.state.bool_activation.get_mut(&lit.0.var()) else {
+			return;
+		};
+		if let Some(pos) = activations
+			.iter()
+			.position(|&act| is_advisor_of(advisors, act, prop, data))
+		{
+			let _ = activations.swap_remove(pos);
+		}
+	}
+
+	/// Internal method used to remove the enqueue subscription of the
+	/// propagator being initialized from the activation list of a [`RawLit`].
+	fn cancel_lit_enqueue(&mut self, lit: Decision<bool>) {
+		let target = ActivationActionS::from(ActivationAction::<AdvisorId, _>::Enqueue(self.prop));
+		let Some(activations) = self.state.bool_activation.get_mut(&lit.0.var()) else {
+			return;
+		};
+		if let Some(pos) = activations.iter().position(|&act| act == target) {
+			let _ = activations.swap_remove(pos);
+		}
 	}
 }
 
@@ -188,8 +264,8 @@ impl<'a> InitializationContext<'a> {
 		}
 	}
 	/// Create a new posting context for a [`Solver`] to post a [`Propagator`]
-	/// that will be referred to using [`PropRef`].
-	pub(crate) fn new(state: &'a mut State, prop: PropRef) -> Self {
+	/// that will be referred to using [`PropagatorId`].
+	pub(crate) fn new(state: &'a mut State, prop: PropagatorId) -> Self {
 		Self {
 			state,
 			prop,
@@ -204,11 +280,34 @@ impl<'a> InitializationContext<'a> {
 	pub(crate) fn priority(&self) -> PriorityLevel {
 		self.priority
 	}
+
+	/// Create a new context to revise the subscriptions of a propagator that
+	/// has already been posted.
+	///
+	/// Unlike [`Self::new`], the context starts from the priority the
+	/// propagator was given when it was posted, so that a propagator that does
+	/// not set its priority again keeps the one it has.
+	pub(crate) fn update(state: &'a mut State, prop: PropagatorId) -> Self {
+		let priority = state.propagator_queue.info[prop.index()].priority;
+		Self {
+			state,
+			prop,
+			priority,
+			semantic_enqueue: false,
+			decision_enqueue: None,
+			observed_variables: Vec::new(),
+		}
+	}
 }
 
 impl InitActions for InitializationContext<'_> {
 	fn advise_on_backtrack(&mut self) {
-		self.state.notify_of_backtrack.push(self.prop);
+		// Registering is idempotent, since a propagator is allowed to run its
+		// initialization actions again after it has been posted, and a duplicate
+		// entry would advise it of every backtrack twice.
+		if !self.state.notify_of_backtrack.contains(&self.prop) {
+			self.state.notify_of_backtrack.push(self.prop);
+		}
 	}
 
 	fn enqueue_now(&mut self, option: bool) {
@@ -229,6 +328,12 @@ impl IntInitActions<InitializationContext<'_>> for IntVal {
 		// constant will never change, so we don't need to add an
 		// advisor.
 	}
+	fn cancel_advise_when(&self, _: &mut InitializationContext<'_>, _: IntPropCond, _: u64) {
+		// A constant never subscribed, so there is nothing to cancel.
+	}
+	fn cancel_enqueue_when(&self, _: &mut InitializationContext<'_>, _: IntPropCond) {
+		// A constant never subscribed, so there is nothing to cancel.
+	}
 	fn enqueue_when(&self, ctx: &mut InitializationContext<'_>, _: IntPropCond) {
 		ctx.semantic_enqueue = true;
 	}
@@ -239,6 +344,14 @@ impl<'a> IntInitActions<InitializationContext<'a>>
 {
 	fn advise_when(&self, ctx: &mut InitializationContext<'a>, _: IntPropCond, data: u64) {
 		ctx.add_lit_advisor(self.var, data, true);
+	}
+
+	fn cancel_advise_when(&self, ctx: &mut InitializationContext<'a>, _: IntPropCond, data: u64) {
+		ctx.cancel_lit_advisor(self.var, data);
+	}
+
+	fn cancel_enqueue_when(&self, ctx: &mut InitializationContext<'a>, _: IntPropCond) {
+		self.var.cancel_enqueue_when_fixed(ctx);
 	}
 
 	fn enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
@@ -254,29 +367,34 @@ impl<'a> IntInitActions<InitializationContext<'a>>
 {
 	fn advise_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond, data: u64) {
 		let negated = self.scale.is_negative();
-		let cond = match condition {
-			IntPropCond::LowerBound if self.scale.is_negative() => IntPropCond::UpperBound,
-			IntPropCond::UpperBound if self.scale.is_negative() => IntPropCond::LowerBound,
-			_ => condition,
-		};
+		let cond = self.scale_condition(condition);
 		ctx.state.advisors.push(AdvisorDef {
 			bool2int: false,
 			data,
 			negated,
 			propagator: ctx.prop,
 		});
-		let adv = AdvRef::new(ctx.state.advisors.len() - 1);
+		let adv = AdvisorId::new(ctx.state.advisors.len() - 1);
 		ctx.state.int_activation[self.var.idx()]
-			.add(ActivationAction::<_, PropRef>::Advise(adv), cond);
+			.add(ActivationAction::<_, PropagatorId>::Advise(adv), cond);
+	}
+
+	fn cancel_advise_when(
+		&self,
+		ctx: &mut InitializationContext<'a>,
+		condition: IntPropCond,
+		data: u64,
+	) {
+		ctx.cancel_int_advisor(self.var, self.scale_condition(condition), data);
+	}
+
+	fn cancel_enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
+		self.var
+			.cancel_enqueue_when(ctx, self.scale_condition(condition));
 	}
 
 	fn enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
-		let condition = match condition {
-			IntPropCond::LowerBound if self.scale.is_negative() => IntPropCond::UpperBound,
-			IntPropCond::UpperBound if self.scale.is_negative() => IntPropCond::LowerBound,
-			_ => condition,
-		};
-		self.var.enqueue_when(ctx, condition);
+		self.var.enqueue_when(ctx, self.scale_condition(condition));
 	}
 }
 
@@ -286,6 +404,19 @@ where
 {
 	fn advise_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond, data: u64) {
 		self.var.advise_when(ctx, condition, data);
+	}
+
+	fn cancel_advise_when(
+		&self,
+		ctx: &mut InitializationContext<'a>,
+		condition: IntPropCond,
+		data: u64,
+	) {
+		self.var.cancel_advise_when(ctx, condition, data);
+	}
+
+	fn cancel_enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
+		self.var.cancel_enqueue_when(ctx, condition);
 	}
 
 	fn enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
@@ -303,6 +434,24 @@ impl BoolInitActions<InitializationContext<'_>> for View<bool> {
 			}
 		}
 	}
+	fn cancel_advise_when_fixed(&self, ctx: &mut InitializationContext<'_>, data: u64) {
+		match self.0 {
+			BoolView::Lit(lit) => lit.cancel_advise_when_fixed(ctx, data),
+			BoolView::Const(_) => {
+				// A constant never subscribed, so there is nothing to cancel.
+			}
+		}
+	}
+
+	fn cancel_enqueue_when_fixed(&self, ctx: &mut InitializationContext<'_>) {
+		match self.0 {
+			BoolView::Lit(lit) => lit.cancel_enqueue_when_fixed(ctx),
+			BoolView::Const(_) => {
+				// A constant never subscribed, so there is nothing to cancel.
+			}
+		}
+	}
+
 	fn enqueue_when_fixed(&self, ctx: &mut InitializationContext<'_>) {
 		match self.0 {
 			BoolView::Lit(lit) => lit.enqueue_when_fixed(ctx),
@@ -328,6 +477,31 @@ impl<'a> IntInitActions<InitializationContext<'a>> for View<IntVal> {
 			}
 		}
 	}
+	fn cancel_advise_when(
+		&self,
+		ctx: &mut InitializationContext<'a>,
+		condition: IntPropCond,
+		data: u64,
+	) {
+		match self.0 {
+			IntView::Linear(lin) => lin.cancel_advise_when(ctx, condition, data),
+			IntView::Bool(lin) => lin.cancel_advise_when(ctx, condition, data),
+			IntView::Const(_) => {
+				// A constant never subscribed, so there is nothing to cancel.
+			}
+		}
+	}
+
+	fn cancel_enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
+		match self.0 {
+			IntView::Linear(lin) => lin.cancel_enqueue_when(ctx, condition),
+			IntView::Bool(lin) => lin.cancel_enqueue_when(ctx, condition),
+			IntView::Const(_) => {
+				// A constant never subscribed, so there is nothing to cancel.
+			}
+		}
+	}
+
 	fn enqueue_when(&self, ctx: &mut InitializationContext<'a>, condition: IntPropCond) {
 		match self.0 {
 			IntView::Const(_) => {
@@ -348,6 +522,12 @@ impl<'a> IntInitActions<InitializationContext<'a>> for View<IntVal> {
 impl BoolInitActions<InitializationContext<'_>> for bool {
 	fn advise_when_fixed(&self, _: &mut InitializationContext<'_>, _: u64) {
 		// The literal will never change, so we don't need to add an advisor.
+	}
+	fn cancel_advise_when_fixed(&self, _: &mut InitializationContext<'_>, _: u64) {
+		// A constant never subscribed, so there is nothing to cancel.
+	}
+	fn cancel_enqueue_when_fixed(&self, _: &mut InitializationContext<'_>) {
+		// A constant never subscribed, so there is nothing to cancel.
 	}
 	fn enqueue_when_fixed(&self, ctx: &mut InitializationContext<'_>) {
 		ctx.semantic_enqueue = true;

--- a/crates/huub/src/solver/solving_context.rs
+++ b/crates/huub/src/solver/solving_context.rs
@@ -29,7 +29,8 @@ use crate::{
 		BoxedPropagator, IntLitMeaning, Polarity,
 		decision::{Decision, integer::LazyLitDef},
 		engine::{
-			Engine, EngineReason, EngineReasonSink, LitPropagation, PropRef, State, trace_new_lit,
+			Engine, EngineReason, EngineReasonSink, LitPropagation, PropagatorId, State,
+			trace_new_lit,
 		},
 		view::{View, boolean::BoolView},
 	},
@@ -82,7 +83,7 @@ pub struct SolvingContext<'a> {
 	/// Engine state object.
 	pub(crate) state: &'a mut State,
 	/// Current propagator being executed.
-	pub(crate) current_prop: PropRef,
+	pub(crate) current_prop: PropagatorId,
 }
 
 /// The reason-build sink for the engine's [`SolvingContext`]: a reason closure
@@ -301,7 +302,7 @@ impl<'a> SolvingContext<'a> {
 		Self {
 			slv,
 			state,
-			current_prop: PropRef::INVALID,
+			current_prop: PropagatorId::INVALID,
 		}
 	}
 
@@ -472,12 +473,12 @@ impl<'a> SolvingContext<'a> {
 			.propagator_queue
 			.pop()
 			.expect("`run_next_propagator` called with an empty propagator queue");
-		self.current_prop = PropRef::from_raw(p);
+		self.current_prop = PropagatorId::from_raw(p);
 		let res = propagators[self.current_prop.index()]
 			.as_mut()
 			.propagate(self);
 		self.state.statistics.propagations += 1;
-		self.current_prop = PropRef::INVALID;
+		self.current_prop = PropagatorId::INVALID;
 		res
 	}
 
@@ -488,11 +489,11 @@ impl<'a> SolvingContext<'a> {
 		while let Some(p) = self.state.propagator_queue.pop() {
 			debug_assert!(!self.state.failed);
 			debug_assert!(self.state.conflict.is_none());
-			self.current_prop = PropRef::from_raw(p);
+			self.current_prop = PropagatorId::from_raw(p);
 			let prop = propagators[self.current_prop.index()].as_mut();
 			let res = prop.propagate(self);
 			self.state.statistics.propagations += 1;
-			self.current_prop = PropRef::INVALID;
+			self.current_prop = PropagatorId::INVALID;
 			if let Err(conflict) = res {
 				trace!(
 					target: "solver",

--- a/crates/huub/src/views/linear_view.rs
+++ b/crates/huub/src/views/linear_view.rs
@@ -14,8 +14,8 @@ use crate::{
 	IntSet, IntVal,
 	actions::{
 		IntAnalyzeActions, IntDecisionActions, IntExplanationActions, IntInspectionActions,
-		IntPropagationActions, IntSimplificationActions, PropagationActions, PropagationContext,
-		ReasoningContext,
+		IntPropCond, IntPropagationActions, IntSimplificationActions, PropagationActions,
+		PropagationContext, ReasoningContext,
 	},
 	helpers::{div_ceil, div_floor},
 	solver::{
@@ -108,6 +108,17 @@ impl<Var> LinearView<NonZero<IntVal>, IntVal, Var> {
 	/// Reverses the transformation of an [`IntVal`], rounding down.
 	pub(crate) fn reverse_val_floor(&self, val: IntVal) -> IntVal {
 		div_floor(val - self.offset, self.scale)
+	}
+
+	/// Transform a propagation condition on the view into the equivalent
+	/// condition on the underlying variable, swapping the bounds when the view
+	/// is negatively scaled.
+	pub(crate) fn scale_condition(&self, condition: IntPropCond) -> IntPropCond {
+		match condition {
+			IntPropCond::LowerBound if self.scale.is_negative() => IntPropCond::UpperBound,
+			IntPropCond::UpperBound if self.scale.is_negative() => IntPropCond::LowerBound,
+			_ => condition,
+		}
 	}
 
 	/// Transform a [`IntLitMeaning`] from the variable given the view's scale


### PR DESCRIPTION
`Propagator::initialize` runs exactly once, so a propagator that is built up
incrementally subscribes to whatever it happens to know at that moment, and
an aggregating constraint created before the first constraint is routed into
it registers no advisors at all. `Propagator::update_initialization` hands
the propagator its initialization context again, so that it can subscribe to
the decision variables it has acquired, cancel the subscriptions it no longer
needs, and change its priority. The engine never calls the hook itself: the
code that gives the propagator the new information calls
`PostingActions::update_initialization` or `Model::update_initialization`
afterwards, neither of which is reachable below the root, so subscriptions
are still not trailed.
