### PR TITLE
feat!: clone propagators through `deepclone` instead of `dyn-clone`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "deepclone"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d610034873dccc220be6670fec920e3760a365d524279ca3f5716561f05820a3"
+dependencies = [
+ "deepclone-derive",
+ "rustc-hash",
+]
+
+[[package]]
+name = "deepclone-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0df7c787c15b53efce4e2ffebf8d31846d68e98c37708644aecc8bf548b0729"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,12 +371,6 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -447,7 +462,7 @@ dependencies = [
  "bon",
  "clap",
  "ctrlc",
- "dyn-clone",
+ "deepclone",
  "expect-test",
  "flatzinc-serde",
  "humantime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ bon = { version = "3.9.3", features = ["experimental-generics-setters"] }
 clap = { version = "4.6.4", features = ["derive"] }
 clap_complete = "4.6.8"
 ctrlc = "3.5.2"
+deepclone = "0.3.0"
 divan = { package = "codspeed-divan-compat", version = "5.0.1" }
-dyn-clone = "1.0.20"
 expect-test = "1.5.1"
 flatzinc-serde = { version = "0.5.1" }
 humantime = "2.4.0"

--- a/crates/huub/Cargo.toml
+++ b/crates/huub/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../../README.md"
 
 [dependencies]
 bon = { workspace = true }
-dyn-clone = { workspace = true }
+deepclone = { workspace = true }
 flatzinc-serde = { workspace = true, optional	= true }
 itertools = { workspace = true }
 pindakaas = { workspace = true, features = ["external-propagation"] }

--- a/crates/huub/examples/jobshop/brancher.rs
+++ b/crates/huub/examples/jobshop/brancher.rs
@@ -2,6 +2,7 @@
 
 use clap::{ValueEnum, builder::PossibleValue};
 use huub::{
+	DeepClone,
 	actions::{
 		BoolInspectionActions, BrancherInitActions, DecisionActions, IntDecisionActions,
 		IntInspectionActions, ReasoningContext, Trailed,
@@ -28,7 +29,7 @@ pub(crate) enum BranchingStrategy {
 	Dynamic(DynamicBranching),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, PartialEq)]
 /// A dynamic branching strategy that selects variables to branch on based on
 /// the given [`DynamicBranching`] strategy.
 struct DynamicBrancher {
@@ -42,7 +43,7 @@ struct DynamicBrancher {
 	next: Trailed<usize>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(DeepClone, Debug, Clone, Copy, PartialEq, Eq, Default)]
 /// Branching strategies for [`DynamicBranching`], a specialized [`Brancher`]
 /// implementation for the job shop scheduling problem.
 pub(crate) enum DynamicBranching {

--- a/crates/huub/examples/jobshop/model.rs
+++ b/crates/huub/examples/jobshop/model.rs
@@ -8,6 +8,7 @@ use std::{
 
 use clap::ValueEnum;
 use huub::{
+	DeepClone,
 	lower::{LoweringError, LoweringMap},
 	model::{self, Model, expressions::IntLinearExp},
 	solver::{self, Solver, Valuation},
@@ -54,7 +55,7 @@ pub(crate) enum ObjectiveType {
 	TotalCompletionTime,
 }
 
-#[derive(Copy, Debug, Clone, PartialEq, Eq)]
+#[derive(Copy, DeepClone, Debug, Clone, PartialEq, Eq)]
 /// The representation of an operation to be scheduled on a machine.
 pub(crate) struct Operation {
 	/// The index of the job this operation belongs to.

--- a/crates/huub/src/actions.rs
+++ b/crates/huub/src/actions.rs
@@ -20,6 +20,7 @@ pub use crate::actions::{
 	},
 };
 use crate::{
+	DeepClone,
 	constraints::{BoxedPropagator, Constraint},
 	helpers::bytes::Bytes,
 };
@@ -197,7 +198,7 @@ pub trait SimplificationActions {
 }
 
 /// A typed handle to a value tracked by the trail.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct Trailed<T: Bytes> {
 	/// Index into the trail's integer value storage.
 	pub(crate) index: u32,

--- a/crates/huub/src/actions/boolean.rs
+++ b/crates/huub/src/actions/boolean.rs
@@ -3,6 +3,7 @@
 use std::{fmt::Debug, hash::Hash, ops::Not};
 
 use crate::{
+	DeepClone,
 	actions::{PropagationActions, PropagationContext, ReasoningContext},
 	model::view::View,
 };
@@ -18,7 +19,7 @@ pub trait BoolInspectionActions<Context: ?Sized>: BoolOperations {
 
 /// Operations that are required to be possible to perform on types acting as
 /// Boolean decision variables.
-pub trait BoolOperations: Clone + Debug + Eq + Hash + Not + 'static {}
+pub trait BoolOperations: Clone + Debug + DeepClone + Eq + Hash + Not + 'static {}
 
 /// Actions available to [`Propagator`](crate::constraints::Propagator) and
 /// [`Constraint`](crate::constraints::Constraint) implementations in
@@ -69,7 +70,7 @@ where
 	) -> Result<(), Context::Conflict>;
 }
 
-impl<T> BoolOperations for T where T: Clone + Debug + Eq + Hash + Not + 'static {}
+impl<T> BoolOperations for T where T: Clone + Debug + DeepClone + Eq + Hash + Not + 'static {}
 
 impl<Ctx> BoolInspectionActions<Ctx> for bool {
 	fn val(&self, _: &Ctx) -> Option<bool> {

--- a/crates/huub/src/actions/integer.rs
+++ b/crates/huub/src/actions/integer.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, hash::Hash};
 use rangelist::IntervalIterator;
 
 use crate::{
-	IntSet, IntVal,
+	DeepClone, IntSet, IntVal,
 	actions::{PropagationActions, PropagationContext, ReasoningContext},
 	constraints::NO_REASON,
 	solver::IntLitMeaning,
@@ -121,7 +121,7 @@ where
 
 /// Operations that are required to be possible to perform on types acting as
 /// integer decision variables.
-pub trait IntOperations: Clone + Debug + Eq + Hash + 'static {}
+pub trait IntOperations: Clone + Debug + DeepClone + Eq + Hash + 'static {}
 
 /// The conditions of an integer variable domain change that can trigger a
 /// propagator to be enqueued.
@@ -396,4 +396,4 @@ where
 	}
 }
 
-impl<T> IntOperations for T where T: Clone + Debug + Eq + Hash + 'static {}
+impl<T> IntOperations for T where T: Clone + Debug + DeepClone + Eq + Hash + 'static {}

--- a/crates/huub/src/constraints.rs
+++ b/crates/huub/src/constraints.rs
@@ -24,11 +24,10 @@ use std::{
 	slice,
 };
 
-use dyn_clone::DynClone;
 use pindakaas::solver::propagation::ClauseBuilder;
 
 use crate::{
-	IntVal,
+	DeepClone, DynDeepClone, IntVal,
 	actions::{
 		BoolAnalyzeActions, BoolInitActions, BoolInspectionActions, BoolPropagationActions,
 		BoolSimplificationActions, IntAnalyzeActions, IntEvent, IntExplanationActions,
@@ -111,7 +110,9 @@ pub(crate) enum ConflictInner<Atom> {
 /// Constraints specified in the library implement this trait, but are using
 /// their explicit type in an enumerated type to allow for global model
 /// analysis.
-pub trait Constraint<E: ReasoningEngine + ?Sized>: Any + Debug + DynClone + Propagator<E> {
+pub trait Constraint<E: ReasoningEngine + ?Sized>:
+	Any + Debug + DynDeepClone + Propagator<E>
+{
 	/// Analyze the constraint to declare the literal encoding it requires, and
 	/// to contribute polarity evidence for the decision variables it involves.
 	///
@@ -191,7 +192,7 @@ pub struct Nogood<Atom>(pub(crate) Box<[Atom]>);
 /// If the explanation is needed, then the propagation engine will revert the
 /// state of the solver and call [`Propagator::explain`] to receive the
 /// explanation.
-pub trait Propagator<E: ReasoningEngine + ?Sized>: Any + Debug + DynClone {
+pub trait Propagator<E: ReasoningEngine + ?Sized>: Any + Debug + DynDeepClone {
 	/// Advises the propagator that the solver is backtracking.
 	fn advise_of_backtrack(&mut self, context: &mut E::NotificationContext<'_>) {
 		let _ = context;
@@ -354,24 +355,13 @@ where
 impl<E, B> BoolSolverActions<E> for B
 where
 	E: ReasoningEngine + ?Sized,
-	Self: for<'a> BoolInitActions<E::InitializationContext<'a>>
+	Self: DeepClone
+		+ for<'a> BoolInitActions<E::InitializationContext<'a>>
 		+ for<'a> BoolInspectionActions<E::ExplanationContext<'a>>
 		+ for<'a> BoolInspectionActions<E::NotificationContext<'a>>
 		+ for<'a> BoolPropagationActions<E::PropagationContext<'a>>
 		+ Into<E::Atom>,
 {
-}
-
-impl Clone for BoxedConstraint {
-	fn clone(&self) -> BoxedConstraint {
-		dyn_clone::clone_box(&**self)
-	}
-}
-
-impl Clone for BoxedPropagator {
-	fn clone(&self) -> BoxedPropagator {
-		dyn_clone::clone_box(&**self)
-	}
 }
 
 impl Conflict<model::View<bool>> {
@@ -455,7 +445,8 @@ where
 impl<E, I> IntSolverActions<E> for I
 where
 	E: ReasoningEngine + ?Sized,
-	I: for<'a> IntInitActions<E::InitializationContext<'a>>
+	I: DeepClone
+		+ for<'a> IntInitActions<E::InitializationContext<'a>>
 		+ for<'a> IntExplanationActions<E::ExplanationContext<'a>>
 		+ for<'a> IntInspectionActions<E::NotificationContext<'a>>
 		+ for<'a> IntPropagationActions<E::PropagationContext<'a>>,

--- a/crates/huub/src/constraints/bool_array_element.rs
+++ b/crates/huub/src/constraints/bool_array_element.rs
@@ -5,7 +5,7 @@
 use std::iter::once;
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		BoolInitActions, BoolSimplificationActions, IntAnalyzeActions, IntDecisionActions,
 		IntInitActions, IntInspectionActions, IntPropCond, IntPropagationActions, ReasoningEngine,
@@ -24,7 +24,7 @@ use crate::{
 /// This constraint enforces that a result Boolean decision variable takes the
 /// value equal the element of the given array of Boolean decision variables at
 /// the index given by the index integer decision variable.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct BoolDecisionArrayElement {
 	/// The array of Boolean decision variables
 	pub(crate) array: Vec<View<bool>>,

--- a/crates/huub/src/constraints/circuit.rs
+++ b/crates/huub/src/constraints/circuit.rs
@@ -15,7 +15,7 @@ use tracing::warn;
 
 pub use crate::constraints::circuit::{no_cycle::CircuitNoCycle, scc::CircuitScc};
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		IntAnalyzeActions, IntDecisionActions, IntEvent, IntInspectionActions,
 		IntPropagationActions, PropagationActions, ReasonActions, ReasoningContext,
@@ -33,7 +33,7 @@ use crate::{
 ///
 /// Enforces that the successor variables form a single cycle through all nodes
 /// (or, for `subcircuit`, through a subset, with the rest self-looping).
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct Circuit<const SUBCIRCUIT: bool> {
 	/// Instance of the [`CircuitNoCycle`] propagator.
 	no_cycle_prop: CircuitNoCycle<SUBCIRCUIT, View<IntVal>>,
@@ -53,7 +53,7 @@ pub struct Circuit<const SUBCIRCUIT: bool> {
 /// successor variable per node position `0..n`, plus the value `offset`. The
 /// `SUBCIRCUIT` const generic selects the `subcircuit` variant (nodes may
 /// self-loop off the cycle), so the variant checks compile away.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub(crate) struct CircuitGraph<const SUBCIRCUIT: bool, I> {
 	/// Successor variables, indexed by node position `0..n`.
 	pub(crate) vars: Vec<I>,

--- a/crates/huub/src/constraints/circuit/no_cycle.rs
+++ b/crates/huub/src/constraints/circuit/no_cycle.rs
@@ -10,7 +10,7 @@
 //!   `subcircuit`.
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		InitActions, IntEvent, IntInspectionActions, IntPropCond, IntPropagationActions,
 		PostingActions, PropagationActions, ReasonActions, ReasoningEngine,
@@ -21,7 +21,7 @@ use crate::{
 
 /// The `no_cycle` propagator for the `circuit` and `subcircuit` constraints
 /// (`SUBCIRCUIT` selects the variant).
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct CircuitNoCycle<const SUBCIRCUIT: bool, I> {
 	/// Successor graph plus the shared explanation helpers (the canonical copy
 	/// for the owning `Circuit`).
@@ -35,7 +35,7 @@ pub struct CircuitNoCycle<const SUBCIRCUIT: bool, I> {
 }
 
 /// Reusable scratch for the `no_cycle` algorithm.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub(crate) struct NoCycleScratch {
 	/// Successor position of every fixed node (`None` if unfixed).
 	fixed_succ: Vec<Option<usize>>,

--- a/crates/huub/src/constraints/circuit/scc.rs
+++ b/crates/huub/src/constraints/circuit/scc.rs
@@ -5,7 +5,7 @@
 //! each subtree finishes and failing the moment a closed sub-tour appears.
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		InitActions, IntInspectionActions, IntPropCond, IntPropagationActions, PostingActions,
 		PropagationActions, ReasoningEngine,
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Reusable scratch for the iterative single-root DFS.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 struct CircuitDfs {
 	/// DFS index of each node; `-1` if unvisited.
 	idx: Vec<i64>,
@@ -37,7 +37,7 @@ struct CircuitDfs {
 
 /// The `scc` propagator for the `circuit` and `subcircuit` constraints
 /// (`SUBCIRCUIT` selects the variant).
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct CircuitScc<const SUBCIRCUIT: bool, I> {
 	/// Successor graph plus the shared explanation helpers.
 	graph: CircuitGraph<SUBCIRCUIT, I>,
@@ -46,7 +46,7 @@ pub struct CircuitScc<const SUBCIRCUIT: bool, I> {
 }
 
 /// One pending node in the DFS work-stack, replacing a native call frame.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 struct DfsFrame {
 	/// Graph node this frame is exploring.
 	node: usize,
@@ -62,7 +62,7 @@ struct DfsFrame {
 }
 
 /// Reusable scratch for the `scc` algorithm.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub(crate) struct SccScratch {
 	/// The iterative DFS state.
 	dfs: CircuitDfs,

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -10,7 +10,7 @@ use std::cmp;
 use itertools::Itertools;
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		InitActions, IntAnalyzeActions, IntInspectionActions, IntPropCond, PostingActions,
 		ReasoningContext, ReasoningEngine,
@@ -37,7 +37,7 @@ const MAX_STRENGTHENING_WORK: IntVal = 10_000_000;
 /// capacity at any point in time. The constraint can optionally apply
 /// edge finding propagation to strengthen the reasoning about
 /// the tasks' scheduling.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct Cumulative {
 	/// Inner propagator, used to simplify the constraint within the model.
 	///
@@ -105,7 +105,7 @@ enum CumulativePropagationRule {
 ///   propagation for the cumulative resource constraint. CPAIOR 2013.
 /// - J. Schulz, "Hybrid Solving Techniques for Project Scheduling Problems", TU
 ///   Berlin, 2012
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct CumulativePropagator<I1, I2, I3, I4> {
 	/// Start time variables of each task.
 	start_times: Vec<I1>,

--- a/crates/huub/src/constraints/disjunctive.rs
+++ b/crates/huub/src/constraints/disjunctive.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use tracing::trace;
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		ConstructionActions, DeferReasonActions, InitActions, IntDecisionActions,
 		IntInspectionActions, IntPropCond, PostingActions, PropagationContext, ReasonActions,
@@ -24,7 +24,7 @@ use crate::{
 /// This constraint enforces that the given a list of integer decision variables
 /// representing the start times of tasks and a list of integer values
 /// representing the durations of tasks, the tasks do not overlap in time.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct Disjunctive {
 	/// Inner propagator.
 	pub(crate) propagator: DisjunctivePropagator<model::View<IntVal>>,
@@ -75,7 +75,7 @@ enum DisjunctivePropagationRule {
 ///   Archives of Control Sciences 18.2 (2008): 159-202.
 /// - Vilím, Petr "Computing explanations for the unary resource constraint."
 ///   CPAIOR 2005.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct DisjunctivePropagator<I> {
 	/// Start time variables of each task.
 	start_times: Vec<I>,
@@ -129,7 +129,7 @@ pub struct DisjunctivePropagator<I> {
 ///
 /// This structure allows efficient updates and queries for ECTs and gray ECTs
 /// as tasks are added, removed, or marked gray. For details, see Vilim (2008).
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 struct OmegaThetaTree {
 	/// Storage of the nodes of the tree.
 	nodes: Vec<OmegaThetaTreeNode>,
@@ -145,7 +145,7 @@ struct OmegaThetaTree {
 }
 
 /// A node structure for the [`OmegaThetaTree`].
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 struct OmegaThetaTreeNode {
 	/// Total duration of the tasks under the tree rooted at this node.
 	total_durations: i64,
@@ -161,7 +161,7 @@ struct OmegaThetaTreeNode {
 }
 
 /// Internal structure to store trailed information about tasks.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 struct TaskInfo {
 	/// Earliest start time of the task.
 	earliest_start: Trailed<IntVal>,

--- a/crates/huub/src/constraints/int_abs.rs
+++ b/crates/huub/src/constraints/int_abs.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use crate::{
+	DeepClone,
 	actions::{
 		InitActions, IntDecisionActions, IntPropCond, PostingActions, ReasonActions,
 		ReasoningContext, ReasoningEngine,
@@ -26,7 +27,7 @@ use crate::{
 ///
 /// This constraint enforces that the second integer decision variable takes the
 /// absolute value of the first integer decision variable.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntAbsBounds<I1, I2, B> {
 	/// The integer decision variable whose absolute value is being taken
 	pub(crate) origin: I1,

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -9,7 +9,7 @@ use rangelist::IntervalIterator;
 use rustc_hash::FxHashMap;
 
 use crate::{
-	IntSet, IntVal,
+	DeepClone, IntSet, IntVal,
 	actions::{
 		ConstructionActions, InitActions, IntAnalyzeActions, IntDecisionActions,
 		IntInspectionActions, IntPropCond, IntSimplificationActions, PostingActions, ReasonActions,
@@ -25,7 +25,7 @@ use crate::{
 
 /// Bounds consistent propagator for the `array_element` constraint with an
 /// array of integer decision variables.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntArrayElementBounds<I1, I2, I3> {
 	/// Array of variables from which the element is selected
 	vars: Vec<I1>,
@@ -45,7 +45,7 @@ pub struct IntArrayElementBounds<I1, I2, I3> {
 /// This constraint enforces that a result integer decision variable takes the
 /// value equal the element of the given array of integer values at the given
 /// index decision variable.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntValArrayElement<I1, I2>(pub(crate) IntArrayElementBounds<IntVal, I1, I2>);
 
 impl<I1, I2, I3> IntArrayElementBounds<I1, I2, I3> {

--- a/crates/huub/src/constraints/int_array_minimum.rs
+++ b/crates/huub/src/constraints/int_array_minimum.rs
@@ -3,6 +3,7 @@
 //! decision variables.
 
 use crate::{
+	DeepClone,
 	actions::{InitActions, IntPropCond, PostingActions, ReasonActions, ReasoningEngine},
 	constraints::{
 		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
@@ -12,7 +13,7 @@ use crate::{
 };
 
 /// Bounds consistent propagator for the `array_minimum_int` constraint.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntArrayMinimumBounds<I1, I2> {
 	/// Set of decision variables from which the minimum must be taken
 	pub(crate) vars: Vec<I1>,

--- a/crates/huub/src/constraints/int_div.rs
+++ b/crates/huub/src/constraints/int_div.rs
@@ -5,7 +5,7 @@
 use std::{mem, num::NonZero, ops::Neg};
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		InitActions, IntDecisionActions, IntInspectionActions, IntPropCond, IntPropagationActions,
 		PostingActions, ReasoningEngine, SimplificationActions,
@@ -24,7 +24,7 @@ use crate::{
 ///
 /// This propagator enforces truncating rounding on the result of the division,
 /// and enforces that the denominator is non-zero.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntDivBounds<I1, I2, I3> {
 	/// The numerator of the division
 	pub(crate) numerator: I1,
@@ -214,22 +214,22 @@ where
 
 		// num >= 0 /\ denom > 0 => res >= 0
 		<BoolFormula as Constraint<E>>::simplify(
-			&mut Or(vec![!Atom(num_pos), !Atom(denom_pos), Atom(res_pos)]),
+			&mut BoolFormula(Or(vec![!Atom(num_pos), !Atom(denom_pos), Atom(res_pos)])),
 			ctx,
 		)?;
 		// num <= 0 /\ denom < 0 => res >= 0
 		<BoolFormula as Constraint<E>>::simplify(
-			&mut Or(vec![!Atom(num_neg), !Atom(denom_neg), Atom(res_pos)]),
+			&mut BoolFormula(Or(vec![!Atom(num_neg), !Atom(denom_neg), Atom(res_pos)])),
 			ctx,
 		)?;
 		// num >= 0 /\ denom < 0 => res >= 0
 		<BoolFormula as Constraint<E>>::simplify(
-			&mut Or(vec![!Atom(num_pos), !Atom(denom_neg), Atom(res_neg)]),
+			&mut BoolFormula(Or(vec![!Atom(num_pos), !Atom(denom_neg), Atom(res_neg)])),
 			ctx,
 		)?;
 		// num <= 0 /\ denom > 0 => res <= 0
 		<BoolFormula as Constraint<E>>::simplify(
-			&mut Or(vec![!Atom(num_neg), !Atom(denom_pos), Atom(res_neg)]),
+			&mut BoolFormula(Or(vec![!Atom(num_neg), !Atom(denom_pos), Atom(res_neg)])),
 			ctx,
 		)?;
 

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -9,10 +9,11 @@ use itertools::{Either, Itertools};
 use pindakaas::{
 	Lit as RawLit, Unsatisfiable,
 	bool_linear::{BoolLinAggregator, BoolLinExp, BoolLinVariant, BoolLinear},
+	propositional_logic::Formula,
 };
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		BoolAnalyzeActions, BoolInitActions, BoolInspectionActions, BoolPropagationActions,
 		BoolSimplificationActions, DeferReasonActions, InitActions, IntAnalyzeActions,
@@ -45,7 +46,7 @@ type DoubleIntVal = i128;
 /// Representation of an integer equality constraint that cannot be unified.
 ///
 /// This constraint enforces that two integer decisions take the same value.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub(crate) struct IntEq {
 	/// The two integer decisions that must be equal.
 	pub(crate) vars: [model::View<IntVal>; 2],
@@ -56,7 +57,7 @@ pub(crate) struct IntEq {
 /// This constraint enforces that a sum of (linear transformations of) integer
 /// decision variables is less than, equal, or not equal to a constant value, or
 /// the implication or reification or whether this is so.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntLinear<OF: OverflowMode> {
 	/// The integer linear terms that are being summed.
 	pub(crate) terms: Vec<model::View<IntVal>>,
@@ -74,7 +75,7 @@ pub type IntLinearLessEqBounds<OV, IV> = IntLinearLessEqBoundsImpl<OV, IV, True>
 
 /// Bounds consistent propagator for the `int_lin_le` or `int_lin_le_imp`
 /// constraint.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntLinearLessEqBoundsImpl<OV: OverflowMode, IV, BV> {
 	/// Variables that are being summed
 	terms: Vec<IV>,
@@ -98,7 +99,7 @@ pub type IntLinearNotEqValue<OF, IV> = IntLinearNotEqValueImpl<OF, IV, True>;
 
 /// Value consistent propagator for the `int_lin_ne` or `int_lin_ne_imp`
 /// constraint.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntLinearNotEqValueImpl<OF: OverflowMode, IV, BV> {
 	/// Decision variables in the summation
 	terms: Vec<IV>,
@@ -112,7 +113,7 @@ pub struct IntLinearNotEqValueImpl<OF: OverflowMode, IV, BV> {
 }
 
 /// Possible operators that can be used for in a linear constraint.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub(crate) enum LinComparator {
 	/// Sum is equal to the constant
 	Equal,
@@ -123,7 +124,7 @@ pub(crate) enum LinComparator {
 }
 
 /// Reification possibilities for a linear constraint.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub(crate) enum Reification {
 	/// The constraint is half-reified by the given [`BoolDecision`].
 	ImpliedBy(model::View<bool>),
@@ -396,10 +397,10 @@ where
 				};
 				match self.reif.unwrap() {
 					Reification::ImpliedBy(r) => {
-						let _ = ctx.post_constraint(BoolFormula::Implies(
-							Box::new(BoolFormula::Atom(r)),
-							Box::new(BoolFormula::Atom(lit)),
-						));
+						let _ = ctx.post_constraint(BoolFormula(Formula::Implies(
+							Box::new(r.into()),
+							Box::new(lit.into()),
+						)));
 					}
 					Reification::ReifiedBy(r) => r.unify(ctx, lit)?,
 				}

--- a/crates/huub/src/constraints/int_mul.rs
+++ b/crates/huub/src/constraints/int_mul.rs
@@ -7,7 +7,7 @@ use std::{marker::PhantomData, num::NonZero, ops::Mul};
 use itertools::{Itertools, MinMaxResult, iproduct};
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		InitActions, IntInspectionActions, IntPropCond, IntSimplificationActions, PostingActions,
 		ReasoningContext, ReasoningEngine,
@@ -26,7 +26,7 @@ use crate::{
 
 /// This propagator enforces that the product of the two integer decision
 /// variables is equal to a third, i.e.`x * y = z`.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntMulBounds<OM: OverflowMode, I1, I2, I3> {
 	/// First factor variable
 	pub(crate) factor1: I1,

--- a/crates/huub/src/constraints/int_no_overlap.rs
+++ b/crates/huub/src/constraints/int_no_overlap.rs
@@ -10,7 +10,7 @@ use std::{
 use itertools::izip;
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		ConstructionActions, InitActions, IntDecisionActions, IntInspectionActions, IntPropCond,
 		PostingActions, PropagationContext, ReasonActions, ReasoningContext, ReasoningEngine,
@@ -42,7 +42,7 @@ use crate::{
 /// forbidden in the sense that if we would put our rectangle at that place, it
 /// would guarantee that at least two rectangles are overlapping, which violates
 /// the constraint.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 // All Matrix attributes are 2-dimensional, with the first index
 // representing the object and the second representing the dimension.
 pub struct IntNoOverlapSweep<const STRICT: bool, I1, I2> {
@@ -78,7 +78,7 @@ pub struct IntNoOverlapSweep<const STRICT: bool, I1, I2> {
 ///
 /// It is represented by a vector of tuples, where each tuple contains the lower
 /// and upper bounds for a single dimension.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 struct Region(Vec<(IntVal, IntVal)>);
 
 impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {

--- a/crates/huub/src/constraints/int_pow.rs
+++ b/crates/huub/src/constraints/int_pow.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 use itertools::{Itertools, MinMaxResult};
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		InitActions, IntDecisionActions, IntInspectionActions, IntPropCond, PostingActions,
 		ReasonActions, ReasoningContext, ReasoningEngine,
@@ -32,7 +32,7 @@ use crate::{
 ///
 /// The OVERFLOW parameter determines whether the propagator will expect
 /// possible integer overflows.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntPowBounds<OM: OverflowMode, I1, I2, I3> {
 	/// The base in the exponentiation
 	pub(crate) base: I1,

--- a/crates/huub/src/constraints/int_set_contains.rs
+++ b/crates/huub/src/constraints/int_set_contains.rs
@@ -6,7 +6,7 @@ use pindakaas::propositional_logic::Formula;
 use rangelist::IntervalIterator;
 
 use crate::{
-	IntSet, IntVal,
+	DeepClone, IntSet, IntVal,
 	actions::{
 		BoolInitActions, BoolInspectionActions, BoolPropagationActions, BoolSimplificationActions,
 		IntInitActions, IntInspectionActions, IntPropCond, IntSimplificationActions, ReasonActions,
@@ -17,18 +17,19 @@ use crate::{
 		NO_REASON, Propagator, SimplificationStatus,
 	},
 	lower::{LoweringContext, LoweringError},
-	model::{expressions::BoolFormula, view::View},
+	model::{expressions::bool_formula::BoolFormula, view::View},
 };
 
 /// Representation of the integer `contains` constraint within a model.
 ///
 /// This constraint enforces that the given Boolean variable takes the value
 /// `true` if-and-only-if an integer variable is in a given set.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntSetContainsReif {
 	/// The integer decision variable monitored.
 	pub(crate) var: View<IntVal>,
 	/// The set of considered values for the integer decision variable.
+	#[deepclone(clone)]
 	pub(crate) set: IntSet,
 	/// The Boolean variable that indicates if the integer decision variable is
 	/// in the set.
@@ -111,10 +112,10 @@ where
 			let lb = *self.set.min().unwrap();
 			let ub = *self.set.max().unwrap();
 			<BoolFormula as Constraint<E>>::to_solver(
-				&Formula::Equiv(vec![
+				&BoolFormula(Formula::Equiv(vec![
 					Formula::And(vec![self.var.geq(lb).into(), self.var.leq(ub).into()]),
 					self.reif.into(),
-				]),
+				])),
 				slv,
 			)
 		} else {
@@ -125,7 +126,7 @@ where
 				.map(|v| self.var.eq(v).into())
 				.collect();
 			<BoolFormula as Constraint<E>>::to_solver(
-				&Formula::Equiv(vec![self.reif.into(), Formula::Or(eq_lits)]),
+				&BoolFormula(Formula::Equiv(vec![self.reif.into(), Formula::Or(eq_lits)])),
 				slv,
 			)
 		}

--- a/crates/huub/src/constraints/int_table.rs
+++ b/crates/huub/src/constraints/int_table.rs
@@ -7,7 +7,7 @@ use std::mem;
 use itertools::Itertools;
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		InitActions, IntAnalyzeActions, IntDecisionActions, IntInitActions, IntInspectionActions,
 		IntPropCond, IntPropagationActions, IntSimplificationActions, PropagationActions,
@@ -25,7 +25,7 @@ use crate::{
 ///
 /// This constraint enforces that the given list of integer views take their
 /// values according to one of the given lists of integer values.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntTable {
 	/// List of variables that must take the values of a row in the table.
 	pub(crate) vars: Vec<View<IntVal>>,

--- a/crates/huub/src/constraints/int_unique.rs
+++ b/crates/huub/src/constraints/int_unique.rs
@@ -20,7 +20,7 @@ pub use crate::constraints::int_unique::{
 	bounds::IntUniqueBounds, domain::IntUniqueDomain, value::IntUniqueValue,
 };
 use crate::{
-	IntSet, IntVal,
+	DeepClone, IntSet, IntVal,
 	actions::{IntAnalyzeActions, IntEvent, IntInspectionActions, ReasoningEngine},
 	constraints::{
 		Constraint, IntModelActions, IntSolverActions, Propagator, SimplificationStatus,
@@ -33,7 +33,7 @@ use crate::{
 ///
 /// This constraint enforces that all the given integer decisions take different
 /// values.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntUnique {
 	/// Instance of the [`IntUniqueBounds`] propagator.
 	pub(crate) bounds_prop: IntUniqueBounds<View<IntVal>>,

--- a/crates/huub/src/constraints/int_unique/bounds.rs
+++ b/crates/huub/src/constraints/int_unique/bounds.rs
@@ -8,14 +8,14 @@
 use std::cmp;
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{InitActions, IntPropCond, PostingActions, ReasoningEngine},
 	constraints::{IntSolverActions, Propagator},
 	solver::{IntLitMeaning, engine::Engine, queue::PriorityLevel},
 };
 
 /// Bounds consistent propagator for the integer `unique` constraint.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntUniqueBounds<I> {
 	/// List of integer variables that must take different values.
 	pub(crate) vars: Vec<I>,
@@ -52,7 +52,7 @@ pub struct IntUniqueBounds<I> {
 
 /// Information that is tracked for each variable for the propagation of
 /// [`IntUniqueBounds`].
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 struct UniqueVarMeta {
 	/// Transition for the variable's position in the Hall interval tree.
 	next: usize,

--- a/crates/huub/src/constraints/int_unique/domain.rs
+++ b/crates/huub/src/constraints/int_unique/domain.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashSet;
 use tracing::trace;
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		DeferReasonActions, InitActions, IntEvent, IntInspectionActions, IntPropCond,
 		PostingActions, PropagationActions, ReasonActions, ReasoningContext, ReasoningEngine,
@@ -22,7 +22,7 @@ use crate::{
 
 /// Reusable scratch for BFS-based augmenting-path search on a bipartite
 /// graph. Depends only on the number of left nodes.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, DeepClone)]
 struct AugmentingPathScratch {
 	/// BFS queue (over left nodes).
 	queue: Vec<usize>,
@@ -32,7 +32,7 @@ struct AugmentingPathScratch {
 }
 
 /// Reusable scratch for the explain-time down-closure.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, DeepClone)]
 struct ClosureScratch {
 	/// Decision members `H` of the tight Hall set. Membership is marked in
 	/// [`Self::dcn_in`]; the list lets the marks be cleared in O(closure).
@@ -53,7 +53,7 @@ struct ClosureScratch {
 /// union-domain origin used to translate between integer values and right-side
 /// indices, and the matching tables. Algorithms (augmenting-path search,
 /// Tarjan, Hall-set reasoning) operate on this struct from the outside.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, DeepClone)]
 struct DecisionValueMatching<I> {
 	/// Left side: the integer decision variables.
 	dcns: Vec<I>,
@@ -88,7 +88,7 @@ struct DecisionValueMatching<I> {
 /// - Downing, Nicholas, Thibaut Feydy, and Peter J. Stuckey. "Explaining
 ///   alldifferent." In Proceedings of the Australasian Computer Science
 ///   Conference (ACSC 2012), CRPIT Volume 122, pages 115--124, 2012.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, DeepClone)]
 pub struct IntUniqueDomain<I> {
 	/// Decisions, values, and their current matching.
 	graph: DecisionValueMatching<I>,
@@ -114,7 +114,7 @@ pub struct IntUniqueDomain<I> {
 /// One pending node in the explicit (heap-allocated) Tarjan DFS work-stack.
 /// Replaces a native call frame: `i` is the resumption point into this node's
 /// neighbour slice `[frame_start, frame_end)` of [`TarjanScratch::neighbours`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, DeepClone)]
 struct TarjanFrame {
 	/// Graph node this frame is exploring.
 	node: usize,
@@ -131,7 +131,7 @@ struct TarjanFrame {
 /// nodes. `dcns_buf` / `vals_buf` are sized for the bipartite use-case (one
 /// buffer per side); a single-bucket variant would suit a non-bipartite
 /// consumer.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, DeepClone)]
 struct TarjanScratch {
 	/// Stack for Tarjan's algorithm.
 	dfs_stack: Vec<usize>,

--- a/crates/huub/src/constraints/int_unique/value.rs
+++ b/crates/huub/src/constraints/int_unique/value.rs
@@ -8,13 +8,14 @@
 use itertools::Itertools;
 
 use crate::{
+	DeepClone,
 	actions::{InitActions, IntEvent, IntPropCond, PostingActions, ReasonActions, ReasoningEngine},
 	constraints::{IntSolverActions, Propagator},
 	solver::engine::Engine,
 };
 
 /// Value consistent propagator for the integer `unique` constraint.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntUniqueValue<I> {
 	/// List of integer variables that must take different values.
 	vars: Vec<I>,

--- a/crates/huub/src/constraints/int_value_precede.rs
+++ b/crates/huub/src/constraints/int_value_precede.rs
@@ -5,7 +5,7 @@
 use std::cmp::{max, min};
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		ConstructionActions, InitActions, IntDecisionActions, IntInspectionActions, IntPropCond,
 		PostingActions, PropagationContext, ReasonActions, ReasoningContext, ReasoningEngine,
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// Bounds propagator for the `seq_precede_chain_int` constraint.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntSeqPrecedeChainBounds<I> {
 	/// List of integer variables where first occurrences of all i>0 must be
 	/// ordered.
@@ -38,7 +38,7 @@ pub struct IntSeqPrecedeChainBounds<I> {
 }
 
 /// Value consistent propagator for the `value_precede_chain` constraint.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct IntValuePrecedeChainValue<I> {
 	/// List of integers that need to occur in order
 	values: Vec<IntVal>,

--- a/crates/huub/src/helpers/matrix.rs
+++ b/crates/huub/src/helpers/matrix.rs
@@ -24,8 +24,10 @@ use std::{
 	ops::{Index, IndexMut},
 };
 
+use crate::DeepClone;
+
 /// A generic n-dimensional matrix.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub(crate) struct Matrix<const DIMS: usize, T> {
 	/// The data stored in the matrix in a row-major layout.
 	data: Box<[T]>,

--- a/crates/huub/src/helpers/overflow.rs
+++ b/crates/huub/src/helpers/overflow.rs
@@ -6,20 +6,20 @@ use std::{
 	ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
 
-use crate::IntVal;
+use crate::{DeepClone, IntVal};
 
 /// Type alias for an integer value that has double the bit width of [`IntVal`].
 pub(crate) type DoubleIntVal = i128;
 
 /// Marker type indicating that overflow is impossible, and does not need to be
 /// handled by the [`Propagator`](crate::constraints::Propagator).
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct OverflowImpossible;
 
 /// Helper trait that defines the capabilities of [`OverflowPossible`] and
 /// [`OverflowImpossible`] that can be used in
 /// [`Propagator`](crate::constraints::Propagator) implementations.
-pub trait OverflowMode: private::Sealed + Clone + fmt::Debug + 'static {
+pub trait OverflowMode: private::Sealed + Clone + DeepClone + fmt::Debug + 'static {
 	/// Constant indicating whether overflow should be handled.
 	const HANDLE_OVERFLOW: bool;
 
@@ -28,6 +28,7 @@ pub trait OverflowMode: private::Sealed + Clone + fmt::Debug + 'static {
 		+ AddAssign
 		+ Copy
 		+ Clone
+		+ DeepClone
 		+ fmt::Debug
 		+ fmt::Display
 		+ From<IntVal>
@@ -42,7 +43,7 @@ pub trait OverflowMode: private::Sealed + Clone + fmt::Debug + 'static {
 
 /// Marker type indicating that overflow might be possible, and should be
 /// handled by the [`Propagator`](crate::constraints::Propagator).
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct OverflowPossible;
 
 impl OverflowMode for OverflowImpossible {

--- a/crates/huub/src/helpers/trailed_partition.rs
+++ b/crates/huub/src/helpers/trailed_partition.rs
@@ -8,7 +8,10 @@
 
 use std::cmp;
 
-use crate::actions::{ConstructionActions, Trailed, TrailingActions};
+use crate::{
+	DeepClone,
+	actions::{ConstructionActions, Trailed, TrailingActions},
+};
 
 /// Backtrackable disjoint-set partition of `{0, .., n-1}`. Each block is a
 /// contiguous slice of the underlying element permutation (see
@@ -30,7 +33,7 @@ use crate::actions::{ConstructionActions, Trailed, TrailingActions};
 ///   positions:     0  2  1  3
 ///   layout:        2  0  4  2     // pos 0 -> end 2; pos 2 -> end 4
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, DeepClone)]
 pub(crate) struct TrailedPartition {
 	/// Permutation of `0..n` whose contiguous slices are the current blocks.
 	elems: Vec<usize>,

--- a/crates/huub/src/helpers/true_type.rs
+++ b/crates/huub/src/helpers/true_type.rs
@@ -3,6 +3,7 @@
 use std::ops::Not;
 
 use crate::{
+	DeepClone,
 	actions::{
 		BoolInitActions, BoolInspectionActions, BoolPropagationActions, PropagationActions,
 		PropagationContext, ReasoningContext,
@@ -11,7 +12,7 @@ use crate::{
 };
 
 /// Type that represents compile time constant [`true`] value.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Default, Eq, Hash, PartialEq)]
 pub struct True;
 
 impl<Ctx> BoolInitActions<Ctx> for True

--- a/crates/huub/src/lib.rs
+++ b/crates/huub/src/lib.rs
@@ -70,6 +70,13 @@ pub mod solver;
 pub(crate) mod tests;
 pub mod views;
 
+/// Re-exported so that a downstream [`Propagator`](constraints::Propagator),
+/// [`Constraint`](constraints::Constraint), or
+/// [`Brancher`](solver::branchers::Brancher) can derive [`DeepClone`] without
+/// depending on `deepclone` directly. [`DynDeepClone`] is the supertrait those
+/// three carry, and [`Cloner`] is the argument a hand-written [`DeepClone`]
+/// impl has to name.
+pub use deepclone::{Cloner, DeepClone, DynDeepClone};
 use rangelist::RangeList;
 
 /// Type alias for a disjunction of literals, used for internal type

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -25,7 +25,7 @@ pub use crate::model::{
 	view::{DefaultView, View},
 };
 use crate::{
-	IntSet, IntVal,
+	DeepClone, IntSet, IntVal,
 	actions::{
 		ConstructionActions, DecisionActions, DeferReasonActions, IntEvent, IntInspectionActions,
 		PropagationActions, PropagationContext, ReasonActions, ReasoningContext, ReasoningEngine,
@@ -114,32 +114,39 @@ pub struct ConstraintId(u32);
 /// # assert_eq!(x + y, 4);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, DeepClone, Default)]
 pub struct Model {
 	/// A base [`Cnf`] object that contains pure Boolean parts of the problem.
+	#[deepclone(clone)]
 	pub(crate) cnf: Cnf,
 	/// A list of constraints that have been added to the model.
 	pub(crate) constraints: Vec<Option<BoxedConstraint>>,
 	/// The definitions of the Boolean decision variables that have been
 	/// created.
+	#[deepclone(clone)]
 	pub(crate) bool_vars: Vec<BoolDecision>,
 	/// The definitions of the integer decision variables that have been
 	/// created.
+	#[deepclone(clone)]
 	pub(crate) int_vars: Vec<IntDecision>,
 	/// A queue of constraints that need to be propagated.
+	#[deepclone(clone)]
 	propagator_queue: PropagatorQueue,
 	/// Fake trailed storage
 	pub(crate) trail: Vec<[u8; 8]>,
 	/// Reference for the current propagator being executed.
+	#[deepclone(clone)]
 	cur_prop: Option<ConstraintId>,
 	/// Integer variable changes that occurred during the execution of the
 	/// current propagator.
+	#[deepclone(clone)]
 	int_events: FxHashMap<u32, IntEvent>,
 	/// Boolean variable changes that occurred during the execution of the
 	/// current propagator.
 	bool_events: Vec<Decision<bool>>,
 
 	/// Definitions of the advisors that are listening to selected changes.
+	#[deepclone(clone)]
 	advisors: Vec<Advisor>,
 }
 
@@ -654,6 +661,15 @@ impl Model {
 	}
 }
 
+impl Clone for Model {
+	/// Deep, because a copied model has to be independent of the original.
+	/// Sharing within it survives: an object two constraints both hold stays
+	/// one object, held by both of their copies.
+	fn clone(&self) -> Self {
+		self.deep_clone()
+	}
+}
+
 impl ConstructionActions for Model {
 	fn new_trailed<T: Bytes>(&mut self, init: T) -> Trailed<T> {
 		self.trail.push(init.to_bytes());
@@ -833,7 +849,7 @@ mod tests {
 	use tracing_test::traced_test;
 
 	use crate::{
-		IntVal,
+		DeepClone, IntVal,
 		actions::{
 			BoolInitActions, BoolInspectionActions, ConstructionActions, IntEvent, IntInitActions,
 			IntInspectionActions, IntPropCond, IntPropagationActions, IntSimplificationActions,
@@ -850,7 +866,7 @@ mod tests {
 
 	/// A constraint that acquires the decisions it constrains after it has been
 	/// posted, and only ever subscribes to the ones it has not seen before.
-	#[derive(Clone, Debug)]
+	#[derive(Clone, Debug, DeepClone)]
 	struct GrowingModel {
 		/// The decisions the constraint has been given so far.
 		decisions: Vec<View<IntVal>>,
@@ -860,7 +876,7 @@ mod tests {
 		advised: Trailed<IntVal>,
 	}
 
-	#[derive(Clone, Debug)]
+	#[derive(Clone, Debug, DeepClone)]
 	struct TestModel {
 		b: View<bool>,
 		i: View<IntVal>,

--- a/crates/huub/src/model/decision.rs
+++ b/crates/huub/src/model/decision.rs
@@ -3,11 +3,12 @@
 pub(crate) mod boolean;
 pub(crate) mod integer;
 
-use crate::solver::Polarity;
+use crate::{DeepClone, solver::Polarity};
 
 /// A typed handle to a decision variable in a model.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct Decision<T: DecisionReference>(pub(crate) T::Ref);
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
+#[deepclone(bound = "T: DecisionReference, T::Ref: Clone")]
+pub struct Decision<T: DecisionReference>(#[deepclone(clone)] pub(crate) T::Ref);
 
 /// Marker trait for types that can be used as model decision references.
 pub trait DecisionReference: private::Sealed + 'static {

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -33,7 +33,7 @@ use crate::{
 	model::{
 		Model,
 		deserialize::{AnyView, Branching, Goal},
-		expressions::{BoolFormula, linear::IntLinearExp},
+		expressions::linear::IntLinearExp,
 		view::{View, boolean::BoolView},
 	},
 	solver::{
@@ -1674,7 +1674,7 @@ impl<'a> FznModelBuilder<'a> {
 						return num_args_err(1);
 					};
 					let es = self.arg_array(es)?;
-					let es: Vec<BoolFormula> = es
+					let es: Vec<_> = es
 						.iter()
 						.map(|l| self.lit_bool(l).map(Into::into))
 						.try_collect()?;

--- a/crates/huub/src/model/expressions.rs
+++ b/crates/huub/src/model/expressions.rs
@@ -13,11 +13,10 @@ use std::{cmp, marker::PhantomData, num::NonZero};
 
 use bon::bon;
 use itertools::{Itertools, MinMaxResult, iproduct};
+use pindakaas::propositional_logic::Formula;
 use rangelist::RangeList;
 
-pub use crate::model::expressions::{
-	bool_formula::BoolFormula, element::ElementConstraint, linear::IntLinearExp,
-};
+pub use crate::model::expressions::{element::ElementConstraint, linear::IntLinearExp};
 use crate::{
 	IntSet, IntVal,
 	actions::{
@@ -42,7 +41,11 @@ use crate::{
 		int_value_precede::{IntSeqPrecedeChainBounds, IntValuePrecedeChainValue},
 	},
 	helpers::overflow::{OverflowImpossible, OverflowPossible},
-	model::{Model, View, expressions::linear::Comparator, view::integer::IntView},
+	model::{
+		Model, View,
+		expressions::{bool_formula::BoolFormula, linear::Comparator},
+		view::integer::IntView,
+	},
 };
 
 #[bon]
@@ -525,10 +528,10 @@ impl Model {
 	) -> Result<(), Nogood<View<bool>>> {
 		match reif {
 			Some(Reification::ReifiedBy(b)) => {
-				formula = BoolFormula::Equiv(vec![BoolFormula::Atom(b), formula]);
+				formula = Formula::Equiv(vec![Formula::Atom(b), formula.0]).into();
 			}
 			Some(Reification::ImpliedBy(b)) => {
-				formula = BoolFormula::Implies(BoolFormula::Atom(b).into(), formula.into());
+				formula = Formula::Implies(Formula::Atom(b).into(), formula.0.into()).into();
 			}
 			None => {}
 		}

--- a/crates/huub/src/model/expressions/bool_formula.rs
+++ b/crates/huub/src/model/expressions/bool_formula.rs
@@ -7,6 +7,7 @@ use pindakaas::{
 };
 
 use crate::{
+	DeepClone,
 	actions::{
 		BoolInitActions, BoolInspectionActions, BoolPropagationActions, InitActions,
 		PropagationActions, ReasoningEngine, SimplificationActions,
@@ -20,9 +21,35 @@ use crate::{
 	solver::view::boolean::BoolView,
 };
 
-/// Type alias for the type used to represent propositional logic formulas that
-/// can be used in [`Model`](crate::model::Model).
-pub type BoolFormula = Formula<View<bool>>;
+/// A pindakaas [`Formula`](pindakaas::propositional_logic::Formula) wrapped so
+/// that it can be posted as a constraint.
+#[derive(Clone, Debug, DeepClone)]
+pub struct BoolFormula(#[deepclone(clone)] pub(crate) Formula<View<bool>>);
+
+/// Subscribe every atom in `formula` to be notified when it is fixed.
+fn subscribe_atoms<E>(formula: &mut Formula<View<bool>>, ctx: &mut E::InitializationContext<'_>)
+where
+	E: ReasoningEngine,
+	View<bool>: BoolSolverActions<E>,
+{
+	match formula {
+		Formula::And(v) => v.iter_mut().for_each(|f| subscribe_atoms::<E>(f, ctx)),
+		Formula::Atom(a) => a.enqueue_when_fixed(ctx),
+		Formula::Equiv(v) => v.iter_mut().for_each(|f| subscribe_atoms::<E>(f, ctx)),
+		Formula::IfThenElse { cond, then, els } => {
+			subscribe_atoms::<E>(cond, ctx);
+			subscribe_atoms::<E>(then, ctx);
+			subscribe_atoms::<E>(els, ctx);
+		}
+		Formula::Implies(f1, f2) => {
+			subscribe_atoms::<E>(f1, ctx);
+			subscribe_atoms::<E>(f2, ctx);
+		}
+		Formula::Not(f) => subscribe_atoms::<E>(f, ctx),
+		Formula::Or(v) => v.iter_mut().for_each(|f| subscribe_atoms::<E>(f, ctx)),
+		Formula::Xor(v) => v.iter_mut().for_each(|f| subscribe_atoms::<E>(f, ctx)),
+	}
+}
 
 impl<E> Constraint<E> for BoolFormula
 where
@@ -40,14 +67,14 @@ where
 			};
 			Ok(bv)
 		};
-		let result = self.clone().simplify_with(&mut resolver);
+		let result = self.0.clone().simplify_with(&mut resolver);
 		let mut f = match result {
 			Ok(f) => f,
 			Err(true) => return Ok(SimplificationStatus::Subsumed),
 			Err(false) => return Err(ctx.declare_conflict(NO_REASON)),
 		};
 
-		let negate = |f: BoolFormula| match f {
+		let negate = |f: Formula<View<bool>>| match f {
 			Formula::Atom(x) => Formula::Atom(!x),
 			Formula::Not(x) if matches!(*x, Formula::Atom(_)) => {
 				let Formula::Atom(x) = *x else { unreachable!() };
@@ -88,7 +115,7 @@ where
 			};
 		}
 
-		*self = match f {
+		self.0 = match f {
 			Formula::And(v) => {
 				for f in v {
 					match f {
@@ -100,7 +127,7 @@ where
 							x.fix(ctx, false, NO_REASON)?;
 						}
 						f => {
-							ctx.post_constraint(f);
+							ctx.post_constraint(BoolFormula(f));
 						}
 					}
 				}
@@ -124,7 +151,7 @@ where
 				BoolView::Lit(l) => Ok(l.0),
 			}
 		};
-		let result: Result<Formula<RawLit>, _> = self.clone().simplify_with(&mut resolver);
+		let result: Result<Formula<RawLit>, _> = self.0.clone().simplify_with(&mut resolver);
 		match result {
 			Err(false) => Err(slv.declare_conflict(NO_REASON).into()),
 			Err(true) => Ok(()),
@@ -133,9 +160,15 @@ where
 	}
 }
 
+impl From<Formula<View<bool>>> for BoolFormula {
+	fn from(f: Formula<View<bool>>) -> Self {
+		BoolFormula(f)
+	}
+}
+
 impl From<View<bool>> for BoolFormula {
 	fn from(v: View<bool>) -> Self {
-		Self::Atom(v)
+		BoolFormula(Formula::Atom(v))
 	}
 }
 
@@ -146,23 +179,7 @@ where
 {
 	fn initialize(&mut self, ctx: &mut E::InitializationContext<'_>) {
 		ctx.enqueue_now(true);
-		match self {
-			Formula::And(v) => v.iter_mut().for_each(|f| f.initialize(ctx)),
-			Formula::Atom(a) => a.enqueue_when_fixed(ctx),
-			Formula::Equiv(v) => v.iter_mut().for_each(|f| f.initialize(ctx)),
-			Formula::IfThenElse { cond, then, els } => {
-				cond.initialize(ctx);
-				then.initialize(ctx);
-				els.initialize(ctx);
-			}
-			Formula::Implies(f1, f2) => {
-				f1.initialize(ctx);
-				f2.initialize(ctx);
-			}
-			Formula::Not(f) => f.initialize(ctx),
-			Formula::Or(v) => v.iter_mut().for_each(|f| f.initialize(ctx)),
-			Formula::Xor(v) => v.iter_mut().for_each(|f| f.initialize(ctx)),
-		}
+		subscribe_atoms::<E>(&mut self.0, ctx);
 	}
 
 	fn propagate(
@@ -170,6 +187,12 @@ where
 		_: &mut <E as ReasoningEngine>::PropagationContext<'_>,
 	) -> Result<(), <E as ReasoningEngine>::Conflict> {
 		unreachable!()
+	}
+}
+
+impl From<View<bool>> for Formula<View<bool>> {
+	fn from(v: View<bool>) -> Self {
+		Formula::Atom(v)
 	}
 }
 
@@ -190,7 +213,7 @@ mod tests {
 		// Test case for And with a true literal
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f: BoolFormula = And(vec![Atom(x), Atom(true.into())]);
+		let mut f = BoolFormula(And(vec![Atom(x), Atom(true.into())]));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -203,7 +226,7 @@ mod tests {
 		// Test case for And with a false literal
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f: BoolFormula = And(vec![Atom(x), Atom(false.into())]);
+		let mut f = BoolFormula(And(vec![Atom(x), Atom(false.into())]));
 		assert!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -220,7 +243,7 @@ mod tests {
 		// Test case for Equiv(x, true) -> x
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f: BoolFormula = Equiv(vec![Atom(x), Atom(true.into())]);
+		let mut f = BoolFormula(Equiv(vec![Atom(x), Atom(true.into())]));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -233,7 +256,7 @@ mod tests {
 		// Test case for Equiv(x, false) -> !x
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f: BoolFormula = Equiv(vec![Atom(x), Atom(false.into())]);
+		let mut f = BoolFormula(Equiv(vec![Atom(x), Atom(false.into())]));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -252,11 +275,11 @@ mod tests {
 		let mut prb = Model::default();
 		let t = prb.new_bool_decision();
 		let e = prb.new_bool_decision();
-		let mut f: BoolFormula = IfThenElse {
+		let mut f = BoolFormula(IfThenElse {
 			cond: Box::new(Atom(true.into())),
 			then: Box::new(Atom(t)),
 			els: Box::new(Atom(e)),
-		};
+		});
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -271,11 +294,11 @@ mod tests {
 		let mut prb = Model::default();
 		let t = prb.new_bool_decision();
 		let e = prb.new_bool_decision();
-		let mut f: BoolFormula = IfThenElse {
+		let mut f = BoolFormula(IfThenElse {
 			cond: Box::new(Atom(false.into())),
 			then: Box::new(Atom(t)),
 			els: Box::new(Atom(e)),
-		};
+		});
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -294,7 +317,7 @@ mod tests {
 		// Test case for Implies(true, y) -> y
 		let mut prb = Model::default();
 		let y = prb.new_bool_decision();
-		let mut f: BoolFormula = Implies(Box::new(Atom(true.into())), Box::new(Atom(y)));
+		let mut f = BoolFormula(Implies(Box::new(Atom(true.into())), Box::new(Atom(y))));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -307,7 +330,7 @@ mod tests {
 		// Test case for Implies(x, false) -> !x
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f: BoolFormula = Implies(Box::new(Atom(x)), Box::new(Atom(false.into())));
+		let mut f = BoolFormula(Implies(Box::new(Atom(x)), Box::new(Atom(false.into()))));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -325,7 +348,7 @@ mod tests {
 		// Test case for Not(Not(x))
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f: BoolFormula = Not(Box::new(Not(Box::new(Atom(x)))));
+		let mut f = BoolFormula(Not(Box::new(Not(Box::new(Atom(x))))));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -339,7 +362,7 @@ mod tests {
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
-		let mut f: BoolFormula = Not(Box::new(And(vec![Atom(x), Atom(y)])));
+		let mut f = BoolFormula(Not(Box::new(And(vec![Atom(x), Atom(y)]))));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -347,13 +370,13 @@ mod tests {
 			),
 			Ok(SimplificationStatus::NoFixpoint)
 		);
-		assert_eq!(f, Or(vec![Atom(!x), Atom(!y)]));
+		assert_eq!(f.0, Or(vec![Atom(!x), Atom(!y)]));
 
 		// Test case for De Morgan's law with Or
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
-		let mut f: BoolFormula = Not(Box::new(Or(vec![Atom(x), Atom(y)])));
+		let mut f = BoolFormula(Not(Box::new(Or(vec![Atom(x), Atom(y)]))));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -368,7 +391,7 @@ mod tests {
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
-		let mut f: BoolFormula = Not(Box::new(Implies(Box::new(Atom(x)), Box::new(Atom(y)))));
+		let mut f = BoolFormula(Not(Box::new(Implies(Box::new(Atom(x)), Box::new(Atom(y))))));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -384,11 +407,11 @@ mod tests {
 		let c = prb.new_bool_decision();
 		let t = prb.new_bool_decision();
 		let e = prb.new_bool_decision();
-		let mut f: BoolFormula = Not(Box::new(IfThenElse {
+		let mut f = BoolFormula(Not(Box::new(IfThenElse {
 			cond: Box::new(Atom(c)),
 			then: Box::new(Atom(t)),
 			els: Box::new(Atom(e)),
-		}));
+		})));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -397,7 +420,7 @@ mod tests {
 			Ok(SimplificationStatus::NoFixpoint)
 		);
 		assert_eq!(
-			f,
+			f.0,
 			IfThenElse {
 				cond: Box::new(Atom(c)),
 				then: Box::new(Not(Box::new(Atom(t)))),
@@ -409,7 +432,7 @@ mod tests {
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
-		let mut f: BoolFormula = Not(Box::new(Equiv(vec![Atom(x), Atom(y)])));
+		let mut f = BoolFormula(Not(Box::new(Equiv(vec![Atom(x), Atom(y)]))));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -424,7 +447,7 @@ mod tests {
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
-		let mut f: BoolFormula = Not(Box::new(Xor(vec![Atom(x), Atom(y)])));
+		let mut f = BoolFormula(Not(Box::new(Xor(vec![Atom(x), Atom(y)]))));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -432,14 +455,14 @@ mod tests {
 			),
 			Ok(SimplificationStatus::NoFixpoint)
 		);
-		assert_eq!(f, Equiv(vec![Atom(x), Atom(y)]));
+		assert_eq!(f.0, Equiv(vec![Atom(x), Atom(y)]));
 
 		// Test case for Not(Xor(x, y, z))
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
 		let z = prb.new_bool_decision();
-		let mut f: BoolFormula = Not(Box::new(Xor(vec![Atom(x), Atom(y), Atom(z)])));
+		let mut f = BoolFormula(Not(Box::new(Xor(vec![Atom(x), Atom(y), Atom(z)]))));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -447,7 +470,7 @@ mod tests {
 			),
 			Ok(SimplificationStatus::NoFixpoint)
 		);
-		assert_eq!(f, Xor(vec![Atom(!x), Atom(y), Atom(z)]));
+		assert_eq!(f.0, Xor(vec![Atom(!x), Atom(y), Atom(z)]));
 	}
 
 	#[test]
@@ -457,7 +480,7 @@ mod tests {
 		// Test case for Or with a true literal
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f: BoolFormula = Or(vec![Atom(x), Atom(true.into())]);
+		let mut f = BoolFormula(Or(vec![Atom(x), Atom(true.into())]));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -470,7 +493,7 @@ mod tests {
 		// Test case for Or with a false literal
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f: BoolFormula = Or(vec![Atom(x), Atom(false.into())]);
+		let mut f = BoolFormula(Or(vec![Atom(x), Atom(false.into())]));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -488,7 +511,7 @@ mod tests {
 		// Test case for Xor(x, false) -> x
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f: BoolFormula = Xor(vec![Atom(x), Atom(false.into())]);
+		let mut f = BoolFormula(Xor(vec![Atom(x), Atom(false.into())]));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,
@@ -501,7 +524,7 @@ mod tests {
 		// Test case for Xor(x, true) -> !x
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f: BoolFormula = Xor(vec![Atom(x), Atom(true.into())]);
+		let mut f = BoolFormula(Xor(vec![Atom(x), Atom(true.into())]));
 		assert_eq!(
 			<BoolFormula as Constraint<Model>>::simplify(
 				&mut f,

--- a/crates/huub/src/model/resolved.rs
+++ b/crates/huub/src/model/resolved.rs
@@ -3,7 +3,7 @@
 use std::{num::NonZero, ops::Not};
 
 use crate::{
-	IntVal,
+	Cloner, DeepClone, IntVal,
 	actions::IntInspectionActions,
 	model::{
 		Decision, Model, View,
@@ -56,6 +56,14 @@ impl Resolved<View<IntVal>> {
 			IntView::Linear(lin) => Some(Resolved(lin.var)),
 			IntView::Const(_) | IntView::Bool(_) => None,
 		}
+	}
+}
+
+impl<T> DeepClone for Resolved<T> {
+	fn deep_clone_in(&self, _: &mut Cloner) -> Self {
+		unreachable!(
+			"resolved views should not be cloned as it can then no longer guarantee it stays resolved."
+		)
 	}
 }
 

--- a/crates/huub/src/model/view.rs
+++ b/crates/huub/src/model/view.rs
@@ -3,6 +3,8 @@
 pub(crate) mod boolean;
 pub(crate) mod integer;
 
+use crate::DeepClone;
+
 /// Trait implemented by types that provide a default model view.
 pub trait DefaultView: private::Sealed + 'static {
 	/// The view type associated with this default view.
@@ -10,7 +12,8 @@ pub trait DefaultView: private::Sealed + 'static {
 }
 
 /// A typed view over a decision variable or constant in the model.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
+#[deepclone(bound = "T: DefaultView, T::View: DeepClone")]
 pub struct View<T: DefaultView>(pub(crate) T::View);
 
 /// Sealing helpers for model view traits.

--- a/crates/huub/src/model/view/boolean.rs
+++ b/crates/huub/src/model/view/boolean.rs
@@ -7,8 +7,10 @@ use std::{
 	ops::{Add, Mul, Not, Sub},
 };
 
+use pindakaas::propositional_logic::Formula;
+
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::{
 		BoolAnalyzeActions, BoolInspectionActions, BoolPropagationActions,
 		BoolSimplificationActions, IntInspectionActions, IntPropCond, PropagationActions,
@@ -18,14 +20,14 @@ use crate::{
 	model::{
 		Advisor, AdvisorId, ConstraintId, Model, SimplificationContext, SimplificationReasonSink,
 		decision::Decision,
-		expressions::BoolFormula,
+		expressions::bool_formula::BoolFormula,
 		resolved::Resolved,
 		view::{DefaultView, View, private},
 	},
 	solver::{IntLitMeaning, Polarity, activation_list::ActivationAction},
 };
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 /// Inner storage for [`BoolDecision`], kept private to prevent access from
 /// users.
 #[non_exhaustive]
@@ -161,11 +163,11 @@ impl Resolved<View<bool>> {
 				Ok(())
 			}
 			(x, y) => {
-				let x = BoolFormula::Atom(View(x));
-				let y = BoolFormula::Atom(View(y));
+				let x = Formula::Atom(View(x));
+				let y = Formula::Atom(View(y));
 
 				ctx.0
-					.post_constraint_internal(BoolFormula::Equiv(vec![x, y]));
+					.post_constraint_internal(BoolFormula(Formula::Equiv(vec![x, y])));
 				Ok(())
 			}
 		}

--- a/crates/huub/src/model/view/integer.rs
+++ b/crates/huub/src/model/view/integer.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::{
-	IntSet, IntVal,
+	DeepClone, IntSet, IntVal,
 	actions::{
 		BoolPropagationActions, IntAnalyzeActions, IntDecisionActions, IntExplanationActions,
 		IntInspectionActions, IntPropagationActions, IntSimplificationActions, PropagationActions,
@@ -28,7 +28,7 @@ use crate::{
 /// The internal representation of [`IntDecision`].
 ///
 /// Note that this representation is not meant to be exposed to the user.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum IntView {
 	/// Constant Integer Value

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -1374,12 +1374,13 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 	///
 	/// ```
 	/// # use huub::{
+	/// # 	DeepClone,
 	/// # 	actions::{IntInitActions, IntPropCond, PostingActions, ReasoningEngine},
 	/// # 	constraints::Propagator,
 	/// # 	solver::{Engine, Solver, View},
 	/// # };
 	/// /// A propagator that is told which decisions to watch after it is posted.
-	/// #[derive(Clone, Debug)]
+	/// #[derive(Clone, Debug, DeepClone)]
 	/// struct Watcher {
 	/// 	decisions: Vec<View<i64>>,
 	/// 	subscribed: usize,
@@ -1721,7 +1722,7 @@ mod tests {
 	use std::{cell::RefCell, rc::Rc};
 
 	use crate::{
-		IntVal,
+		DeepClone, IntVal,
 		actions::{
 			BrancherInitActions, IntDecisionActions, IntEvent, IntInitActions, IntPropCond,
 			ReasoningEngine,
@@ -1736,7 +1737,7 @@ mod tests {
 
 	/// A propagator that acquires the decisions it constrains after it has been
 	/// posted, and only ever subscribes to the ones it has not seen before.
-	#[derive(Clone, Debug)]
+	#[derive(Clone, Debug, DeepClone)]
 	struct GrowingPropagator {
 		/// The decisions the propagator has been given so far.
 		decisions: Vec<View<IntVal>>,
@@ -1833,6 +1834,48 @@ mod tests {
 
 		let _ = slv.solve().satisfy();
 		assert_eq!(*advised.borrow(), 0);
+	}
+
+	/// Two propagators that share one object must still share one object after
+	/// the solver is cloned, and it must be a copy rather than the original.
+	#[test]
+	fn test_solver_clone_shares_one_copy_of_shared_state() {
+		let mut slv: Solver = Solver::default();
+		let advised = Rc::new(RefCell::new(0));
+		let props: Vec<PropagatorId> = (0..2)
+			.map(|_| {
+				slv.add_propagator(
+					Box::new(GrowingPropagator {
+						decisions: Vec::new(),
+						subscribed: 0,
+						cancel: false,
+						advised: Rc::clone(&advised),
+					}),
+					false,
+				)
+			})
+			.collect();
+
+		let mut copy = slv.clone();
+		let first = Rc::clone(
+			&copy
+				.propagator_mut::<GrowingPropagator>(props[0])
+				.expect("propagator is a GrowingPropagator")
+				.advised,
+		);
+		let second = Rc::clone(
+			&copy
+				.propagator_mut::<GrowingPropagator>(props[1])
+				.expect("propagator is a GrowingPropagator")
+				.advised,
+		);
+
+		assert!(Rc::ptr_eq(&first, &second));
+		assert!(!Rc::ptr_eq(&first, &advised));
+
+		*first.borrow_mut() = 7;
+		assert_eq!(*advised.borrow(), 0);
+		assert_eq!(*second.borrow(), 7);
 	}
 
 	impl Propagator<Engine> for GrowingPropagator {

--- a/crates/huub/src/solver/branchers.rs
+++ b/crates/huub/src/solver/branchers.rs
@@ -2,12 +2,11 @@
 
 use std::{cmp, fmt::Debug};
 
-use dyn_clone::DynClone;
 use itertools::Itertools;
 use rangelist::IntervalIterator;
 
 use crate::{
-	IntSet, IntVal,
+	DeepClone, DynDeepClone, IntSet, IntVal,
 	actions::{
 		BoolInspectionActions, BrancherInitActions, DecisionActions, IntDecisionActions,
 		IntInspectionActions, ReasoningContext, Trailed,
@@ -21,7 +20,7 @@ use crate::{
 
 /// General brancher for Boolean decision variables that makes search decisions
 /// by following a given [`DecisionSelection`] and [`DomainSelection`] strategy.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct BoolBrancher {
 	/// Boolean decision variables to be branched on.
 	vars: Vec<Decision<bool>>,
@@ -42,14 +41,14 @@ pub struct BoolBrancher {
 pub(crate) type BoxedBrancher = Box<dyn for<'a> Brancher<SolvingContext<'a>>>;
 
 /// A trait for making search decisions in the solver.
-pub trait Brancher<D: DecisionActions>: Debug + DynClone {
+pub trait Brancher<D: DecisionActions>: Debug + DynDeepClone {
 	/// Make a next search decision using the given decision actions.
 	fn decide(&mut self, actions: &mut D) -> Directive;
 }
 
 /// Strategy of selecting the next decision variable for a [`BoolBrancher`] or
 /// [`IntBrancher`].
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum DecisionSelection {
 	/// Select the unfixed decision variable with the largest remaining domain
@@ -100,7 +99,7 @@ pub enum Directive {
 
 /// Strategy for limiting the domain of a selected decision variable for a
 /// [`BoolBrancher`] or [`IntBrancher`].
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum DomainSelection {
 	/// If the domain consists of several contiguous intervals, reduce the
@@ -137,7 +136,7 @@ pub enum DomainSelection {
 
 /// General brancher for integer decision variables that makes search decisions
 /// by following a given [`DecisionSelection`] and [`DomainSelection`] strategy.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, PartialEq)]
 pub struct IntBrancher {
 	/// Integer decision variables to be branched on.
 	vars: Vec<View<IntVal>>,
@@ -163,7 +162,7 @@ pub struct IntBrancher {
 /// A brancher that enforces Boolean conditions and is abandoned when a
 /// conflict is encountered. These branchers are generally used to warm start,
 /// i.e. quickly reach, a (partial) known or expected solution.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, DeepClone, Eq, PartialEq)]
 pub struct WarmStartBrancher {
 	/// Boolean conditions to be tried.
 	decisions: Vec<Decision<bool>>,
@@ -300,12 +299,6 @@ where
 
 		// Branch on the selected decision variable using the precomputed polarity.
 		Directive::Select(if self.value { var } else { !var }.into())
-	}
-}
-
-impl Clone for BoxedBrancher {
-	fn clone(&self) -> BoxedBrancher {
-		dyn_clone::clone_box(&**self)
 	}
 }
 

--- a/crates/huub/src/solver/decision.rs
+++ b/crates/huub/src/solver/decision.rs
@@ -3,9 +3,12 @@
 pub(crate) mod boolean;
 pub(crate) mod integer;
 
+use crate::DeepClone;
+
 /// A typed handle to a decision variable in the solver.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct Decision<T: DecisionReference>(pub(crate) T::Ref);
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
+#[deepclone(bound = "T: DecisionReference, T::Ref: Clone")]
+pub struct Decision<T: DecisionReference>(#[deepclone(clone)] pub(crate) T::Ref);
 
 /// Marker trait for types that can be used as solver decision references.
 pub trait DecisionReference: private::Sealed + 'static {

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -33,7 +33,7 @@ pub(crate) use trace_new_lit;
 use tracing::{debug, trace, warn};
 
 use crate::{
-	Clause, IntVal,
+	Clause, DeepClone, IntVal,
 	actions::{
 		BoolInspectionActions, IntEvent, ReasonActions, ReasoningContext, ReasoningEngine, Trailed,
 		TrailingActions,
@@ -77,13 +77,14 @@ pub(crate) struct AdvisorId(u32);
 
 /// A propagation engine implementing the
 /// [`Propagator`](crate::constraints::Propagator) trait.
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, DeepClone, Default)]
 pub struct Engine {
 	/// Storage of the propagators.
 	pub(crate) propagators: Vec<BoxedPropagator>,
 	/// Storage of the branchers.
 	pub(crate) branchers: Vec<BoxedBrancher>,
 	/// Internal State representation of the propagation engine.
+	#[deepclone(clone)]
 	pub(crate) state: State,
 }
 
@@ -396,6 +397,15 @@ impl Engine {
 		} else {
 			self.propagators[prop.index()].advise_of_bool_change(&mut self.state, data)
 		}
+	}
+}
+
+impl Clone for Engine {
+	/// Deep, because a copied engine has to be independent of the original.
+	/// Sharing within it survives: an object a propagator and a brancher both
+	/// hold stays one object, held by both of their copies.
+	fn clone(&self) -> Self {
+		self.deep_clone()
 	}
 }
 
@@ -1166,7 +1176,7 @@ mod tests {
 	use pindakaas::solver::propagation::Propagator as ExternalPropagator;
 
 	use crate::{
-		IntVal,
+		DeepClone, IntVal,
 		actions::{
 			BoolPropagationActions, InitActions, IntDecisionActions, IntEvent, IntInitActions,
 			IntPropCond, IntPropagationActions, ReasoningEngine,
@@ -1194,7 +1204,7 @@ mod tests {
 	fn queued_integer_event_survives_sat_assignment() {
 		use std::{cell::RefCell, rc::Rc};
 
-		#[derive(Clone, Debug)]
+		#[derive(Clone, Debug, DeepClone)]
 		struct ProducerAndListener {
 			req_first: Decision<bool>,
 			notifications: Rc<RefCell<usize>>,

--- a/crates/huub/src/solver/view.rs
+++ b/crates/huub/src/solver/view.rs
@@ -3,6 +3,8 @@
 pub(crate) mod boolean;
 pub(crate) mod integer;
 
+use crate::DeepClone;
+
 /// Trait implemented by types that provide a default solver view.
 pub trait DefaultView: private::Sealed + 'static {
 	/// The view type associated with this default view.
@@ -10,7 +12,8 @@ pub trait DefaultView: private::Sealed + 'static {
 }
 
 /// A typed view over a decision variable or constant in the solver.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
+#[deepclone(bound = "T: DefaultView, T::View: DeepClone")]
 pub struct View<T: DefaultView>(pub(crate) T::View);
 
 /// Sealing helpers for solver view traits.

--- a/crates/huub/src/solver/view/boolean.rs
+++ b/crates/huub/src/solver/view/boolean.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-	IntVal,
+	DeepClone, IntVal,
 	actions::BoolInspectionActions,
 	solver::{
 		Decision,
@@ -25,6 +25,7 @@ use crate::{
 ///
 /// Note that this representation is not meant to be exposed to the user.
 #[non_exhaustive]
+#[derive(DeepClone)]
 pub enum BoolView {
 	/// A Boolean literal in the solver.
 	Lit(Decision<bool>),

--- a/crates/huub/src/solver/view/integer.rs
+++ b/crates/huub/src/solver/view/integer.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-	IntSet, IntVal,
+	DeepClone, IntSet, IntVal,
 	actions::{
 		BoolInspectionActions, BoolPropagationActions, IntDecisionActions, IntExplanationActions,
 		IntInspectionActions, IntPropagationActions, PropagationActions, ReasoningContext,
@@ -22,7 +22,7 @@ use crate::{
 /// The internal representation of [`IntView`].
 ///
 /// Note that this representation is not meant to be exposed to the user.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub enum IntView {
 	/// Constant Integer Value

--- a/crates/huub/src/views/linear_bool_view.rs
+++ b/crates/huub/src/views/linear_bool_view.rs
@@ -13,7 +13,7 @@ use std::{
 use rangelist::IntervalIterator;
 
 use crate::{
-	IntSet, IntVal,
+	DeepClone, IntSet, IntVal,
 	actions::{
 		BoolAnalyzeActions, BoolInspectionActions, BoolOperations, BoolPropagationActions,
 		BoolSimplificationActions, IntAnalyzeActions, IntDecisionActions, IntExplanationActions,
@@ -58,7 +58,7 @@ use crate::{
 /// // From a boolean variable directly (scale = 1, offset = 0):
 /// let as_int = LinearBoolView::from(v.clone()); // Domain {0, 1}
 /// ```
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct LinearBoolView<Scale, Offset, Var> {
 	/// Scale applied to the decision variable.
 	///

--- a/crates/huub/src/views/linear_view.rs
+++ b/crates/huub/src/views/linear_view.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use crate::{
-	IntSet, IntVal,
+	DeepClone, IntSet, IntVal,
 	actions::{
 		IntAnalyzeActions, IntDecisionActions, IntExplanationActions, IntInspectionActions,
 		IntPropCond, IntPropagationActions, IntSimplificationActions, PropagationActions,
@@ -45,7 +45,7 @@ use crate::{
 /// y += 5;                 // y = 2*x + 8
 /// y *= NonZero::new(-1).unwrap(); // y = -2*x - 8
 /// ```
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct LinearView<Scale, Offset, Var> {
 	/// Scale applied to the decision variable.
 	pub(crate) scale: Scale,

--- a/crates/huub/src/views/offset_view.rs
+++ b/crates/huub/src/views/offset_view.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::{
-	IntSet, IntVal,
+	DeepClone, IntSet, IntVal,
 	actions::{
 		IntAnalyzeActions, IntDecisionActions, IntExplanationActions, IntInspectionActions,
 		IntPropagationActions, PropagationContext, ReasoningContext,
@@ -51,7 +51,7 @@ use crate::{
 ///
 /// See also:
 /// - [`LinearView`] for general linear transformations of integer variables.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, DeepClone, Eq, Hash, PartialEq)]
 pub struct OffsetView<Offset, Var> {
 	/// Offset applied to the decision variable.
 	pub(crate) offset: Offset,


### PR DESCRIPTION
`dyn-clone` reproduces `Clone`, so a propagator holding an `Rc` could not be
copied correctly: cloning a `Solver` either aliased the shared object or split
it in two. `deepclone` threads a memo through the clone, so an object reached
twice is copied once and both copies point at it.

BREAKING CHANGE: `Propagator`, `Constraint`, and `Brancher` now require
`DynDeepClone` rather than `DynClone`; implementors derive `DeepClone`, marking
fields that share nothing with `#[deepclone(clone)]`. `BoolFormula` now is a
new-type struct.
