### PR TITLE
ci: match MiniZinc's release platforms and compatibility

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,6 +12,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  MACOSX_DEPLOYMENT_TARGET: "12.0" # Match the MiniZinc compiler's deployment target.
   RUST_BACKTRACE: 1
   RUSTUP_MAX_RETRIES: 10
 
@@ -23,32 +24,30 @@ jobs:
   upload-assets:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     if: github.repository_owner == 'huub-solver' && (startsWith(github.event.release.name, 'huub-v') || github.event_name == 'push' )
     strategy:
       matrix:
+        # Use `manylinux_2_28` images to match the MiniZinc compiler and pin the
+        # glibc baseline to 2.28.
         include:
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04
-          - target: aarch64-unknown-linux-musl
-            os: ubuntu-22.04
-          - target: aarch64-apple-darwin
-            os: macos-latest
-          # TODO: Possibly add support (requires work on CaDiCaL compilation)
-          # - target: aarch64-pc-windows-msvc
-          #   os: windows-2022
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-22.04
-          - target: x86_64-apple-darwin
-            os: macos-15-intel
-          - target: x86_64-pc-windows-msvc
-            os: windows-2022
-          - target: x86_64-unknown-freebsd
-            os: ubuntu-22.04
+          - { target: aarch64-unknown-linux-gnu,  os: ubuntu-24.04-arm, container: "quay.io/pypa/manylinux_2_28_aarch64" }
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-24.04,     container: "" }
+          - { target: aarch64-apple-darwin,       os: macos-14,         container: "" }
+          - { target: aarch64-pc-windows-msvc,    os: windows-11-arm,   container: "" }
+          - { target: x86_64-unknown-linux-gnu,   os: ubuntu-24.04,     container: "quay.io/pypa/manylinux_2_28_x86_64" }
+          - { target: x86_64-unknown-linux-musl,  os: ubuntu-24.04,     container: "" }
+          - { target: x86_64-apple-darwin,        os: macos-26-intel,   container: "" }
+          - { target: x86_64-pc-windows-msvc,     os: windows-2022,     container: "" }
+          - { target: x86_64-unknown-freebsd,     os: ubuntu-24.04,     container: "" }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+      # The container runs as root while the workspace belongs to the runner
+      # user, which git otherwise refuses to read.
+      - name: Trust the workspace
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+        if: matrix.container != ''
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Generate MiniZinc solver configuration
@@ -58,8 +57,8 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
-        if: startsWith(matrix.os, 'ubuntu') && !contains(matrix.target, '-musl')
-      - uses: taiki-e/install-action@v2.86.1
+        if: matrix.target == 'x86_64-unknown-freebsd'
+      - uses: taiki-e/install-action@v2.86.5
         with:
           tool: cross
         if: contains(matrix.target, '-musl')

--- a/crates/huub/src/constraints/int_div.rs
+++ b/crates/huub/src/constraints/int_div.rs
@@ -16,7 +16,7 @@ use crate::{
 	},
 	helpers::div_ceil,
 	lower::{LoweringContext, LoweringError},
-	model::{expressions::bool_formula::BoolFormula, view::View},
+	model::{expressions::proposition::PropositionConstraint, view::View},
 	solver::{IntLitMeaning, engine::Engine, queue::PriorityLevel},
 };
 
@@ -213,23 +213,23 @@ where
 		let res_neg = self.result.lit(ctx, IntLitMeaning::Less(1));
 
 		// num >= 0 /\ denom > 0 => res >= 0
-		<BoolFormula as Constraint<E>>::simplify(
-			&mut BoolFormula(Or(vec![!Atom(num_pos), !Atom(denom_pos), Atom(res_pos)])),
+		<PropositionConstraint as Constraint<E>>::simplify(
+			&mut PropositionConstraint(Or(vec![!Atom(num_pos), !Atom(denom_pos), Atom(res_pos)])),
 			ctx,
 		)?;
 		// num <= 0 /\ denom < 0 => res >= 0
-		<BoolFormula as Constraint<E>>::simplify(
-			&mut BoolFormula(Or(vec![!Atom(num_neg), !Atom(denom_neg), Atom(res_pos)])),
+		<PropositionConstraint as Constraint<E>>::simplify(
+			&mut PropositionConstraint(Or(vec![!Atom(num_neg), !Atom(denom_neg), Atom(res_pos)])),
 			ctx,
 		)?;
 		// num >= 0 /\ denom < 0 => res >= 0
-		<BoolFormula as Constraint<E>>::simplify(
-			&mut BoolFormula(Or(vec![!Atom(num_pos), !Atom(denom_neg), Atom(res_neg)])),
+		<PropositionConstraint as Constraint<E>>::simplify(
+			&mut PropositionConstraint(Or(vec![!Atom(num_pos), !Atom(denom_neg), Atom(res_neg)])),
 			ctx,
 		)?;
 		// num <= 0 /\ denom > 0 => res <= 0
-		<BoolFormula as Constraint<E>>::simplify(
-			&mut BoolFormula(Or(vec![!Atom(num_neg), !Atom(denom_pos), Atom(res_neg)])),
+		<PropositionConstraint as Constraint<E>>::simplify(
+			&mut PropositionConstraint(Or(vec![!Atom(num_neg), !Atom(denom_pos), Atom(res_neg)])),
 			ctx,
 		)?;
 

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -31,7 +31,7 @@ use crate::{
 		true_type::True,
 	},
 	lower::{LoweringContext, LoweringError},
-	model::{self, expressions::bool_formula::BoolFormula},
+	model::{self, expressions::proposition::PropositionConstraint},
 	solver::{
 		self, BoolView, Decision, IntLitMeaning, Polarity, queue::PriorityLevel,
 		view::integer::IntView,
@@ -397,7 +397,7 @@ where
 				};
 				match self.reif.unwrap() {
 					Reification::ImpliedBy(r) => {
-						let _ = ctx.post_constraint(BoolFormula(Formula::Implies(
+						let _ = ctx.post_constraint(PropositionConstraint(Formula::Implies(
 							Box::new(r.into()),
 							Box::new(lit.into()),
 						)));

--- a/crates/huub/src/constraints/int_set_contains.rs
+++ b/crates/huub/src/constraints/int_set_contains.rs
@@ -17,7 +17,7 @@ use crate::{
 		NO_REASON, Propagator, SimplificationStatus,
 	},
 	lower::{LoweringContext, LoweringError},
-	model::{expressions::bool_formula::BoolFormula, view::View},
+	model::{expressions::proposition::PropositionConstraint, view::View},
 };
 
 /// Representation of the integer `contains` constraint within a model.
@@ -111,8 +111,8 @@ where
 		if self.set.iter().len() == 1 {
 			let lb = *self.set.min().unwrap();
 			let ub = *self.set.max().unwrap();
-			<BoolFormula as Constraint<E>>::to_solver(
-				&BoolFormula(Formula::Equiv(vec![
+			<PropositionConstraint as Constraint<E>>::to_solver(
+				&PropositionConstraint(Formula::Equiv(vec![
 					Formula::And(vec![self.var.geq(lb).into(), self.var.leq(ub).into()]),
 					self.reif.into(),
 				])),
@@ -125,8 +125,11 @@ where
 				.flatten()
 				.map(|v| self.var.eq(v).into())
 				.collect();
-			<BoolFormula as Constraint<E>>::to_solver(
-				&BoolFormula(Formula::Equiv(vec![self.reif.into(), Formula::Or(eq_lits)])),
+			<PropositionConstraint as Constraint<E>>::to_solver(
+				&PropositionConstraint(Formula::Equiv(vec![
+					self.reif.into(),
+					Formula::Or(eq_lits),
+				])),
 				slv,
 			)
 		}

--- a/crates/huub/src/model/expressions.rs
+++ b/crates/huub/src/model/expressions.rs
@@ -5,18 +5,20 @@
 //! constraint to the model, or use a `.define()` or `.reify()` helper when the
 //! builder supports creating the result decision variable for you.
 
-pub(crate) mod bool_formula;
 pub(crate) mod element;
 pub(crate) mod linear;
+pub(crate) mod proposition;
 
 use std::{cmp, marker::PhantomData, num::NonZero};
 
 use bon::bon;
 use itertools::{Itertools, MinMaxResult, iproduct};
-use pindakaas::propositional_logic::Formula;
+pub use pindakaas::propositional_logic::Formula as Proposition;
 use rangelist::RangeList;
 
-pub use crate::model::expressions::{element::ElementConstraint, linear::IntLinearExp};
+pub use crate::model::expressions::{
+	element::ElementConstraint, linear::IntLinearExp, proposition::PropositionConstraint,
+};
 use crate::{
 	IntSet, IntVal,
 	actions::{
@@ -41,11 +43,7 @@ use crate::{
 		int_value_precede::{IntSeqPrecedeChainBounds, IntValuePrecedeChainValue},
 	},
 	helpers::overflow::{OverflowImpossible, OverflowPossible},
-	model::{
-		Model, View,
-		expressions::{bool_formula::BoolFormula, linear::Comparator},
-		view::integer::IntView,
-	},
+	model::{Model, View, expressions::linear::Comparator, view::integer::IntView},
 };
 
 #[bon]
@@ -523,15 +521,16 @@ impl Model {
 	#[builder(finish_fn = post)]
 	pub fn proposition(
 		&mut self,
-		#[builder(start_fn, into)] mut formula: BoolFormula,
+		#[builder(start_fn, into)] mut formula: PropositionConstraint,
 		#[builder(setters(name = reif_internal, vis = ""))] reif: Option<Reification>,
 	) -> Result<(), Nogood<View<bool>>> {
 		match reif {
 			Some(Reification::ReifiedBy(b)) => {
-				formula = Formula::Equiv(vec![Formula::Atom(b), formula.0]).into();
+				formula = Proposition::Equiv(vec![Proposition::Atom(b), formula.0]).into();
 			}
 			Some(Reification::ImpliedBy(b)) => {
-				formula = Formula::Implies(Formula::Atom(b).into(), formula.0.into()).into();
+				formula =
+					Proposition::Implies(Proposition::Atom(b).into(), formula.0.into()).into();
 			}
 			None => {}
 		}

--- a/crates/huub/src/model/expressions/proposition.rs
+++ b/crates/huub/src/model/expressions/proposition.rs
@@ -21,10 +21,10 @@ use crate::{
 	solver::view::boolean::BoolView,
 };
 
-/// A pindakaas [`Formula`](pindakaas::propositional_logic::Formula) wrapped so
-/// that it can be posted as a constraint.
+/// A [`Proposition`](crate::model::expressions::Proposition) wrapped so that it
+/// can be posted as a constraint.
 #[derive(Clone, Debug, DeepClone)]
-pub struct BoolFormula(#[deepclone(clone)] pub(crate) Formula<View<bool>>);
+pub struct PropositionConstraint(#[deepclone(clone)] pub(crate) Formula<View<bool>>);
 
 /// Subscribe every atom in `formula` to be notified when it is fixed.
 fn subscribe_atoms<E>(formula: &mut Formula<View<bool>>, ctx: &mut E::InitializationContext<'_>)
@@ -51,7 +51,13 @@ where
 	}
 }
 
-impl<E> Constraint<E> for BoolFormula
+impl From<View<bool>> for Formula<View<bool>> {
+	fn from(v: View<bool>) -> Self {
+		Formula::Atom(v)
+	}
+}
+
+impl<E> Constraint<E> for PropositionConstraint
 where
 	E: ReasoningEngine,
 	for<'a> E::PropagationContext<'a>: SimplificationActions<Target = E>,
@@ -127,7 +133,7 @@ where
 							x.fix(ctx, false, NO_REASON)?;
 						}
 						f => {
-							ctx.post_constraint(BoolFormula(f));
+							ctx.post_constraint(PropositionConstraint(f));
 						}
 					}
 				}
@@ -160,19 +166,19 @@ where
 	}
 }
 
-impl From<Formula<View<bool>>> for BoolFormula {
+impl From<Formula<View<bool>>> for PropositionConstraint {
 	fn from(f: Formula<View<bool>>) -> Self {
-		BoolFormula(f)
+		PropositionConstraint(f)
 	}
 }
 
-impl From<View<bool>> for BoolFormula {
+impl From<View<bool>> for PropositionConstraint {
 	fn from(v: View<bool>) -> Self {
-		BoolFormula(Formula::Atom(v))
+		PropositionConstraint(Formula::Atom(v))
 	}
 }
 
-impl<E> Propagator<E> for BoolFormula
+impl<E> Propagator<E> for PropositionConstraint
 where
 	E: ReasoningEngine,
 	View<bool>: BoolSolverActions<E>,
@@ -190,12 +196,6 @@ where
 	}
 }
 
-impl From<View<bool>> for Formula<View<bool>> {
-	fn from(v: View<bool>) -> Self {
-		Formula::Atom(v)
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use pindakaas::propositional_logic::Formula;
@@ -203,7 +203,7 @@ mod tests {
 	use crate::{
 		actions::BoolInspectionActions,
 		constraints::{Constraint, SimplificationStatus},
-		model::{Model, SimplificationContext, expressions::bool_formula::BoolFormula},
+		model::{Model, SimplificationContext, expressions::proposition::PropositionConstraint},
 	};
 
 	#[test]
@@ -213,9 +213,9 @@ mod tests {
 		// Test case for And with a true literal
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f = BoolFormula(And(vec![Atom(x), Atom(true.into())]));
+		let mut f = PropositionConstraint(And(vec![Atom(x), Atom(true.into())]));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -226,9 +226,9 @@ mod tests {
 		// Test case for And with a false literal
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f = BoolFormula(And(vec![Atom(x), Atom(false.into())]));
+		let mut f = PropositionConstraint(And(vec![Atom(x), Atom(false.into())]));
 		assert!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			)
@@ -243,9 +243,9 @@ mod tests {
 		// Test case for Equiv(x, true) -> x
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f = BoolFormula(Equiv(vec![Atom(x), Atom(true.into())]));
+		let mut f = PropositionConstraint(Equiv(vec![Atom(x), Atom(true.into())]));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -256,9 +256,9 @@ mod tests {
 		// Test case for Equiv(x, false) -> !x
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f = BoolFormula(Equiv(vec![Atom(x), Atom(false.into())]));
+		let mut f = PropositionConstraint(Equiv(vec![Atom(x), Atom(false.into())]));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -275,13 +275,13 @@ mod tests {
 		let mut prb = Model::default();
 		let t = prb.new_bool_decision();
 		let e = prb.new_bool_decision();
-		let mut f = BoolFormula(IfThenElse {
+		let mut f = PropositionConstraint(IfThenElse {
 			cond: Box::new(Atom(true.into())),
 			then: Box::new(Atom(t)),
 			els: Box::new(Atom(e)),
 		});
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -294,13 +294,13 @@ mod tests {
 		let mut prb = Model::default();
 		let t = prb.new_bool_decision();
 		let e = prb.new_bool_decision();
-		let mut f = BoolFormula(IfThenElse {
+		let mut f = PropositionConstraint(IfThenElse {
 			cond: Box::new(Atom(false.into())),
 			then: Box::new(Atom(t)),
 			els: Box::new(Atom(e)),
 		});
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -317,9 +317,9 @@ mod tests {
 		// Test case for Implies(true, y) -> y
 		let mut prb = Model::default();
 		let y = prb.new_bool_decision();
-		let mut f = BoolFormula(Implies(Box::new(Atom(true.into())), Box::new(Atom(y))));
+		let mut f = PropositionConstraint(Implies(Box::new(Atom(true.into())), Box::new(Atom(y))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -330,9 +330,9 @@ mod tests {
 		// Test case for Implies(x, false) -> !x
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f = BoolFormula(Implies(Box::new(Atom(x)), Box::new(Atom(false.into()))));
+		let mut f = PropositionConstraint(Implies(Box::new(Atom(x)), Box::new(Atom(false.into()))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -348,9 +348,9 @@ mod tests {
 		// Test case for Not(Not(x))
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f = BoolFormula(Not(Box::new(Not(Box::new(Atom(x))))));
+		let mut f = PropositionConstraint(Not(Box::new(Not(Box::new(Atom(x))))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -362,9 +362,9 @@ mod tests {
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
-		let mut f = BoolFormula(Not(Box::new(And(vec![Atom(x), Atom(y)]))));
+		let mut f = PropositionConstraint(Not(Box::new(And(vec![Atom(x), Atom(y)]))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -376,9 +376,9 @@ mod tests {
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
-		let mut f = BoolFormula(Not(Box::new(Or(vec![Atom(x), Atom(y)]))));
+		let mut f = PropositionConstraint(Not(Box::new(Or(vec![Atom(x), Atom(y)]))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -391,9 +391,10 @@ mod tests {
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
-		let mut f = BoolFormula(Not(Box::new(Implies(Box::new(Atom(x)), Box::new(Atom(y))))));
+		let mut f =
+			PropositionConstraint(Not(Box::new(Implies(Box::new(Atom(x)), Box::new(Atom(y))))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -407,13 +408,13 @@ mod tests {
 		let c = prb.new_bool_decision();
 		let t = prb.new_bool_decision();
 		let e = prb.new_bool_decision();
-		let mut f = BoolFormula(Not(Box::new(IfThenElse {
+		let mut f = PropositionConstraint(Not(Box::new(IfThenElse {
 			cond: Box::new(Atom(c)),
 			then: Box::new(Atom(t)),
 			els: Box::new(Atom(e)),
 		})));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -432,9 +433,9 @@ mod tests {
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
-		let mut f = BoolFormula(Not(Box::new(Equiv(vec![Atom(x), Atom(y)]))));
+		let mut f = PropositionConstraint(Not(Box::new(Equiv(vec![Atom(x), Atom(y)]))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -447,9 +448,9 @@ mod tests {
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
-		let mut f = BoolFormula(Not(Box::new(Xor(vec![Atom(x), Atom(y)]))));
+		let mut f = PropositionConstraint(Not(Box::new(Xor(vec![Atom(x), Atom(y)]))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -462,9 +463,9 @@ mod tests {
 		let x = prb.new_bool_decision();
 		let y = prb.new_bool_decision();
 		let z = prb.new_bool_decision();
-		let mut f = BoolFormula(Not(Box::new(Xor(vec![Atom(x), Atom(y), Atom(z)]))));
+		let mut f = PropositionConstraint(Not(Box::new(Xor(vec![Atom(x), Atom(y), Atom(z)]))));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -480,9 +481,9 @@ mod tests {
 		// Test case for Or with a true literal
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f = BoolFormula(Or(vec![Atom(x), Atom(true.into())]));
+		let mut f = PropositionConstraint(Or(vec![Atom(x), Atom(true.into())]));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -493,9 +494,9 @@ mod tests {
 		// Test case for Or with a false literal
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f = BoolFormula(Or(vec![Atom(x), Atom(false.into())]));
+		let mut f = PropositionConstraint(Or(vec![Atom(x), Atom(false.into())]));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -511,9 +512,9 @@ mod tests {
 		// Test case for Xor(x, false) -> x
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f = BoolFormula(Xor(vec![Atom(x), Atom(false.into())]));
+		let mut f = PropositionConstraint(Xor(vec![Atom(x), Atom(false.into())]));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),
@@ -524,9 +525,9 @@ mod tests {
 		// Test case for Xor(x, true) -> !x
 		let mut prb = Model::default();
 		let x = prb.new_bool_decision();
-		let mut f = BoolFormula(Xor(vec![Atom(x), Atom(true.into())]));
+		let mut f = PropositionConstraint(Xor(vec![Atom(x), Atom(true.into())]));
 		assert_eq!(
-			<BoolFormula as Constraint<Model>>::simplify(
+			<PropositionConstraint as Constraint<Model>>::simplify(
 				&mut f,
 				&mut SimplificationContext(&mut prb)
 			),

--- a/crates/huub/src/model/view/boolean.rs
+++ b/crates/huub/src/model/view/boolean.rs
@@ -20,7 +20,7 @@ use crate::{
 	model::{
 		Advisor, AdvisorId, ConstraintId, Model, SimplificationContext, SimplificationReasonSink,
 		decision::Decision,
-		expressions::bool_formula::BoolFormula,
+		expressions::proposition::PropositionConstraint,
 		resolved::Resolved,
 		view::{DefaultView, View, private},
 	},
@@ -167,7 +167,7 @@ impl Resolved<View<bool>> {
 				let y = Formula::Atom(View(y));
 
 				ctx.0
-					.post_constraint_internal(BoolFormula(Formula::Equiv(vec![x, y])));
+					.post_constraint_internal(PropositionConstraint(Formula::Equiv(vec![x, y])));
 				Ok(())
 			}
 		}

--- a/docs/src/modelling/constraints.md
+++ b/docs/src/modelling/constraints.md
@@ -234,21 +234,16 @@ Boolean formulas allow you to express complex logical conditions using conjuncti
 ```rust
 # extern crate huub;
 # use huub::model::Model;
-# use huub::model::expressions::BoolFormula;
+# use huub::model::expressions::Proposition;
 # let mut model = Model::default();
 let x = model.new_bool_decision();
 let y = model.new_bool_decision();
 let z = model.new_bool_decision();
 
 // Create a formula: (x AND y) OR NOT z
-let formula = BoolFormula::Or(vec![
-	  BoolFormula::And(vec![
-		    BoolFormula::Atom(x),
-		    BoolFormula::Atom(y),
-	  ]),
-	  BoolFormula::Not(Box::new(
-	    	BoolFormula::Atom(z),
-	  )),
+let formula = Proposition::Or(vec![
+	Proposition::And(vec![Proposition::Atom(x), Proposition::Atom(y)]),
+	Proposition::Not(Box::new(Proposition::Atom(z))),
 ]);
 
 model.proposition(formula).post();


### PR DESCRIPTION
Huub is intended to ship alongside MiniZinc, so its binaries have to run
wherever the MiniZinc compiler's do.

- Build the GNU/Linux targets in the `manylinux_2_28` images, pinning the
  glibc baseline to 2.28 instead of the runner's 2.35.
- Set `MACOSX_DEPLOYMENT_TARGET` to 12.0 rather than following the runner
  image's default.
- Add `aarch64-pc-windows-msvc` on the native `windows-11-arm` runner,
  which sidesteps the CaDiCaL cross-compilation that blocked it before.
