### PR TITLE
refactor(xtask): compile the CLI definition instead of linking huub-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ version = "100.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "huub-cli",
+ "humantime",
  "serde",
  "serde_json",
 ]

--- a/crates/huub-cli/src/cli.rs
+++ b/crates/huub-cli/src/cli.rs
@@ -1,22 +1,24 @@
 //! Command-line argument definitions and parsing helpers.
+//!
+//! This module depends on nothing but `clap` and `humantime`, so that the
+//! `xtask` crate can compile it directly (through `#[path]`) to generate the
+//! shell completions and the MiniZinc solver configuration without building the
+//! solver. Anything that requires the `huub` library lives elsewhere in this
+//! crate, including the solver defaults that the `DEFAULT_*` constants below
+//! repeat; `crate::tests::solver_backed_defaults` asserts that the two agree.
 
 use std::{
 	ffi::OsString,
 	fmt::{self, Debug, Write},
-	fs::OpenOptions,
 	io,
 	path::PathBuf,
-	sync::Arc,
 	time::Duration,
 };
 
-use anstream::AutoStream;
 use clap::{
 	ArgAction, Args, ColorChoice, Parser, ValueEnum,
 	builder::{BoolishValueParser, StyledStr, styling::Styles},
 };
-use huub::lower::{Lowerer, ReduceType};
-use tracing_subscriber::fmt::writer::BoxMakeWriter;
 
 /// Long description for the command-line interface.
 const CLI_LONG_ABOUT: &str = r#"Create a Huub Solver instance tailored to a given FlatZinc JSON input file and solve the problem.
@@ -34,6 +36,30 @@ const CLI_SECTION_INIT: &str = "Initialization Options";
 const CLI_SECTION_PROCESSING: &str = "Preprocessing/Inprocessing Options";
 /// Help heading used for search flags.
 const CLI_SECTION_SEARCH: &str = "Search Options";
+/// Default value for the `--cadical-conditioning` flag.
+const DEFAULT_CONDITIONING: bool = false;
+/// Default value for the `--cadical-inprocessing` flag.
+const DEFAULT_INPROCESSING: bool = false;
+/// Default value for the `--int-eager-limit` flag.
+const DEFAULT_INT_EAGER_LIMIT: usize = 255;
+/// Default value for the `--cadical-preprocessing` flag.
+const DEFAULT_PREPROCESSING: usize = 0;
+/// Default value for the `--cadical-preprocessing-light` flag.
+const DEFAULT_PREPROCESSING_LIGHT: bool = false;
+/// Default value for the `--cadical-probing` flag.
+const DEFAULT_PROBING: bool = false;
+/// Default value for the `--cadical-reason-eager` flag.
+const DEFAULT_REASON_EAGER: bool = false;
+/// Default value for the `--cadical-reduce-interval` flag.
+const DEFAULT_REDUCE_INTERVAL: usize = 100;
+/// Default value for the `--restart` flag.
+const DEFAULT_RESTART: bool = false;
+/// Default value for the `--cadical-subsumption` flag.
+const DEFAULT_SUBSUMPTION: bool = false;
+/// Default value for the `--cadical-variable-elimination` flag.
+const DEFAULT_VARIABLE_ELIMINATION: bool = false;
+/// Default value for the `--cadical-vivify` flag.
+const DEFAULT_VIVIFICATION: bool = false;
 
 /// CaDiCaL-specific solver options.
 ///
@@ -43,44 +69,44 @@ const CLI_SECTION_SEARCH: &str = "Search Options";
 #[derive(Args, Debug)]
 pub(crate) struct CadicalOptions {
 	/// Control globally blocked clause elimination (conditioning).
-	#[arg(long = "cadical-conditioning", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_CONDITIONING, help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long = "cadical-conditioning", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = DEFAULT_CONDITIONING, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) conditioning: bool,
 	/// Control SAT inprocessing during search.
-	#[arg(long = "cadical-inprocessing", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_INPROCESSING, help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long = "cadical-inprocessing", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = DEFAULT_INPROCESSING, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) inprocessing: bool,
 	/// Run the given number of SAT preprocessing rounds before search.
 	#[arg(
 		long = "cadical-preprocessing",
 		value_name = "usize",
-		default_value_t = Lowerer::DEFAULT_PREPROCESSING,
+		default_value_t = DEFAULT_PREPROCESSING,
 		help_heading = CLI_SECTION_PROCESSING
 	)]
 	pub(crate) preprocessing: usize,
 	/// Whether to enable CaDiCaL's light preprocessing.
-	#[arg(long = "cadical-preprocessing-light", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_PREPROCESSING_LIGHT, help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long = "cadical-preprocessing-light", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = DEFAULT_PREPROCESSING_LIGHT, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) preprocessing_light: bool,
 	/// Control failed-literal probing in the SAT solver.
-	#[arg(long = "cadical-probing", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_PROBING, help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long = "cadical-probing", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = DEFAULT_PROBING, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) probing: bool,
 	/// Request explanation clauses for all literals propagated at the conflict
 	/// level.
-	#[arg(long = "cadical-reason-eager", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_REASON_EAGER, help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long = "cadical-reason-eager", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = DEFAULT_REASON_EAGER, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) reason_eager: bool,
 	/// Set the interval (in conflicts) between clause-database reductions.
-	#[arg(long = "cadical-reduce-interval", value_name = "usize", default_value_t = Lowerer::DEFAULT_REDUCE_INTERVAL, help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long = "cadical-reduce-interval", value_name = "usize", default_value_t = DEFAULT_REDUCE_INTERVAL, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) reduce_interval: usize,
 	/// Set the function used to compute the target size of the learned clause
 	/// database when it is reduced.
 	#[arg(long = "cadical-reduce-type", value_enum, value_name = "type", default_value_t = CliReduceType::Sqrt, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) reduce_type: CliReduceType,
 	/// Control global forward subsumption in the SAT solver.
-	#[arg(long = "cadical-subsumption", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_SUBSUMPTION, help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long = "cadical-subsumption", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = DEFAULT_SUBSUMPTION, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) subsumption: bool,
 	/// Control bounded variable elimination in the SAT solver.
-	#[arg(long = "cadical-variable-elimination", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_VARIABLE_ELIMINATION, help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long = "cadical-variable-elimination", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = DEFAULT_VARIABLE_ELIMINATION, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) variable_elimination: bool,
 	/// Control clause vivification.
-	#[arg(long = "cadical-vivify", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_VIVIFICATION, help_heading = CLI_SECTION_PROCESSING)]
+	#[arg(long = "cadical-vivify", action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = DEFAULT_VIVIFICATION, help_heading = CLI_SECTION_PROCESSING)]
 	pub(crate) vivification: bool,
 }
 
@@ -158,11 +184,11 @@ pub struct Cli<'a> {
 	pub(crate) color: ColorChoice,
 
 	/// Maximum domain size for eagerly creating order literals.
-	#[arg(long, value_name = "usize", default_value_t = Lowerer::DEFAULT_INT_EAGER_LIMIT, help_heading = CLI_SECTION_INIT)]
+	#[arg(long, value_name = "usize", default_value_t = DEFAULT_INT_EAGER_LIMIT, help_heading = CLI_SECTION_INIT)]
 	pub(crate) int_eager_limit: usize,
 
 	/// Control whether the solver may restart, overwritten by `-f`.
-	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = Lowerer::DEFAULT_RESTART, help_heading = CLI_SECTION_SEARCH)]
+	#[arg(long, action = ArgAction::Set, value_parser = BoolishValueParser::new(), value_name = "bool", default_value_t = DEFAULT_RESTART, help_heading = CLI_SECTION_SEARCH)]
 	pub(crate) restart: bool,
 	/// Set the overarching search strategy used by the solver, overwritten by
 	/// `-f`.
@@ -274,44 +300,6 @@ fn parse_time_limit(s: &str) -> Result<Duration, humantime::DurationError> {
 }
 
 impl<'a> Cli<'a> {
-	/// Collect the active tracing targets after applying user overrides.
-	pub(crate) fn trace_targets(&self) -> Vec<String> {
-		let mut trace_targets = vec!["solver".to_owned(), "flatzinc".to_owned()];
-		trace_targets.extend(self.trace_target.iter().cloned());
-		for target in &self.no_trace_target {
-			trace_targets.retain(|value| value != target);
-		}
-		trace_targets
-	}
-
-	/// Build the tracing writer and whether ANSI colors should be enabled.
-	pub(crate) fn trace_writer(&self) -> Result<(BoxMakeWriter, bool), String> {
-		match &self.log_file {
-			Some(path) => {
-				let file = OpenOptions::new()
-					.create(true)
-					.write(true)
-					.truncate(true)
-					.open(path)
-					.map_err(|err| {
-						format!("Unable to open log file “{}”: {err}", path.display())
-					})?;
-				Ok((BoxMakeWriter::new(Arc::new(file)), false))
-			}
-			None => Ok((
-				BoxMakeWriter::new(io::stderr),
-				match self.color {
-					ColorChoice::Always => true,
-					ColorChoice::Never => false,
-					ColorChoice::Auto => !matches!(
-						AutoStream::choice(&io::stderr()),
-						anstream::ColorChoice::Never
-					),
-				},
-			)),
-		}
-	}
-
 	/// Set the writer that is used for the standard (solution) output.
 	pub fn with_stdout<'new, W: io::Write + 'new>(self, stdout: W) -> Cli<'new> {
 		Cli {
@@ -392,22 +380,11 @@ impl Debug for Cli<'_> {
 	}
 }
 
-impl From<CliReduceType> for ReduceType {
-	fn from(value: CliReduceType) -> Self {
-		match value {
-			CliReduceType::Prct => ReduceType::Percent,
-			CliReduceType::Sqrt => ReduceType::Sqrt,
-			CliReduceType::Log => ReduceType::Log,
-		}
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use std::{path::PathBuf, time::Duration};
 
 	use clap::ColorChoice;
-	use huub::lower::{Lowerer, ReduceType};
 
 	use crate::cli::{Cli, CliReduceType};
 
@@ -507,10 +484,6 @@ mod tests {
 		.unwrap();
 
 		assert_eq!(cli.cadical.reduce_type, CliReduceType::Prct);
-		assert_eq!(
-			ReduceType::from(cli.cadical.reduce_type),
-			ReduceType::Percent
-		);
 		assert_eq!(cli.cadical.reduce_interval, 250);
 
 		for (input, expected) in [
@@ -535,37 +508,6 @@ mod tests {
 	}
 
 	#[test]
-	fn solver_backed_defaults() {
-		let cli = Cli::try_parse_from(["huub", "instance.fzn.json"]).unwrap();
-
-		assert_eq!(cli.int_eager_limit, Lowerer::DEFAULT_INT_EAGER_LIMIT);
-		assert_eq!(cli.restart, Lowerer::DEFAULT_RESTART);
-		assert_eq!(cli.cadical.conditioning, Lowerer::DEFAULT_CONDITIONING);
-		assert_eq!(cli.cadical.inprocessing, Lowerer::DEFAULT_INPROCESSING);
-		assert_eq!(cli.cadical.preprocessing, Lowerer::DEFAULT_PREPROCESSING);
-		assert_eq!(
-			cli.cadical.preprocessing_light,
-			Lowerer::DEFAULT_PREPROCESSING_LIGHT
-		);
-		assert_eq!(cli.cadical.probing, Lowerer::DEFAULT_PROBING);
-		assert_eq!(cli.cadical.reason_eager, Lowerer::DEFAULT_REASON_EAGER);
-		assert_eq!(
-			cli.cadical.reduce_interval,
-			Lowerer::DEFAULT_REDUCE_INTERVAL
-		);
-		assert_eq!(
-			ReduceType::from(cli.cadical.reduce_type),
-			Lowerer::DEFAULT_REDUCE_TYPE
-		);
-		assert_eq!(cli.cadical.subsumption, Lowerer::DEFAULT_SUBSUMPTION);
-		assert_eq!(
-			cli.cadical.variable_elimination,
-			Lowerer::DEFAULT_VARIABLE_ELIMINATION
-		);
-		assert_eq!(cli.cadical.vivification, Lowerer::DEFAULT_VIVIFICATION);
-	}
-
-	#[test]
 	fn string_args() {
 		let cli = Cli::try_parse_from([
 			"huub",
@@ -579,10 +521,8 @@ mod tests {
 		])
 		.unwrap();
 
-		assert_eq!(
-			cli.trace_targets(),
-			vec!["flatzinc".to_owned(), "brancher".to_owned()]
-		);
+		assert_eq!(cli.trace_target, vec!["brancher".to_owned()]);
+		assert_eq!(cli.no_trace_target, vec!["solver".to_owned()]);
 		assert_eq!(cli.log_file.unwrap().to_string_lossy(), "huub.log");
 	}
 

--- a/crates/huub-cli/src/lib.rs
+++ b/crates/huub-cli/src/lib.rs
@@ -37,7 +37,7 @@ use std::{
 
 use flatzinc_serde::{FlatZinc, Literal, Method, NamedRef, Variable, helpers::ArcKey};
 use huub::{
-	lower::LoweringError,
+	lower::{LoweringError, ReduceType},
 	model::deserialize::{
 		Goal,
 		flatzinc::{FlatZincError, FznIdent, HuubFlatZinc},
@@ -53,7 +53,7 @@ use tracing::{subscriber::set_default, warn};
 
 pub use crate::cli::Cli;
 use crate::{
-	cli::{CliSearchStrategy, CliSearchTrigger},
+	cli::{CliReduceType, CliSearchStrategy, CliSearchTrigger},
 	trace::ReverseMap,
 };
 
@@ -423,6 +423,16 @@ impl<'a> Cli<'a> {
 	}
 }
 
+impl From<CliReduceType> for ReduceType {
+	fn from(value: CliReduceType) -> Self {
+		match value {
+			CliReduceType::Prct => ReduceType::Percent,
+			CliReduceType::Sqrt => ReduceType::Sqrt,
+			CliReduceType::Log => ReduceType::Log,
+		}
+	}
+}
+
 impl SolutionWrap<'_> {
 	/// Method used to print a literal that is part of a solution.
 	fn print_lit(&self, lit: &Literal<FznIdent>) -> String {
@@ -471,5 +481,53 @@ impl Display for SolutionWrap<'_> {
 			}
 		}
 		writeln!(f, "{FZN_SEPARATOR}")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use huub::lower::{Lowerer, ReduceType};
+
+	use crate::cli::{Cli, CliReduceType};
+
+	#[test]
+	fn reduce_type_conversion() {
+		assert_eq!(ReduceType::from(CliReduceType::Prct), ReduceType::Percent);
+		assert_eq!(ReduceType::from(CliReduceType::Sqrt), ReduceType::Sqrt);
+		assert_eq!(ReduceType::from(CliReduceType::Log), ReduceType::Log);
+	}
+
+	/// The [`Cli`] defaults are spelled out in `cli.rs`, so that the module can
+	/// be compiled without the `huub` library. This test is what keeps them
+	/// from drifting away from the values that [`Lowerer`] uses.
+	#[test]
+	fn solver_backed_defaults() {
+		let cli = Cli::try_parse_from(["huub", "instance.fzn.json"]).unwrap();
+
+		assert_eq!(cli.int_eager_limit, Lowerer::DEFAULT_INT_EAGER_LIMIT);
+		assert_eq!(cli.restart, Lowerer::DEFAULT_RESTART);
+		assert_eq!(cli.cadical.conditioning, Lowerer::DEFAULT_CONDITIONING);
+		assert_eq!(cli.cadical.inprocessing, Lowerer::DEFAULT_INPROCESSING);
+		assert_eq!(cli.cadical.preprocessing, Lowerer::DEFAULT_PREPROCESSING);
+		assert_eq!(
+			cli.cadical.preprocessing_light,
+			Lowerer::DEFAULT_PREPROCESSING_LIGHT
+		);
+		assert_eq!(cli.cadical.probing, Lowerer::DEFAULT_PROBING);
+		assert_eq!(cli.cadical.reason_eager, Lowerer::DEFAULT_REASON_EAGER);
+		assert_eq!(
+			cli.cadical.reduce_interval,
+			Lowerer::DEFAULT_REDUCE_INTERVAL
+		);
+		assert_eq!(
+			ReduceType::from(cli.cadical.reduce_type),
+			Lowerer::DEFAULT_REDUCE_TYPE
+		);
+		assert_eq!(cli.cadical.subsumption, Lowerer::DEFAULT_SUBSUMPTION);
+		assert_eq!(
+			cli.cadical.variable_elimination,
+			Lowerer::DEFAULT_VARIABLE_ELIMINATION
+		);
+		assert_eq!(cli.cadical.vivification, Lowerer::DEFAULT_VIVIFICATION);
 	}
 }

--- a/crates/huub-cli/src/trace.rs
+++ b/crates/huub-cli/src/trace.rs
@@ -3,12 +3,15 @@
 
 use std::{
 	fmt::{self, Display},
-	io::Write,
+	fs::OpenOptions,
+	io::{self, Write},
 	num::NonZeroI32,
 	str::FromStr,
 	sync::{Arc, Mutex},
 };
 
+use anstream::AutoStream;
+use clap::ColorChoice;
 use flatzinc_serde::{FlatZinc, Type, Variable};
 use huub::{model::deserialize::flatzinc::FznIdent, solver::IntLitMeaning};
 use rustc_hash::FxHashMap;
@@ -25,9 +28,12 @@ use tracing_subscriber::{
 		FormatFields, MakeWriter,
 		format::{DefaultFields, Writer},
 		time::uptime,
+		writer::BoxMakeWriter,
 	},
 	layer::{Context, SubscriberExt},
 };
+
+use crate::cli::Cli;
 
 /// A [`tracing_subscriber::FormatFields`] implementation that attempts to
 /// format literals and integer variables according to their FlatZinc names,
@@ -244,6 +250,46 @@ pub(crate) fn parse_int_list<T: FromStr>(value: &dyn fmt::Debug) -> Option<Vec<T
 		.split(',')
 		.map(|item| item.trim().parse().ok())
 		.collect()
+}
+
+impl Cli<'_> {
+	/// Collect the active tracing targets after applying user overrides.
+	pub(crate) fn trace_targets(&self) -> Vec<String> {
+		let mut trace_targets = vec!["solver".to_owned(), "flatzinc".to_owned()];
+		trace_targets.extend(self.trace_target.iter().cloned());
+		for target in &self.no_trace_target {
+			trace_targets.retain(|value| value != target);
+		}
+		trace_targets
+	}
+
+	/// Build the tracing writer and whether ANSI colors should be enabled.
+	pub(crate) fn trace_writer(&self) -> Result<(BoxMakeWriter, bool), String> {
+		match &self.log_file {
+			Some(path) => {
+				let file = OpenOptions::new()
+					.create(true)
+					.write(true)
+					.truncate(true)
+					.open(path)
+					.map_err(|err| {
+						format!("Unable to open log file “{}”: {err}", path.display())
+					})?;
+				Ok((BoxMakeWriter::new(Arc::new(file)), false))
+			}
+			None => Ok((
+				BoxMakeWriter::new(io::stderr),
+				match self.color {
+					ColorChoice::Always => true,
+					ColorChoice::Never => false,
+					ColorChoice::Auto => !matches!(
+						AutoStream::choice(&io::stderr()),
+						anstream::ColorChoice::Never
+					),
+				},
+			)),
+		}
+	}
 }
 
 impl FmtLitFields {
@@ -642,5 +688,28 @@ impl<S: Subscriber> Layer<S> for ReverseMapLayer {
 		let mut rec = RegistrationEvent::default();
 		event.record(&mut rec);
 		self.map.lock().unwrap().register(&self.fzn, rec);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::cli::Cli;
+
+	#[test]
+	fn trace_target_overrides() {
+		let cli = Cli::try_parse_from([
+			"huub",
+			"--trace-target",
+			"brancher",
+			"--no-trace-target",
+			"solver",
+			"instance.fzn.json",
+		])
+		.unwrap();
+
+		assert_eq!(
+			cli.trace_targets(),
+			vec!["flatzinc".to_owned(), "brancher".to_owned()]
+		);
 	}
 }

--- a/crates/huub-cli/src/trace.rs
+++ b/crates/huub-cli/src/trace.rs
@@ -476,8 +476,8 @@ impl Visit for RegistrationEvent {
 	fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
 		match field.name() {
 			"message" => {
-				// Write message on the stack to avoid heap allocation, and immediately
-				// convert it to a `RegistrationKind`.
+				// Write message on the stack to avoid heap allocation, and
+				// immediately convert it to a `RegistrationKind`.
 				const CAP: usize = "register solver bool-backed int".len();
 				let mut buf = [0_u8; CAP];
 				let mut tail: &mut [u8] = &mut buf;
@@ -600,18 +600,20 @@ impl ReverseMap {
 				let Some(var) = self.solver_int(int_var as usize).cloned() else {
 					return;
 				};
-				// `dom` is a flat list of inclusive range bounds; the domain values
-				// in ascending order are the concatenation of those ranges.
+				// `dom` is a flat list of inclusive range bounds; the domain
+				// values in ascending order are the concatenation of those
+				// ranges.
 				let values = || dom.as_chunks::<2>().0.iter().flat_map(|c| c[0]..=c[1]);
-				// The order literal at `order + k` means `< values[k + 1]`, so one is
-				// created for every domain value except the first.
+				// The order literal at `order + k` means `< values[k + 1]`, so
+				// one is created for every domain value except the first.
 				if let Some(order) = event.order.filter(|&o| o != 0) {
 					for (k, val) in values().skip(1).enumerate() {
 						self.insert_int_lit(order + k as i32, &var, IntLitMeaning::Less(val));
 					}
 				}
-				// The equality literal at `eq + k` means `== values[k + 1]`, so one is
-				// created for every domain value except the first and the last.
+				// The equality literal at `eq + k` means `== values[k + 1]`, so
+				// one is created for every domain value except the first
+				// and the last.
 				if let Some(eq) = event.eq.filter(|&e| e != 0) {
 					let mut it = values();
 					it.next_back();

--- a/crates/huub/examples/jobshop/brancher.rs
+++ b/crates/huub/examples/jobshop/brancher.rs
@@ -288,7 +288,8 @@ impl StaticBranching {
 		let mut vars = Vec::new();
 		match self {
 			StaticBranching::JobInputOrder | StaticBranching::OperationInputOrder => {
-				// Order jobs or operations by their original order in the input.
+				// Order jobs or operations by their original order in the
+				// input.
 				for &op in start_time.iter().flatten() {
 					vars.push(op);
 				}

--- a/crates/huub/src/constraints/circuit.rs
+++ b/crates/huub/src/constraints/circuit.rs
@@ -112,7 +112,8 @@ where
 		let offset = graph.offset;
 		let max_node = offset + graph.vars.len() as IntVal - 1;
 		// Tighten every successor to the node range (offset..=max_node). The
-		// constraint itself implies the range, so the narrowing is unconditional.
+		// constraint itself implies the range, so the narrowing is
+		// unconditional.
 		for v in &graph.vars {
 			v.tighten_min(ctx, offset, NO_REASON)?;
 			v.tighten_max(ctx, max_node, NO_REASON)?;
@@ -169,7 +170,8 @@ where
 		data: u64,
 		event: IntEvent,
 	) -> bool {
-		// Forward advising to `no_cycle` to update its incremental successor state.
+		// Forward advising to `no_cycle` to update its incremental successor
+		// state.
 		self.no_cycle_prop.advise_of_int_change(ctx, data, event)
 	}
 
@@ -353,7 +355,8 @@ mod tests {
 	fn test_circuit_scc_disconnection() {
 		for scc in [false, true] {
 			let mut prb = Model::default();
-			// Nodes 0,1,2 may only point within {0,1,2}; nodes 3,4,5 within {3,4,5}.
+			// Nodes 0,1,2 may only point within {0,1,2}; nodes 3,4,5 within
+			// {3,4,5}.
 			let vars =
 				[1..=3, 1..=3, 1..=3, 4..=6, 4..=6, 4..=6].map(|dom| prb.new_int_decision(dom));
 			let posted = prb

--- a/crates/huub/src/constraints/circuit/no_cycle.rs
+++ b/crates/huub/src/constraints/circuit/no_cycle.rs
@@ -73,7 +73,8 @@ impl<const SUBCIRCUIT: bool, I> CircuitNoCycle<SUBCIRCUIT, I> {
 		I: IntInspectionActions<E> + IntSolverActions<Engine>,
 	{
 		// The domain bounds for variables should exclude out-of-range values
-		// that would otherwise satisfy the constraint without forming a valid cycle.
+		// that would otherwise satisfy the constraint without forming a valid
+		// cycle.
 		let max_node = offset + vars.len() as IntVal - 1;
 		assert!(
 			vars.iter()
@@ -175,8 +176,8 @@ where
 				continue;
 			}
 
-			// Forward walk the fixed chain from `start`, collecting its nodes and
-			// detecting whether the tour is closed.
+			// Forward walk the fixed chain from `start`, collecting its nodes
+			// and detecting whether the tour is closed.
 			scratch.nodes.clear();
 			scratch.nodes.push(start);
 			scratch.visited[start] = true;
@@ -284,7 +285,8 @@ impl NoCycleScratch {
 				reason.reserve(nodes.len());
 				for &i in nodes {
 					if i != end {
-						// Every interior node of the chain is fixed, so its value literal exists.
+						// Every interior node of the chain is fixed, so its
+						// value literal exists.
 						reason.push(graph.vars[i].val_lit(ctx).unwrap());
 					}
 				}
@@ -349,8 +351,8 @@ impl NoCycleScratch {
 			}));
 		}
 
-		// `subcircuit`: every outside node is excluded and must self-loop, all for
-		// the same reason.
+		// `subcircuit`: every outside node is excluded and must self-loop, all
+		// for the same reason.
 		let reason = reason_ty::<C, _>(|ctx, reason| {
 			graph.push_no_edge(ctx, reason, cycle, outside, None);
 			graph.push_forced_in(ctx, reason, start);

--- a/crates/huub/src/constraints/circuit/scc.rs
+++ b/crates/huub/src/constraints/circuit/scc.rs
@@ -159,7 +159,8 @@ impl<const SUBCIRCUIT: bool, I> CircuitScc<SUBCIRCUIT, I> {
 		I: IntInspectionActions<E> + IntSolverActions<Engine>,
 	{
 		// The domain bounds for variables should exclude out-of-range values
-		// that would otherwise satisfy the constraint without forming a valid cycle.
+		// that would otherwise satisfy the constraint without forming a valid
+		// cycle.
 		let max_node = offset + vars.len() as IntVal - 1;
 		assert!(
 			vars.iter()
@@ -202,8 +203,8 @@ where
 	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationContext<'_>) -> Result<(), E::Conflict> {
 		let Self { graph, scratch } = self;
-		// The node count is fixed at construction, and the `circuit` / `subcircuit`
-		// builders never post the propagator below two nodes.
+		// The node count is fixed at construction, and the `circuit` /
+		// `subcircuit` builders never post the propagator below two nodes.
 		let n = graph.vars.len();
 		debug_assert!(n >= 2, "circuit scc posted with fewer than two nodes");
 
@@ -248,7 +249,8 @@ where
 			let (numback, backfrom, backto) =
 				scratch.explore_subtree(graph, ctx, child, prev_lo, prev_hi, k)?;
 
-			// Snapshot the subtree just explored and the still-unexplored nodes.
+			// Snapshot the subtree just explored and the still-unexplored
+			// nodes.
 			scratch.this_subtree.clear();
 			scratch
 				.this_subtree
@@ -284,16 +286,17 @@ where
 					graph.push_no_edge(ctx, reason, &reached, &unreached, None);
 				}));
 			}
-			// `subcircuit`: if a reached node must lie on the cycle, every unreached
-			// node is off it and must self-loop. Every one of those fixes has the same
-			// reason.
+			// `subcircuit`: if a reached node must lie on the cycle, every
+			// unreached node is off it and must self-loop. Every one of
+			// those fixes has the same reason.
 			if let Some(w_in) = reached.iter().copied().find(|&q| graph.forced_in(ctx, q)) {
 				let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
 					graph.push_forced_in(ctx, reason, w_in);
 					graph.push_no_edge(ctx, reason, &reached, &unreached, None);
 				});
-				// `fix` is sound when redundant and fails when the self-loop is absent
-				// (an unreached forced-in node ⇒ a genuine conflict), so do not gate it.
+				// `fix` is sound when redundant and fails when the self-loop is
+				// absent (an unreached forced-in node ⇒ a genuine
+				// conflict), so do not gate it.
 				for &u in &unreached {
 					graph.vars[u].fix(ctx, graph.edge_val(u), reason)?;
 				}
@@ -301,8 +304,8 @@ where
 			return Ok(());
 		}
 
-		// Prune-root: with ≥2 subtrees the root may only enter the last one. The
-		// witness and reason are the same for every pruned root edge.
+		// Prune-root: with ≥2 subtrees the root may only enter the last one.
+		// The witness and reason are the same for every pruned root edge.
 		if k >= 2 {
 			let e_set = scratch.blocks(n, |s| s < k);
 			let l_set = scratch.blocks(n, |s| s == k);
@@ -501,9 +504,9 @@ impl SccScratch {
 			} else {
 				None
 			};
-			// `c_set` reaches nothing outside but `p`, so one reason justifies pruning
-			// both the down edge `p -> c` and every incoming edge `o -> p` (Chuffed
-			// shares the same clause).
+			// `c_set` reaches nothing outside but `p`, so one reason justifies
+			// pruning both the down edge `p -> c` and every incoming edge `o
+			// -> p` (Chuffed shares the same clause).
 			let reason = reason_ty::<C, _>(|ctx, reason| {
 				if let Some((aw, bw)) = wit {
 					graph.push_forced_in(ctx, reason, aw);
@@ -515,7 +518,8 @@ impl SccScratch {
 				graph.vars[p].remove_val(ctx, graph.edge_val(c), reason)?;
 			}
 			// The strengthened incoming prune holds for `circuit` only: in
-			// `subcircuit` an outside node may still enter `p` when `c_set` is excluded.
+			// `subcircuit` an outside node may still enter `p` when `c_set` is
+			// excluded.
 			if !SUBCIRCUIT {
 				let pv = graph.edge_val(p);
 				for &o in &a_set {
@@ -558,8 +562,9 @@ impl SccScratch {
 		}
 		let mut witnesses = None;
 		if SUBCIRCUIT {
-			// Only a contradiction if a forced-in node lies on each side. Check that
-			// before materialising the two node sets, since it usually fails.
+			// Only a contradiction if a forced-in node lies on each side. Check
+			// that before materialising the two node sets, since it usually
+			// fails.
 			let (Some(w_in), Some(w_out)) = (
 				(0..n).find(|&q| self.membership[q] && graph.forced_in(ctx, q)),
 				(0..n).find(|&q| !self.membership[q] && graph.forced_in(ctx, q)),
@@ -615,16 +620,18 @@ impl SccScratch {
 				self.dfs.work_stack.last_mut().unwrap().cursor += 1;
 				let iw = self.dfs.idx[w];
 				if iw != -1 {
-					// Visited neighbour: classify the arc, then fold its index into
-					// the low-link.
+					// Visited neighbour: classify the arc, then fold its index
+					// into the low-link.
 					let iw = iw as usize;
 					if iw >= prev_lo && iw <= prev_hi {
-						// Back arc to the previous subtree (the root for the first one).
+						// Back arc to the previous subtree (the root for the
+						// first one).
 						numback += 1;
 						backfrom = node;
 						backto = w;
 					} else if iw < prev_lo {
-						// Arc to an earlier subtree (or the root for `t >= 2`): a skip arc.
+						// Arc to an earlier subtree (or the root for `t >= 2`):
+						// a skip arc.
 						self.skip_edges.push((node, w));
 					}
 					if (iw as i64) < self.dfs.low[node] {
@@ -643,22 +650,24 @@ impl SccScratch {
 				self.dfs.neighbours.truncate(frame.nbr_start);
 				self.dfs.subtree_hi[frame.node] = self.dfs.next;
 
-				// prune-within: the first child's subtree reaches nothing above its
-				// parent (`low[c] >= idx[parent]`).
+				// prune-within: the first child's subtree reaches nothing above
+				// its parent (`low[c] >= idx[parent]`).
 				if let Some(c) = frame.first_child
 					&& self.dfs.low[c] >= self.dfs.idx[frame.node]
 				{
 					self.within_edges.push((frame.node, c));
 				}
 
-				// Discovered a subtour and check conflict / pruning reasons for it.
+				// Discovered a subtour and check conflict / pruning reasons for
+				// it.
 				if self.dfs.low[frame.node] == self.dfs.idx[frame.node]
 					&& let Some(conflict) = self.closed_conflict(graph, ctx, frame.node)
 				{
 					return Err(conflict);
 				}
 
-				// Fold this node's low-link into its parent (the post-recursion update).
+				// Fold this node's low-link into its parent (the post-recursion
+				// update).
 				if let Some(parent) = self.dfs.work_stack.last() {
 					let p = parent.node;
 					if self.dfs.low[frame.node] < self.dfs.low[p] {
@@ -723,8 +732,8 @@ mod tests {
 	#[traced_test]
 	fn test_scc_detects_closed_subset_reachable_from_root() {
 		let mut slv = Solver::default();
-		// 1-based values; only node 0 points to value 1 (=node 0), so {1,2,3} has
-		// no edge out.
+		// 1-based values; only node 0 points to value 1 (=node 0), so {1,2,3}
+		// has no edge out.
 		let vars = [
 			IntSet::from(2..=4),               // 0 -> nodes 1,2,3
 			IntSet::from(3..=4),               // 1 -> nodes 2,3
@@ -752,8 +761,8 @@ mod tests {
 	#[test]
 	#[traced_test]
 	fn test_scc_detects_disconnection_one_round() {
-		// `scc` alone: {0,1} and {2,3} never point at each other, so a single round
-		// detects the disconnection.
+		// `scc` alone: {0,1} and {2,3} never point at each other, so a single
+		// round detects the disconnection.
 		let mut slv = Solver::default();
 		let vars = [1..=2, 1..=2, 3..=4, 3..=4].map(|dom| {
 			slv.new_int_decision(dom)
@@ -773,8 +782,8 @@ mod tests {
 	#[test]
 	#[should_panic(expected = "domains must exclude out-of-range values")]
 	fn test_scc_post_rejects_out_of_range_successor() {
-		// The same precondition holds for `scc`; here a successor can still take
-		// `4`, one past the 3-node range `1..=3`.
+		// The same precondition holds for `scc`; here a successor can still
+		// take `4`, one past the 3-node range `1..=3`.
 		let mut slv: Solver = Solver::default();
 		let vars = [1..=3, 1..=3, 1..=4].map(|dom| {
 			slv.new_int_decision(dom)

--- a/crates/huub/src/constraints/cumulative.rs
+++ b/crates/huub/src/constraints/cumulative.rs
@@ -219,8 +219,8 @@ impl Cumulative {
 	/// removes no solution and strengthens the energy arguments.
 	fn saturate_usages(usages: &mut [IntVal], capacity: IntVal) {
 		// The smallest usage that any other resource-using task could run
-		// alongside; a task using more than the capacity left by it cannot share
-		// the resource with any other task.
+		// alongside; a task using more than the capacity left by it cannot
+		// share the resource with any other task.
 		let Some(r_min) = usages
 			.iter()
 			.copied()
@@ -242,8 +242,8 @@ impl Cumulative {
 	/// Requires constant durations for all tasks.
 	fn strengthen_usages(usages: &mut [IntVal], capacity: IntVal, windows: &[(IntVal, IntVal)]) {
 		let n = usages.len();
-		// Strengthen usages sequentially since each update changes the knapsacks of
-		// later tasks.
+		// Strengthen usages sequentially since each update changes the
+		// knapsacks of later tasks.
 		for j in 0..n {
 			let r_j = usages[j];
 			let (est_j, lct_j) = windows[j];
@@ -251,13 +251,14 @@ impl Cumulative {
 				continue;
 			}
 			// The most the tasks that can overlap task `j` use together is a
-			// knapsack over their usages bounded by the capacity left for them, so
-			// task `j` can claim whatever remains.
+			// knapsack over their usages bounded by the capacity left for them,
+			// so task `j` can claim whatever remains.
 			let others: Vec<IntVal> = (0..n)
 				.filter(|&i| i != j)
 				.filter_map(|i| {
 					let (est_i, lct_i) = windows[i];
-					// The windows `[est_i, lct_i)` and `[est_j, lct_j)` overlap.
+					// The windows `[est_i, lct_i)` and `[est_j, lct_j)`
+					// overlap.
 					(est_i < lct_j && est_j < lct_i && usages[i] > 0).then_some(usages[i])
 				})
 				.collect();
@@ -305,8 +306,8 @@ impl Cumulative {
 			.max()
 			.unwrap_or(1);
 
-		// The reachable load at each time point is a knapsack over the tasks whose
-		// window covers it.
+		// The reachable load at each time point is a knapsack over the tasks
+		// whose window covers it.
 		let starts: Vec<IntVal> = windows
 			.iter()
 			.map(|&(est, _)| est)
@@ -322,8 +323,8 @@ impl Cumulative {
 				})
 				.collect();
 			let reachable = Self::max_reachable_load(&active, *capacity);
-			// If the reachable load is already at least the current capacity, no
-			// strengthening is possible.
+			// If the reachable load is already at least the current capacity,
+			// no strengthening is possible.
 			if reachable >= *capacity {
 				return;
 			}
@@ -361,9 +362,10 @@ where
 		&mut self,
 		ctx: &mut E::PropagationContext<'_>,
 	) -> Result<SimplificationStatus, E::Conflict> {
-		// Perform coefficient strengthening on a single working copy of the fixed
-		// coefficients, then rewrite the changed usages and capacity in one pass so
-		// that the usages and capacity can never fall out of sync.
+		// Perform coefficient strengthening on a single working copy of the
+		// fixed coefficients, then rewrite the changed usages and capacity in
+		// one pass so that the usages and capacity can never fall out of
+		// sync.
 		if !self.strengthened
 			&& let Some(mut capacity) = self.propagator.capacity.val(ctx)
 			&& let Some(mut usages) = self.fixed_usages(ctx)
@@ -622,10 +624,10 @@ where
 			}
 		}
 
-		// Time-table-edge-finding phases run once the time-table propagation has
-		// reached its fixpoint. Unlike the time-table phase, edge-finding can also
-		// propagate when there are no compulsory parts, so it runs regardless of
-		// whether the profile is empty.
+		// Time-table-edge-finding phases run once the time-table propagation
+		// has reached its fixpoint. Unlike the time-table phase, edge-finding
+		// can also propagate when there are no compulsory parts, so it runs
+		// regardless of whether the profile is empty.
 		//
 		// Tightening a start time can only grow a compulsory part, so a profile
 		// left over from before an edge-finding update understates the resource
@@ -681,7 +683,8 @@ mod tests {
 	/// The bounded max-subset-sum underlying the strengthening rules.
 	#[test]
 	fn test_cumulative_max_reachable_load() {
-		// `{5, 2}` fills the capacity exactly, where `{3, 5}` would overshoot it.
+		// `{5, 2}` fills the capacity exactly, where `{3, 5}` would overshoot
+		// it.
 		assert_eq!(Cumulative::max_reachable_load(&[3, 5, 2], 7), 7);
 		// Without the 2 no subset reaches 7, since `3 + 5` no longer fits.
 		assert_eq!(Cumulative::max_reachable_load(&[3, 5], 7), 5);
@@ -796,8 +799,8 @@ mod tests {
 	#[traced_test]
 	fn test_cumulative_propagate() {
 		let mut prb = Model::default();
-		// Tasks A and B (start [0, 2], duration 3) each have a compulsory part in
-		// [0, 2]; task C (start [0, 4], duration 3) has none.
+		// Tasks A and B (start [0, 2], duration 3) each have a compulsory part
+		// in [0, 2]; task C (start [0, 4], duration 3) has none.
 		let start_time_a = prb.new_int_decision(0..=2);
 		let start_time_b = prb.new_int_decision(0..=2);
 		let start_time_c = prb.new_int_decision(0..=4);
@@ -862,7 +865,8 @@ mod tests {
 		Cumulative::strengthen_usages(&mut usages, 5, &[(0, 2), (0, 2), (0, 2)]);
 		assert_eq!(usages, vec![3, 2, 2]);
 
-		// A task already using the whole capacity, or none of it, is left alone.
+		// A task already using the whole capacity, or none of it, is left
+		// alone.
 		let mut usages = vec![4, 0];
 		Cumulative::strengthen_usages(&mut usages, 4, &[(0, 2), (0, 2)]);
 		assert_eq!(usages, vec![4, 0]);

--- a/crates/huub/src/constraints/cumulative/edge_finding.rs
+++ b/crates/huub/src/constraints/cumulative/edge_finding.rs
@@ -94,8 +94,8 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 	/// logarithmic time instead of rescanning the whole profile for every task.
 	fn build_profile_energy(&self) -> Vec<IntVal> {
 		let mut profile_energy = vec![0; self.bounds.len()];
-		// The profile is empty after its last bound, so accumulate backwards from
-		// there.
+		// The profile is empty after its last bound, so accumulate backwards
+		// from there.
 		for i in (0..self.bounds.len().saturating_sub(1)).rev() {
 			profile_energy[i] =
 				profile_energy[i + 1] + self.heights[i] * (self.bounds[i + 1] - self.bounds[i]);
@@ -131,8 +131,9 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 					// The free part of task j is entirely inside the window.
 					en_req_free += state.tasks[j].free_energy;
 				} else {
-					// Task j starts inside the window but completes after it; only
-					// the part of its free duration forced into the window counts.
+					// Task j starts inside the window but completes after it;
+					// only the part of its free duration forced into the
+					// window counts.
 					en_req_free += state.tasks[j].usage * cmp::max(end - state.tasks[j].lst_ef, 0);
 				}
 				let en_req =
@@ -218,8 +219,8 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 		opportunistic: bool,
 		updates: &mut Vec<EdgeFindingUpdate>,
 	) -> Option<(IntVal, IntVal)> {
-		// Strongest new bounds found so far per task, to keep only the best update
-		// and avoid queueing dominated ones.
+		// Strongest new bounds found so far per task, to keep only the best
+		// update and avoid queueing dominated ones.
 		let mut new_est: Vec<IntVal> = state.tasks.iter().map(|t| t.est).collect();
 		let mut new_lct: Vec<IntVal> = state.tasks.iter().map(|t| t.lct).collect();
 		let horizon_energy = state.capacity
@@ -248,9 +249,10 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 					continue;
 				}
 
-				// Opportunistic extended edge finding (Vilím (2011), through/left): if
-				// the tightest window `[min_begin, end)` seen so far cannot fit all of
-				// `j`, lower its latest completion accordingly.
+				// Opportunistic extended edge finding (Vilím (2011),
+				// through/left): if the tightest window `[min_begin, end)`
+				// seen so far cannot fit all of `j`, lower its latest
+				// completion accordingly.
 				if opportunistic && let Some(mb) = min_begin {
 					let min_en_in = state.tasks[j].usage
 						* cmp::max(
@@ -277,10 +279,12 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 				if state.tasks[j].lct <= end {
 					en_req_free += state.tasks[j].free_energy;
 				} else {
-					// The free part of `j` is forced into the window from the right.
+					// The free part of `j` is forced into the window from the
+					// right.
 					let dur_shift = cmp::max(end - state.tasks[j].lst_ef, 0);
 					en_req_free += state.tasks[j].usage * dur_shift;
-					// Extra energy `j` would need in the window if started at est_j.
+					// Extra energy `j` would need in the window if started at
+					// est_j.
 					let en_req_start = cmp::min(
 						state.tasks[j].free_energy,
 						state.tasks[j].usage * (end - state.tasks[j].est),
@@ -312,8 +316,8 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 						0
 					};
 					let en_in = state.tasks[u].usage * (dur_mand + dur_shift);
-					// Only `dur_avail` of `u` can fit before `end`, so it must start at
-					// `end - dur_avail` at the earliest.
+					// Only `dur_avail` of `u` can fit before `end`, so it must
+					// start at `end - dur_avail` at the earliest.
 					let dur_avail = (en_avail + en_in) / state.tasks[u].usage;
 					let start_new = end - dur_avail;
 					if start_new > new_est[u] {
@@ -389,9 +393,10 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 				reason.push(self.durations[i].min_lit(ctx));
 				reason.push(self.usages[i].min_lit(ctx));
 			}
-			// The updated task contributes only the bound on the side from which it
-			// is being pushed (its previous earliest start for a lower-bound update,
-			// or its previous latest start for an upper-bound update).
+			// The updated task contributes only the bound on the side from
+			// which it is being pushed (its previous earliest start for a
+			// lower-bound update, or its previous latest start for an
+			// upper-bound update).
 			if is_lb {
 				reason.push(self.start_times[u].min_lit(ctx));
 			} else {
@@ -446,9 +451,10 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 					continue;
 				}
 
-				// Opportunistic extended edge finding (Vilím (2011), through/left): if
-				// the tightest window `[begin, min_end)` seen so far cannot fit all of
-				// `j`, raise its earliest start accordingly.
+				// Opportunistic extended edge finding (Vilím (2011),
+				// through/left): if the tightest window `[begin, min_end)`
+				// seen so far cannot fit all of `j`, raise its earliest
+				// start accordingly.
 				if opportunistic && let Some(me) = min_end {
 					let min_en_in = state.tasks[j].usage
 						* cmp::max(
@@ -475,7 +481,8 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 				if begin <= state.tasks[j].est {
 					en_req_free += state.tasks[j].free_energy;
 				} else {
-					// The free part of `j` is forced into the window from the left.
+					// The free part of `j` is forced into the window from the
+					// left.
 					let dur_shift = if end >= state.tasks[j].lct {
 						cmp::max(state.tasks[j].ect - begin - state.tasks[j].fixed_dur, 0)
 					} else {
@@ -538,7 +545,8 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 			return profile_energy.first().copied().unwrap_or(0);
 		};
 		if i + 1 == self.bounds.len() {
-			// The profile ends at its last bound, and so carries no energy there.
+			// The profile ends at its last bound, and so carries no energy
+			// there.
 			return 0;
 		}
 		profile_energy[i] - self.heights[i] * (tau - self.bounds[i])
@@ -564,9 +572,9 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 		let profile_energy = self.build_profile_energy();
 		let state = self.edge_finding_data::<E>(ctx, &profile_energy);
 
-		// Bounds filtering subsuming the consistency check: its sweeps also detect
-		// resource overloads. When only the check is enabled, run the cheaper
-		// consistency check on its own.
+		// Bounds filtering subsuming the consistency check: its sweeps also
+		// detect resource overloads. When only the check is enabled, run the
+		// cheaper consistency check on its own.
 		if self.edge_finding_propagation_enabled {
 			let opp = self.opportunistic_edge_finding_propagation_enabled;
 			let mut updates = Vec::new();
@@ -584,8 +592,9 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 			}
 			let mut propagated = false;
 			for upd in &updates {
-				// Re-derive the bound from the forced energy of the other tasks the
-				// reason pins, so the naive edge-finding explanation provably entails it.
+				// Re-derive the bound from the forced energy of the other tasks
+				// the reason pins, so the naive edge-finding explanation
+				// provably entails it.
 				let Some(bound) =
 					Self::sound_update_bound(&state, upd.task, upd.begin, upd.end, upd.is_lb)
 				else {
@@ -642,16 +651,18 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 		let dur_avail = en_avail / task.usage;
 		let overlap = |s: IntVal| cmp::max(cmp::min(s + task.dur, end) - cmp::max(s, begin), 0);
 		if is_lb {
-			// `u` placed at its earliest start cannot fit in the energy left for
-			// it, so any feasible start lies at or after `end - dur_avail`.
+			// `u` placed at its earliest start cannot fit in the energy left
+			// for it, so any feasible start lies at or after `end -
+			// dur_avail`.
 			if overlap(task.est) <= dur_avail {
 				return None;
 			}
 			let start_new = end - dur_avail;
 			(start_new > task.est).then_some(start_new)
 		} else {
-			// Symmetric: `u` placed at its latest start cannot fit, so its latest
-			// completion is at most `begin + dur_avail`, bounding its latest start.
+			// Symmetric: `u` placed at its latest start cannot fit, so its
+			// latest completion is at most `begin + dur_avail`, bounding its
+			// latest start.
 			if overlap(task.lst) <= dur_avail {
 				return None;
 			}
@@ -939,8 +950,8 @@ mod tests {
 				false,
 				false,
 			);
-		// Segments `[0, 2)`, `[2, 5)`, and `[5, 9)` carrying 3, 1, and 2 units of
-		// the resource, and the closing bound of the profile.
+		// Segments `[0, 2)`, `[2, 5)`, and `[5, 9)` carrying 3, 1, and 2 units
+		// of the resource, and the closing bound of the profile.
 		prop.bounds = vec![0, 2, 5, 9];
 		prop.heights = vec![3, 1, 2, 0];
 		let profile_energy = prop.build_profile_energy();

--- a/crates/huub/src/constraints/cumulative/time_table.rs
+++ b/crates/huub/src/constraints/cumulative/time_table.rs
@@ -140,8 +140,8 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 			return Vec::new();
 		}
 
-		// Collect a sufficient set of tasks with compulsory parts at `time_point` that
-		// cover `to_cover` energy
+		// Collect a sufficient set of tasks with compulsory parts at
+		// `time_point` that cover `to_cover` energy
 		let mut relevant_tasks = Vec::new();
 		let mut collected_energy = 0;
 		for i in 0..self.start_times.len() {
@@ -235,8 +235,8 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 				"explain task usage limit"
 			);
 
-			// Explanation: (1) relevant tasks (together with task `task_no`) have
-			// the required compulsory part at time `time_point`
+			// Explanation: (1) relevant tasks (together with task `task_no`)
+			// have the required compulsory part at time `time_point`
 			reason.extend(relevant_tasks.iter().chain(once(&task_no)).flat_map(|&i| {
 				[
 					self.start_times[i].lit(ctx, IntLitMeaning::Less(time_point + 1)),
@@ -284,8 +284,8 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 				"explain resource overload"
 			);
 
-			// Explanation: relevant tasks have the required compulsory part at time
-			// `time_point`
+			// Explanation: relevant tasks have the required compulsory part at
+			// time `time_point`
 			reason.extend(relevant_tasks.iter().flat_map(|&i| {
 				[
 					self.start_times[i].lit(ctx, IntLitMeaning::Less(time_point + 1)),
@@ -337,8 +337,8 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 				"explain task sweeping"
 			);
 
-			// Explanation: (1) relevant tasks have the required compulsory part at time
-			// `time_point`
+			// Explanation: (1) relevant tasks have the required compulsory part
+			// at time `time_point`
 			reason.extend(relevant_tasks.iter().flat_map(|&i| {
 				[
 					self.start_times[i].lit(ctx, IntLitMeaning::Less(time_point + 1)),
@@ -351,8 +351,9 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 				]
 			}));
 
-			// Explanation: (2) the task itself is either left-conflict or right-conflict
-			// with the time point, depending on the propagation rule
+			// Explanation: (2) the task itself is either left-conflict or
+			// right-conflict with the time point, depending on the
+			// propagation rule
 			match propagation_rule {
 				CumulativePropagationRule::ForwardShift => {
 					reason.push(self.start_times[task_no].lit(
@@ -491,12 +492,13 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 			let height = self.heights[i - 1];
 			assert!(b_start < b_end);
 
-			// Stop when the task is not right-conflict with any interval backward
+			// Stop when the task is not right-conflict with any interval
+			// backward
 			if b_end <= cmp::max(ect, updated_lct - dur_lb) {
 				break;
 			}
-			// if `lct` can be push backward (to ≤ `b_end`) and the resource usage is over
-			// the capacity
+			// if `lct` can be push backward (to ≤ `b_end`) and the resource
+			// usage is over the capacity
 			if updated_lct > b_start && usage_lb + height > max_capacity {
 				if updated_lct - dur_lb < ect && updated_lct - dur_lb <= b_start && ect >= b_end {
 					// Skip if the task has a compulsory part in this interval
@@ -588,8 +590,8 @@ impl<I1, I2, I3, I4> CumulativePropagator<I1, I2, I3, I4> {
 			if b_start >= cmp::min(lst, updated_est + dur_lb) {
 				break;
 			}
-			// if `est` can be push forward (to ≥ `b_end`) and the resource usage is over
-			// the capacity
+			// if `est` can be push forward (to ≥ `b_end`) and the resource
+			// usage is over the capacity
 			if updated_est < b_end && usage_lb + height > max_capacity {
 				if lst < updated_est + dur_lb && lst <= b_start && b_end <= updated_est + dur_lb {
 					// Skip if the task has a compulsory part in this

--- a/crates/huub/src/constraints/disjunctive.rs
+++ b/crates/huub/src/constraints/disjunctive.rs
@@ -346,9 +346,9 @@ impl<I> DisjunctivePropagator<I> {
 		// collect at least latest_completion - earliest_start energy (including
 		// durations[task_no]) from tasks bracketed in
 		// [earliest_start, latest_completion] and form a set O [start(t) >=
-		// latest_completion + 1] because [start(t) >= earliest_start] /\ forall (t'
-		// in O) [start(t') >= earliest_start] /\ forall (t' in O) [end(t') <=
-		// latest_completion]
+		// latest_completion + 1] because [start(t) >= earliest_start] /\ forall
+		// (t' in O) [start(t') >= earliest_start] /\ forall (t' in O)
+		// [end(t') <= latest_completion]
 		let (bv, _) =
 			self.start_times[task_no].lit_relaxed(ctx, IntLitMeaning::GreaterEq(earliest_start));
 		reason.push(bv);
@@ -386,8 +386,8 @@ impl<I> DisjunctivePropagator<I> {
 		E: ReasoningEngine,
 		I: IntSolverActions<E>,
 	{
-		// Collect the set of tasks in NLset(i) = { j | lst_j < lct_i && est_j + p_j
-		// ≥ earliest_start & j ≠ i }
+		// Collect the set of tasks in NLset(i) = { j | lst_j < lct_i && est_j +
+		// p_j ≥ earliest_start & j ≠ i }
 		let nlset = (0..self.start_times.len())
 			.filter(|j| {
 				{
@@ -411,16 +411,18 @@ impl<I> DisjunctivePropagator<I> {
 		// Explain the reason why task i cannot be the last task
 		reason.push(self.start_times[task_no].max_lit(ctx));
 		for j in nlset {
-			// explain the reason why all tasks in NLset(i) will stay in NLset(i)
+			// explain the reason why all tasks in NLset(i) will stay in
+			// NLset(i)
 			//
-			// (1) If for all j in NLset(i) [est_j ≥ earliest_start], then ect_Ω >
-			// lst_i, and NLset(i) \not\prec i
+			// (1) If for all j in NLset(i) [est_j ≥ earliest_start], then ect_Ω
+			// > lst_i, and NLset(i) \not\prec i
 			let (bv, _) =
 				self.start_times[j].lit_relaxed(ctx, IntLitMeaning::GreaterEq(earliest_start));
 			reason.push(bv);
-			// (2) explain the reason why the latest completion time of task i is set
-			// to latest_completion If for all j in NLset(i) [lst_j ≤ lct_i'], then
-			// max{lst_j, j \in Ω} ≤ lct_i', and lct_i' should be set
+			// (2) explain the reason why the latest completion time of task i
+			// is set to latest_completion If for all j in NLset(i) [lst_j ≤
+			// lct_i'], then max{lst_j, j \in Ω} ≤ lct_i', and lct_i' should
+			// be set
 			let (bv, _) =
 				self.start_times[j].lit_relaxed(ctx, IntLitMeaning::Less(updated_lct_i + 1));
 			reason.push(bv);
@@ -515,12 +517,12 @@ impl<I> DisjunctivePropagator<I> {
 		reason.push(bv);
 		for j in precedence_set {
 			let v = self.start_times[j].clone();
-			// (1) explain the reason why all tasks in precedence_set will stay in
-			// precedence_set
+			// (1) explain the reason why all tasks in precedence_set will stay
+			// in precedence_set
 			let (bv, _) = v.lit_relaxed(ctx, IntLitMeaning::GreaterEq(earliest_start));
 			reason.push(bv);
-			// (2) explain the reason why the earliest start time of task i is set to
-			// earliest completeion time of the precedence set
+			// (2) explain the reason why the earliest start time of task i is
+			// set to earliest completeion time of the precedence set
 			let (bv, _) = v.lit_relaxed(
 				ctx,
 				IntLitMeaning::Less(task_i_est + self.durations[task_no]),
@@ -656,7 +658,8 @@ impl<I> DisjunctivePropagator<I> {
 		self.tasks_sorted_by_earliest_completion
 			.sort_by_key(|&i| earliest_completion_times[i]);
 
-		// Initialize the placeholer for the index of the front task in the queue
+		// Initialize the placeholer for the index of the front task in the
+		// queue
 		let mut lst_front_idx = 0;
 		// Traverse all tasks by their earliest completion time non-decreasingly
 		for &ect_task in self.tasks_sorted_by_earliest_completion.iter() {
@@ -665,8 +668,9 @@ impl<I> DisjunctivePropagator<I> {
 				&& ect > latest_start_times[self.tasks_sorted_by_latest_start[lst_front_idx]]
 			{
 				let front_task = self.tasks_sorted_by_latest_start[lst_front_idx];
-				// the latest start time of the front task is smaller than the earliest
-				// completion of the current task, `front_task` << `ect_task` detected
+				// the latest start time of the front task is smaller than the
+				// earliest completion of the current task, `front_task` <<
+				// `ect_task` detected
 				self.ot_tree.add_task(
 					front_task,
 					self.earliest_start_time(ctx, front_task),
@@ -684,8 +688,8 @@ impl<I> DisjunctivePropagator<I> {
 			// temporarily remove task `ect_task` from the tree
 			let task_exists = self.ot_tree.remove_task(ect_task);
 
-			// Check if the earliest completion time of tasks in the tree is greater
-			// than the earliest completion time of task `ect_task`
+			// Check if the earliest completion time of tasks in the tree is
+			// greater than the earliest completion time of task `ect_task`
 			let tasks_in_tree_ect = self.ot_tree.root().earliest_completion;
 			if tasks_in_tree_ect > self.earliest_start_time(ctx, ect_task) {
 				binding_tasks[ect_task] = Some(self.ot_tree.binding_task(tasks_in_tree_ect, 0));
@@ -793,25 +797,26 @@ impl<I> DisjunctivePropagator<I> {
 		self.tasks_sorted_by_latest_completion
 			.sort_by_key(|&i| -latest_completion_times[i]);
 
-		// Traverse all tasks ordered by latest completion time and check the edge
-		// finding propagation rule
+		// Traverse all tasks ordered by latest completion time and check the
+		// edge finding propagation rule
 		//
 		// Invariant:
 		//
-		//   1. all non-gray tasks of `ot_tree` (Ω) forms LCut(j) = { i | lct_i ≤ lct_j
-		//      }
-		//   2. all gray tasks of `ot_tree` (Ѳ) are in the set T \setminus LCut(j)
+		//   1. all non-gray tasks of `ot_tree` (Ω) forms LCut(j) = { i | lct_i
+		//      ≤ lct_j }
+		//   2. all gray tasks of `ot_tree` (Ѳ) are in the set T \setminus
+		//      LCut(j)
 		for (j, &lct_task) in self.tasks_sorted_by_latest_completion.iter().enumerate() {
 			let lct = self.latest_completion_time(ctx, lct_task);
-			// Assume that resource overload is not detected, i.e., ect(LCut(j)) <=
-			// lct_j
+			// Assume that resource overload is not detected, i.e., ect(LCut(j))
+			// <= lct_j
 			let ect_in_tree = self.ot_tree.root().earliest_completion;
 			if check_overload {
-				// Checking resource overload for LCut(j): ect(LCut(j)) > lct_j =>
-				// conflict
+				// Checking resource overload for LCut(j): ect(LCut(j)) > lct_j
+				// => conflict
 				if ect_in_tree > lct {
-					// Resource overload detected, eagerly build the reason clause for
-					// conflict
+					// Resource overload detected, eagerly build the reason
+					// clause for conflict
 					let expl = self.explain_overload_checking(lct + 1);
 					self.start_times[lct_task].tighten_min(
 						ctx,
@@ -851,8 +856,8 @@ impl<I> DisjunctivePropagator<I> {
 						.tighten_min(ctx, ect_in_tree, |_, reason| reason.defer(data))?;
 					propagated = true;
 				}
-				// Remove the blocked task as the maximum propagation has been achieved
-				// by LCut(j) where lct_j is maximum
+				// Remove the blocked task as the maximum propagation has been
+				// achieved by LCut(j) where lct_j is maximum
 				self.ot_tree.remove_task(blocked_task);
 			}
 			self.ot_tree.annotate_gray_task(lct_task);
@@ -924,8 +929,8 @@ impl<I> DisjunctivePropagator<I> {
 		// Traverse all tasks by their latest completion time non-decreasingly
 		for &lct_task in self.tasks_sorted_by_latest_completion.iter() {
 			let lct = latest_completion_times[lct_task];
-			// Add all tasks with latest start time less than lct to the Omega-Theta
-			// tree
+			// Add all tasks with latest start time less than lct to the
+			// Omega-Theta tree
 			while lst_front_idx < self.tasks_sorted_by_latest_start.len()
 				&& lct > latest_start_times[self.tasks_sorted_by_latest_start[lst_front_idx]]
 			{
@@ -941,8 +946,8 @@ impl<I> DisjunctivePropagator<I> {
 			// temporarily remove task `ect_task` from the tree
 			let task_exists = self.ot_tree.remove_task(lct_task);
 
-			// Check if the earliest completion time of tasks in the tree is greater
-			// than the earliest completion time of task `ect_task`
+			// Check if the earliest completion time of tasks in the tree is
+			// greater than the earliest completion time of task `ect_task`
 			let tasks_in_tree_ect = self.ot_tree.root().earliest_completion;
 			if tasks_in_tree_ect > (lct - self.durations[lct_task]) {
 				binding_tasks[lct_task] = Some(self.ot_tree.binding_task(tasks_in_tree_ect, 0));
@@ -1041,8 +1046,8 @@ impl<I> DisjunctivePropagator<I> {
 			.sorted_by_key(|(_, lct)| *lct)
 			.collect_vec();
 
-		// Traverse all tasks ordered by latest completion time and check resource
-		// overload
+		// Traverse all tasks ordered by latest completion time and check
+		// resource overload
 		for (i, lct_i) in tasks_sorted_by_lct.iter() {
 			let est_i = self.earliest_start_time(ctx, *i);
 			self.ot_tree.add_task(*i, est_i, self.durations[*i]);
@@ -1133,16 +1138,16 @@ where
 		skip(self, ctx)
 	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationContext<'_>) -> Result<(), E::Conflict> {
-		// Sort the tasks by earliest start time and initialize the Omega-Theta tree
-		// according to the property of the Omega-Theta tree.
+		// Sort the tasks by earliest start time and initialize the Omega-Theta
+		// tree according to the property of the Omega-Theta tree.
 		let earliest_start: Vec<_> = self.start_times.iter().map(|v| v.min(ctx)).collect();
 		self.tasks_sorted_by_earliest_start
 			.sort_by_key(|&i| earliest_start[i]);
 		self.ot_tree
 			.initialize(self.tasks_sorted_by_earliest_start.as_slice());
 
-		// Propagate edge finding propagation rule with overload checking or perform
-		// overload checking only
+		// Propagate edge finding propagation rule with overload checking or
+		// perform overload checking only
 		if self.edge_finding_enabled {
 			if self.propagate_edge_finding(ctx, true)? {
 				return Ok(());
@@ -1222,8 +1227,8 @@ impl OmegaThetaTree {
 				+ self.nodes[Self::right_child(node_id)].total_durations_gray
 				>= earliest_completion_time
 			{
-				// The binding task is to the left, blocked task contributes only to the
-				// sum
+				// The binding task is to the left, blocked task contributes
+				// only to the sum
 				earliest_completion_time -=
 					self.nodes[Self::left_child(node_id)].earliest_completion;
 				node_id = Self::right_child(node_id);

--- a/crates/huub/src/constraints/int_abs.rs
+++ b/crates/huub/src/constraints/int_abs.rs
@@ -119,7 +119,8 @@ where
 
 		match self.origin_positive.val(ctx) {
 			Some(false) => {
-				// If we know that the origin is negative, then just negate the bounds
+				// If we know that the origin is negative, then just negate the
+				// bounds
 				self.abs.tighten_min(ctx, -ub, |ctx, reason| {
 					reason.push(self.origin.max_lit(ctx));
 				})?;
@@ -163,8 +164,9 @@ where
 				})?;
 			}
 			None => {
-				// If the origin can be either positive or negative, then the bounds are
-				// The maximum absolute value bounds the absolute value variable.
+				// If the origin can be either positive or negative, then the
+				// bounds are The maximum absolute value bounds the absolute
+				// value variable.
 				let abs_max = cmp::max(ub, -lb);
 				self.abs.tighten_max(ctx, abs_max, |ctx, reason| {
 					reason.extend([
@@ -173,8 +175,8 @@ where
 					]);
 				})?;
 
-				// If the upper bound of the absolute value variable has changed, we
-				// propagate bounds of the origin variable.
+				// If the upper bound of the absolute value variable has
+				// changed, we propagate bounds of the origin variable.
 				let abs_ub = self.abs.max(ctx);
 				self.origin.tighten_min(ctx, -abs_ub, |ctx, reason| {
 					reason.push(self.abs.max_lit(ctx));

--- a/crates/huub/src/constraints/int_array_element.rs
+++ b/crates/huub/src/constraints/int_array_element.rs
@@ -212,8 +212,8 @@ where
 	)]
 	fn propagate(&mut self, ctx: &mut E::PropagationContext<'_>) -> Result<(), E::Conflict> {
 		// ensure bounds of result and self.vars[self.index] are consistent when
-		// self.index is fixed only trigger when self.index is fixed and (1) y is
-		// updated or (2) self.vars[self.index] is updated
+		// self.index is fixed only trigger when self.index is fixed and (1) y
+		// is updated or (2) self.vars[self.index] is updated
 		if let Some(fixed_index) = self.index.val(ctx) {
 			let index_val_lit = self.index.val_lit(ctx).unwrap();
 			let fixed_var = &self.vars[fixed_index as usize];
@@ -262,7 +262,8 @@ where
 		// 	(1) result.max < self.vars[i].min -> index != i
 		//  (2) result.min > self.vars[i].max -> index != i
 		// 2. update min_support and max_support if necessary
-		// only trigger when result variable is updated or self.vars[i] is updated
+		// only trigger when result variable is updated or self.vars[i] is
+		// updated
 		for i in idx_dom.iter().flatten() {
 			debug_assert!(i >= 0 && i <= self.vars.len() as IntVal);
 			let i = i as usize;
@@ -287,8 +288,8 @@ where
 				})?;
 			}
 
-			// update min_support if i is in the domain of self.index and the lower bound of
-			// // v is less than the current min
+			// update min_support if i is in the domain of self.index and the
+			// lower bound of // v is less than the current min
 			if need_min_support && v_lb < new_min {
 				new_min_support = i;
 				new_min = v_lb;
@@ -296,8 +297,8 @@ where
 				need_min_support = new_min > result_lb;
 			}
 
-			// update max_support if i is in the domain of self.index and the upper bound of
-			// v is greater than the current max
+			// update max_support if i is in the domain of self.index and the
+			// upper bound of v is greater than the current max
 			if need_max_support && v_ub > new_max {
 				new_max_support = i;
 				new_max = v_ub;
@@ -309,13 +310,13 @@ where
 		ctx.set_trailed(self.min_support, new_min_support);
 		ctx.set_trailed(self.max_support, new_max_support);
 
-		// propagate the lower bound of the selected variable y if min_support is not
-		// valid anymore:
+		// propagate the lower bound of the selected variable y if min_support
+		// is not valid anymore:
 		//
 		//   result.min >= min(i in domain(x))(self.vars[i].min)
 		//
-		// only trigger when self.vars[min_support] is changed or self.vars[min_support]
-		// is out of domain
+		// only trigger when self.vars[min_support] is changed or
+		// self.vars[min_support] is out of domain
 		if new_min > result_lb {
 			self.result.tighten_min(ctx, new_min, |ctx, reason| {
 				let dom = self.index.domain(ctx);
@@ -332,13 +333,13 @@ where
 			})?;
 		}
 
-		// propagate the upper bound of the selected variable y if max_support is not
-		// valid anymore:
+		// propagate the upper bound of the selected variable y if max_support
+		// is not valid anymore:
 		//
 		//   result.max <= max(i in domain(x))(self.vars[i].max)
 		//
-		// only trigger when self.vars[max_support] is changed or self.vars[max_support]
-		// is out of domain
+		// only trigger when self.vars[max_support] is changed or
+		// self.vars[max_support] is out of domain
 		if new_max < result_ub {
 			self.result.tighten_max(ctx, new_max, |ctx, reason| {
 				let dom = self.index.domain(ctx);

--- a/crates/huub/src/constraints/int_array_minimum.rs
+++ b/crates/huub/src/constraints/int_array_minimum.rs
@@ -54,15 +54,16 @@ where
 		self.vars.retain(|v| v.min(ctx) <= max_min);
 		debug_assert!(!self.vars.is_empty());
 
-		// If there is only one variable left, unify it with the minimum value and
-		// subsume the constraint.
+		// If there is only one variable left, unify it with the minimum value
+		// and subsume the constraint.
 		if self.vars.len() == 1 {
 			self.vars[0].unify(ctx, self.min.clone())?;
 			return Ok(SimplificationStatus::Subsumed);
 		}
 
-		// If the minimum value is known and one of the variables is equal to it,
-		// tighten the minimum bounds of the others and subsume the constraint.
+		// If the minimum value is known and one of the variables is equal to
+		// it, tighten the minimum bounds of the others and subsume the
+		// constraint.
 		if let Some(c) = self.min.val(ctx)
 			&& self.vars.iter().any(|v| v.val(ctx) == Some(c))
 		{
@@ -120,7 +121,8 @@ where
 			reason.push(min_ub_var.max_lit(ctx));
 		})?;
 
-		// set y to be greater than or equal to the minimum of lower bounds of x_i
+		// set y to be greater than or equal to the minimum of lower bounds of
+		// x_i
 		let min_lb = self.vars.iter().map(|x| x.min(ctx)).min().unwrap();
 		self.min.tighten_min(ctx, min_lb, |ctx, reason| {
 			reason.extend(

--- a/crates/huub/src/constraints/int_div.rs
+++ b/crates/huub/src/constraints/int_div.rs
@@ -285,8 +285,8 @@ where
 			return Ok(());
 		}
 
-		// If the denominator is known negative, then we swap it and the numerator
-		// with their negations.
+		// If the denominator is known negative, then we swap it and the
+		// numerator with their negations.
 		let mut denominator = self.denominator.clone().into();
 		let mut neg_denom = -self.denominator.clone();
 		let mut numerator = self.numerator.clone().into();
@@ -298,12 +298,13 @@ where
 		}
 
 		// If both the upper bound of the numerator and the upper bound of the
-		// right-hand side are positive, then propagate their upper bounds directly.
+		// right-hand side are positive, then propagate their upper bounds
+		// directly.
 		if numerator.max(ctx) >= 0 && self.result.max(ctx) >= 0 {
 			Self::propagate_upper_bounds(ctx, &numerator, &denominator, &self.result)?;
 		}
-		// If their upper bounds are negative, then propagate the upper bounds of
-		// the negated versions.
+		// If their upper bounds are negative, then propagate the upper bounds
+		// of the negated versions.
 		if neg_num.max(ctx) >= 0 && neg_res.max(ctx) >= 0 {
 			Self::propagate_upper_bounds(ctx, &neg_num, &denominator, &neg_res)?;
 		}
@@ -314,8 +315,8 @@ where
 		if numerator.min(ctx) >= 0 && self.result.min(ctx) >= 0 {
 			Self::propagate_positive_domains(ctx, &numerator, &denominator, &self.result)?;
 		}
-		// If the domain of the numerator and the result are known negative, then
-		// propagate their using their negations.
+		// If the domain of the numerator and the result are known negative,
+		// then propagate their using their negations.
 		if neg_num.min(ctx) >= 0 && neg_res.min(ctx) >= 0 {
 			Self::propagate_positive_domains(ctx, &neg_num, &denominator, &neg_res)?;
 		}

--- a/crates/huub/src/constraints/int_linear.rs
+++ b/crates/huub/src/constraints/int_linear.rs
@@ -144,9 +144,9 @@ where
 		ctx: &mut E::PropagationContext<'_>,
 	) -> Result<SimplificationStatus, E::Conflict> {
 		self.propagate(ctx)?;
-		// Note that one variable might be fixed and not the other one. Gaps in domains
-		// or linear view might require multiple rounds of propagation to reach a
-		// fixpoint.
+		// Note that one variable might be fixed and not the other one. Gaps in
+		// domains or linear view might require multiple rounds of propagation
+		// to reach a fixpoint.
 		if self.vars.iter().all(|v| v.val(ctx).is_some()) {
 			Ok(SimplificationStatus::Subsumed)
 		} else {
@@ -325,8 +325,8 @@ where
 		&mut self,
 		ctx: &mut E::PropagationContext<'_>,
 	) -> Result<SimplificationStatus, E::Conflict> {
-		// If the reification of the constraint is known, simplify to non-reified
-		// version
+		// If the reification of the constraint is known, simplify to
+		// non-reified version
 		if let Some(Reification::ImpliedBy(r) | Reification::ReifiedBy(r)) = self.reif {
 			match r.val(ctx) {
 				Some(true) => {
@@ -494,9 +494,9 @@ where
 			return Ok(SimplificationStatus::NoFixpoint);
 		}
 
-		// The difference between the right-hand-side value and the sum of the lower
-		// bounds. The current lower bound plus this difference is an upper bound
-		// for each variable.
+		// The difference between the right-hand-side value and the sum of the
+		// lower bounds. The current lower bound plus this difference is an
+		// upper bound for each variable.
 		let lb_diff = self.rhs - lb_sum;
 		// Propagate the upper bounds of the variables
 		for (i, v) in self.terms.iter().enumerate() {
@@ -536,8 +536,9 @@ where
 				return Ok(SimplificationStatus::Subsumed);
 			}
 
-			// The amount the sum of the upper bounds exceeds the right-hand-side
-			// value (negated). Used to propagate lower bounds of each variable.
+			// The amount the sum of the upper bounds exceeds the
+			// right-hand-side value (negated). Used to propagate lower
+			// bounds of each variable.
 			let ub_diff = self.rhs - ub_sum;
 			for (i, v) in self.terms.iter().enumerate() {
 				let ub_i = ub[i].into();
@@ -568,8 +569,8 @@ where
 					}
 				}
 
-				// We create a negated view in [`Self::to_solver`], ensure that it is correctly
-				// bounded.
+				// We create a negated view in [`Self::to_solver`], ensure that
+				// it is correctly bounded.
 				let _ = v.bounding_neg(ctx)?;
 			}
 		}
@@ -822,8 +823,8 @@ where
 			.sum();
 
 		if TypeId::of::<BV>() != TypeId::of::<True>() {
-			// Propagate the reified variable if the sum of lower bounds is greater than the
-			// right-hand-side value
+			// Propagate the reified variable if the sum of lower bounds is
+			// greater than the right-hand-side value
 			if lb_sum > self.max {
 				self.reification.fix(ctx, false, |ctx, reason| {
 					reason.extend(self.terms.iter().map(|v| v.min_lit(ctx)));
@@ -831,8 +832,8 @@ where
 			}
 		}
 
-		// skip the remaining propagation if the reified variable is not assigned to
-		// true
+		// skip the remaining propagation if the reified variable is not
+		// assigned to true
 		if r_val != Some(true) {
 			return Ok(());
 		}
@@ -1170,8 +1171,8 @@ mod tests {
 
 	#[test]
 	fn test_constraint_rewriting() {
-		// Regression test for GitHub issue 233, where a `int_lin_le_reif` known to be
-		// false was rewritten incorrectly. It allowed `a` to be 2.
+		// Regression test for GitHub issue 233, where a `int_lin_le_reif` known
+		// to be false was rewritten incorrectly. It allowed `a` to be 2.
 		let mut prb = Model::default();
 		let a = prb.new_int_decision(1..=2);
 		let r: View<bool> = false.into();

--- a/crates/huub/src/constraints/int_mul.rs
+++ b/crates/huub/src/constraints/int_mul.rs
@@ -156,8 +156,8 @@ where
 		let (f2_min, f2_max) = self.factor2.bounds(ctx);
 		let (pr_min, pr_max) = self.product.bounds(ctx);
 
-		// TODO: Filter possibilities based on whether variables can be both positive
-		// and negative.
+		// TODO: Filter possibilities based on whether variables can be both
+		// positive and negative.
 
 		// Calculate possible bounds for the product
 		let minmax = iproduct!([f1_min, f1_max], [f2_min, f2_max])
@@ -182,8 +182,8 @@ where
 		// z <= x * y
 		self.product.tighten_max(ctx, max, reason)?;
 
-		// Propagate the bounds of the first factor if the second factor is known
-		// positive or known negative.
+		// Propagate the bounds of the first factor if the second factor is
+		// known positive or known negative.
 		if f2_min > 0 || f2_max < 0 {
 			let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
 				reason.extend([
@@ -207,8 +207,8 @@ where
 			self.factor1.tighten_max(ctx, max, reason)?;
 		}
 
-		// Propagate the bounds of the second factor if the first factor is known
-		// positive or known negative.
+		// Propagate the bounds of the second factor if the first factor is
+		// known positive or known negative.
 		if f1_min > 0 || f1_max < 0 {
 			let reason = reason_ty::<E::PropagationContext<'_>, _>(|ctx, reason| {
 				reason.extend([

--- a/crates/huub/src/constraints/int_no_overlap.rs
+++ b/crates/huub/src/constraints/int_no_overlap.rs
@@ -150,8 +150,8 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 			if sweep[rotation] <= obj_ub[rotation] {
 				return true;
 			} else {
-				// Otherwise, this dimension is exhausted. Reset sweep point to the
-				// lower bound and try the next dimension.
+				// Otherwise, this dimension is exhausted. Reset sweep point to
+				// the lower bound and try the next dimension.
 				sweep[rotation] = obj_lb[rotation];
 			}
 		}
@@ -193,8 +193,8 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 	{
 		for (region, support) in forbidden_regions.iter() {
 			for d in 0..self.num_dimensions() {
-				// If sizes are not [`IntVal`], their lower bounds contribute to the
-				// forbidden region and must be part of the explanation.
+				// If sizes are not [`IntVal`], their lower bounds contribute to
+				// the forbidden region and must be part of the explanation.
 				if TypeId::of::<I2>() != TypeId::of::<IntVal>() {
 					reason.push(self.size[[*support, d]].min_lit(ctx));
 				}
@@ -204,9 +204,9 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 				let mut possible_lb = self.origin_lb[[*support, d]];
 				let origin_lb = self.origin_lb[[obj, d]];
 
-				// "Lifting": If a forbidden region overhangs the domain of the object
-				// being pruned, we can use the object's bounds to create a tighter,
-				// more general explanation.
+				// "Lifting": If a forbidden region overhangs the domain of the
+				// object being pruned, we can use the object's bounds to
+				// create a tighter, more general explanation.
 				if region.max(d) > origin_ub {
 					possible_lb = origin_ub - self.size_lb[[*support, d]] + 1;
 				}
@@ -247,14 +247,15 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 	{
 		move |ctx, reason| {
 			for d in 0..self.num_dimensions() {
-				// If sizes are not [`IntVal`], their lower bounds contribute to the
-				// forbidden region and must be part of the explanation.
+				// If sizes are not [`IntVal`], their lower bounds contribute to
+				// the forbidden region and must be part of the explanation.
 				if TypeId::of::<I2>() != TypeId::of::<IntVal>() {
 					reason.push(self.size[[obj, d]].min_lit(ctx));
 				}
 
-				// The literal for the bound we are about to prune is implicitly part of the
-				// conclusion, so we only need to explain the *other* bounds of the object.
+				// The literal for the bound we are about to prune is implicitly
+				// part of the conclusion, so we only need to explain the
+				// *other* bounds of the object.
 				if d == dim {
 					if prune_upper {
 						reason.push(self.origin[[obj, d]].max_lit(ctx));
@@ -291,8 +292,9 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 				for obj in [target, cause] {
 					reason.push(self.origin[[obj, d]].min_lit(ctx));
 					reason.push(self.origin[[obj, d]].max_lit(ctx));
-					// Leave out `target`'s size lower bound in `dim`: the conclusion is an
-					// upper bound on its size, which does not depend on its lower bound.
+					// Leave out `target`'s size lower bound in `dim`: the
+					// conclusion is an upper bound on its size, which does
+					// not depend on its lower bound.
 					if (obj, d) != (target, dim) {
 						reason.push(self.size[[obj, d]].min_lit(ctx));
 					}
@@ -331,7 +333,8 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 		I1: IntSolverActions<E>,
 		I2: IntSolverActions<E>,
 	{
-		// `obj`'s size can only be tightened while it is a not-yet-fixed decision.
+		// `obj`'s size can only be tightened while it is a not-yet-fixed
+		// decision.
 		let prune_size = TypeId::of::<I2>() != TypeId::of::<IntVal>()
 			&& self.size.row(obj).iter().any(|v| v.val(ctx).is_none());
 
@@ -345,16 +348,17 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 			if i == obj {
 				continue;
 			}
-			// In non-strict mode, objects with size (potential) 0 do not need to be
-			// considered.
+			// In non-strict mode, objects with size (potential) 0 do not need
+			// to be considered.
 			if !STRICT && self.size_lb.row(i).contains(&0) {
 				continue;
 			}
 
-			// The forbidden interval of `i` for `obj` in each dimension, together
-			// with the single dimension (if any) in which the two can still be
-			// separated. That dimension is where `obj`'s origin pokes out of the
-			// interval, either below (so `obj` can lie first) or above (so `i` can).
+			// The forbidden interval of `i` for `obj` in each dimension,
+			// together with the single dimension (if any) in which the two
+			// can still be separated. That dimension is where `obj`'s origin
+			// pokes out of the interval, either below (so `obj` can lie
+			// first) or above (so `i` can).
 			let mut forbidden = Region::with_dimensions(self.num_dimensions());
 			let mut empty = false;
 			let mut free = None;
@@ -377,9 +381,10 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 				}
 			}
 
-			// Tighten `obj`'s size when the objects must be separated in exactly one
-			// dimension (`single_free`) and `obj` can only take the lower position
-			// there (it pokes out below the interval, `true`, but not above, `false`).
+			// Tighten `obj`'s size when the objects must be separated in
+			// exactly one dimension (`single_free`) and `obj` can only take
+			// the lower position there (it pokes out below the interval,
+			// `true`, but not above, `false`).
 			if single_free && let Some((dim, true, false)) = free {
 				let bound = self.origin_ub[[i, dim]] - self.origin_lb[[obj, dim]];
 				self.size[[obj, dim]].tighten_max(
@@ -397,7 +402,8 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 			let lb = self.origin_lb.row(obj);
 			let ub = self.origin_ub.row(obj);
 
-			// Check if the new forbidden region can be coalesced with an existing one.
+			// Check if the new forbidden region can be coalesced with an
+			// existing one.
 			if forbidden.overlaps(lb, ub) {
 				for tup in &mut forbidden_regions {
 					if let Some((f, _)) = tup {
@@ -617,16 +623,17 @@ impl<const STRICT: bool, I1, I2> IntNoOverlapSweep<STRICT, I1, I2> {
 	{
 		// `sweep` is the current point being checked for feasibility.
 		let mut sweep = self.origin_lb.row(obj).to_vec();
-		// `jump` stores the earliest possible escape point from a forbidden region.
+		// `jump` stores the earliest possible escape point from a forbidden
+		// region.
 		let mut jump: Vec<_> = self.origin_ub.row(obj).iter().map(|v| v + 1).collect();
 		let mut b = true;
 
 		// Find the first forbidden region that the sweep point is inside.
 		let mut fr = Region::find_collision(forbidden_regions.iter().map(|(r, _)| r), &sweep);
 		while b && fr.is_some() {
-			// Update the jump point: to escape the current forbidden region `fr`,
-			// we must jump to at least its upper bound + 1 in some dimension.
-			// We take the minimum of all possible jump points.
+			// Update the jump point: to escape the current forbidden region
+			// `fr`, we must jump to at least its upper bound + 1 in some
+			// dimension. We take the minimum of all possible jump points.
 			for (i, j) in jump.iter_mut().enumerate() {
 				*j = cmp::min(*j, fr.unwrap().max(i) + 1);
 			}
@@ -713,8 +720,8 @@ where
 	fn initialize(&mut self, ctx: &mut E::InitializationContext<'_>) {
 		ctx.set_priority(PriorityLevel::Lowest);
 
-		// The propagator needs to be re-run whenever the bounds of any origin or
-		// size variable change.
+		// The propagator needs to be re-run whenever the bounds of any origin
+		// or size variable change.
 		for v in self.origin.iter_elem() {
 			v.enqueue_when(ctx, IntPropCond::Bounds);
 		}
@@ -739,25 +746,27 @@ where
 			}
 		}
 
-		// Main propagation loop: iterate through each object that is still a "target".
+		// Main propagation loop: iterate through each object that is still a
+		// "target".
 		for obj in 0..self.num_objects() {
 			// Skip objects that are already fixed and verified.
 			if ctx.trailed(self.target[obj]) {
 				continue;
 			}
 
-			// In non-strict mode, objects with size (potential) 0 do not need to be
-			// considered.
+			// In non-strict mode, objects with size (potential) 0 do not need
+			// to be considered.
 			if !STRICT && self.size_lb.row(obj).contains(&0) {
 				continue;
 			}
 
-			// Reason about the object's overlaps: collect the forbidden regions for
-			// the origin sweep below and, from the same intervals, tighten its size.
+			// Reason about the object's overlaps: collect the forbidden regions
+			// for the origin sweep below and, from the same intervals,
+			// tighten its size.
 			let forbidden = self.forbidden_regions::<E>(ctx, obj)?;
 			if !forbidden.is_empty() {
-				// Check for conflicts: if an object is fixed and is in a forbidden
-				// region, it's a conflict.
+				// Check for conflicts: if an object is fixed and is in a
+				// forbidden region, it's a conflict.
 				if self.fixed_object(obj) {
 					// Trigger a conflict by increasing the lower bound.
 					self.origin[[obj, 0]].tighten_min(
@@ -767,7 +776,8 @@ where
 					)?;
 				}
 
-				// Prune the domains of the origin variables for the current object.
+				// Prune the domains of the origin variables for the current
+				// object.
 				let mut all_fixed = true;
 				for d in 0..self.num_dimensions() {
 					self.prune_min(ctx, &forbidden, obj, d)?;
@@ -777,8 +787,9 @@ where
 						all_fixed = false;
 					}
 				}
-				// Target optimization: mark the object as no longer being a target,
-				// skipping it in future iterations, when its origin and size are fixed.
+				// Target optimization: mark the object as no longer being a
+				// target, skipping it in future iterations, when its origin
+				// and size are fixed.
 				if all_fixed
 					&& (TypeId::of::<I2>() == TypeId::of::<IntVal>()
 						|| self.size.row(obj).iter().all(|v| v.val(ctx).is_some()))
@@ -788,7 +799,8 @@ where
 			}
 		}
 
-		// Source optimization: update the bounding box of all non-fixed objects.
+		// Source optimization: update the bounding box of all non-fixed
+		// objects.
 		for obj in 0..self.num_objects() {
 			if ctx.trailed(self.target[obj]) {
 				continue;
@@ -805,7 +817,8 @@ where
 
 		// Identify objects that have lost their "source" property. If a fixed
 		// object is now completely disjoint from the bounding box of all other
-		// non-fixed objects, it can no longer create forbidden regions for them.
+		// non-fixed objects, it can no longer create forbidden regions for
+		// them.
 		for obj in 0..self.num_objects() {
 			if ctx.trailed(self.target[obj]) && self.disjoint(&self.bounding_box, obj) {
 				let _ = ctx.set_trailed(self.source[obj], true);
@@ -1135,8 +1148,8 @@ mod tests {
 		let _ = slv.propagate_next().unwrap();
 		assert_eq!(ady.bounds(&slv), (1, 2));
 
-		// Now the same scenario as above, but with `b`'s x-size possibly being zero,
-		// not allowing any further propagation.
+		// Now the same scenario as above, but with `b`'s x-size possibly being
+		// zero, not allowing any further propagation.
 		let mut slv = Solver::default();
 		let ady = slv.new_int_decision(1..=3).view();
 		let bdx = slv.new_int_decision(0..=1).view();

--- a/crates/huub/src/constraints/int_pow.rs
+++ b/crates/huub/src/constraints/int_pow.rs
@@ -209,8 +209,8 @@ where
 		let (res_lb, res_ub) = self.result.bounds(ctx);
 
 		if base_lb <= 1 || res_lb <= 1 {
-			// TODO: It seems there should be propagation possible, but log2() certainly
-			// won't work.
+			// TODO: It seems there should be propagation possible, but log2()
+			// certainly won't work.
 			return Ok(());
 		}
 
@@ -495,8 +495,8 @@ where
 
 		// Protect against saturation inaccuracy: if `pow(base, exp)` causes
 		// overflow, then the `base` and `exp` should be disallowed, but
-		// because of the internal saturation used, it will instead allow `IntVal::MAX`
-		// or `IntVal::MIN` to be used as the result.
+		// because of the internal saturation used, it will instead allow
+		// `IntVal::MAX` or `IntVal::MIN` to be used as the result.
 		if OM::HANDLE_OVERFLOW
 			&& let Some(base) = self.base.val(ctx)
 			&& let Some(exp) = self.exponent.val(ctx)

--- a/crates/huub/src/constraints/int_set_contains.rs
+++ b/crates/huub/src/constraints/int_set_contains.rs
@@ -80,14 +80,14 @@ where
 			})?;
 			return Ok(SimplificationStatus::Subsumed);
 		}
-		// If `set` is a superset of domain, then it is known that `reif` is true.
-		// (After intersection, we can just check equality)
+		// If `set` is a superset of domain, then it is known that `reif` is
+		// true. (After intersection, we can just check equality)
 		if domain == self.set {
 			self.reif.require(ctx, NO_REASON)?;
 			return Ok(SimplificationStatus::Subsumed);
 		}
-		// Otherwise, we check whether we can rewrite the constraint into a simpler
-		// form.
+		// Otherwise, we check whether we can rewrite the constraint into a
+		// simpler form.
 		if self.set.intervals().len() == 1 {
 			let lb = self.set.min().unwrap();
 			let ub = self.set.max().unwrap();

--- a/crates/huub/src/constraints/int_table.rs
+++ b/crates/huub/src/constraints/int_table.rs
@@ -111,8 +111,8 @@ where
 			.map(|&iv| slv.solver_view(iv))
 			.collect_vec();
 
-		// Create clauses that say foreach tuple i, if `selector[i]` is true, then the
-		// variable `j` equals `vals[i][j]`.
+		// Create clauses that say foreach tuple i, if `selector[i]` is true,
+		// then the variable `j` equals `vals[i][j]`.
 		if vars.len() != 2 {
 			for (i, tup) in self.table.iter().enumerate() {
 				assert!(tup.len() == vars.len());
@@ -123,22 +123,22 @@ where
 			}
 		}
 
-		// Create clauses that map from the value taken by the variables back to the
-		// possible selectors that can be active.
+		// Create clauses that map from the value taken by the variables back to
+		// the possible selectors that can be active.
 		for (j, var) in vars.iter().enumerate() {
 			let (lb, ub) = var.bounds(slv);
 			let mut support_clauses: Vec<Vec<_>> = vec![Vec::new(); (ub - lb + 1) as usize];
 			for (i, tup) in self.table.iter().enumerate() {
 				let k = tup[j] - lb;
 				if !(0..support_clauses.len() as IntVal).contains(&k) {
-					// Value is not in the domain of the variable, so this tuple should not
-					// be considered.
+					// Value is not in the domain of the variable, so this tuple
+					// should not be considered.
 					continue;
 				}
 				// Add tuple i to be in support of value `k`.
 				if vars.len() == 2 {
-					// Special case where we can use the values of the other variables as
-					// the selection variables directly.
+					// Special case where we can use the values of the other
+					// variables as the selection variables directly.
 					support_clauses[k as usize]
 						.push(vars[1 - j].lit(slv, IntLitMeaning::Eq(tup[1 - j])));
 				} else {

--- a/crates/huub/src/constraints/int_unique.rs
+++ b/crates/huub/src/constraints/int_unique.rs
@@ -85,9 +85,9 @@ where
 			return;
 		}
 
-		// The eager value encoding pays off when the decisions jointly range over
-		// few values relative to their number. Use the cardinality of the union of
-		// all the decision variable domains.
+		// The eager value encoding pays off when the decisions jointly range
+		// over few values relative to their number. Use the cardinality of
+		// the union of all the decision variable domains.
 		let dcns = &self.bounds_prop.vars;
 		let mut union: Option<IntSet> = None;
 		for d in dcns {
@@ -124,8 +124,8 @@ where
 				Either::Right(var)
 			}
 		});
-		// Propagation should have detected any duplicate fixed values and removed them
-		// from the domains of other decision variables.
+		// Propagation should have detected any duplicate fixed values and
+		// removed them from the domains of other decision variables.
 		debug_assert!(_vals.iter().unique().collect_vec().len() == _vals.len());
 		debug_assert!(
 			_vals

--- a/crates/huub/src/constraints/int_unique/domain.rs
+++ b/crates/huub/src/constraints/int_unique/domain.rs
@@ -359,8 +359,8 @@ impl<I> IntUniqueDomain<I> {
 		self.tarjan.vals_buf.clear();
 
 		// Pop the SCC off the DFS stack into the two bitsets. The dummy node is
-		// not a real graph node, so it is dropped (but still terminates the loop
-		// if it happens to be the SCC root).
+		// not a real graph node, so it is dropped (but still terminates the
+		// loop if it happens to be the SCC root).
 		loop {
 			let node = self.tarjan.dfs_stack.pop().expect("non-empty DFS stack");
 			self.tarjan.dfs_on_stack[node] = false;
@@ -375,8 +375,8 @@ impl<I> IntUniqueDomain<I> {
 		}
 
 		// Every popped SCC must contain at least one decision, because the
-		// 2-cycle construction makes every matched value share its decision's SCC.
-		// This is to avoid value-only SCCs in classic Régin's algorithm,
+		// 2-cycle construction makes every matched value share its decision's
+		// SCC. This is to avoid value-only SCCs in classic Régin's algorithm,
 		// which would require a separate pass to filter out.
 		debug_assert!(
 			!self.tarjan.dcns_buf.is_empty(),
@@ -384,9 +384,10 @@ impl<I> IntUniqueDomain<I> {
 		);
 
 		// Move the SCC's decisions into their own block. `split_off` keeps the
-		// SCC's decisions in positions [new_root..orig_end); the *other* decisions from
-		// the same original block now occupy [orig_root..new_root) — exactly
-		// the decisions that still need this SCC's values stripped from them.
+		// SCC's decisions in positions [new_root..orig_end); the *other*
+		// decisions from the same original block now occupy
+		// [orig_root..new_root) — exactly the decisions that still need this
+		// SCC's values stripped from them.
 		let (orig_root, new_scc_root) = self.partition.split_off(&self.tarjan.dcns_buf, ctx);
 		let Some(new_root) = new_scc_root else {
 			// The new SCC absorbed the entire original block — no outside
@@ -396,8 +397,8 @@ impl<I> IntUniqueDomain<I> {
 
 		// `new_root` is the SCC's block root for both matched and unmatched
 		// values (a matched val's matched_dcn is in this SCC; for an unmatched
-		// val, any in-SCC decision serves as the SCC representative). One scc_id
-		// covers every value in the SCC.
+		// val, any in-SCC decision serves as the SCC representative). One
+		// scc_id covers every value in the SCC.
 		let scc_id = new_root as u64;
 		for &val_idx in self.tarjan.vals_buf.iter() {
 			let val = self.graph.value_at(val_idx);
@@ -461,7 +462,8 @@ impl<I> IntUniqueDomain<I> {
 			let dummy = this.tarjan.dummy_node();
 			if node < n_dncs {
 				// 2-cycle: edges to ALL domain values incl. the matched one, so
-				// every matched pair shares an SCC and no value-only SCC arises.
+				// every matched pair shares an SCC and no value-only SCC
+				// arises.
 				for val in this.graph.dcns[node].domain(ctx).iter().flatten() {
 					let val_idx = this.graph.value_index(val);
 					this.tarjan.neighbours.push(n_dncs + val_idx);
@@ -504,9 +506,9 @@ impl<I> IntUniqueDomain<I> {
 			if i < frame_end {
 				// Advance this frame's cursor, then explore the neighbour. A
 				// not-yet-visited neighbour pushes a new frame (the recursive
-				// call); when we later pop it, the `else` branch below folds its
-				// low-link back into this frame — exactly the post-recursion
-				// update of the original code.
+				// call); when we later pop it, the `else` branch below folds
+				// its low-link back into this frame — exactly the
+				// post-recursion update of the original code.
 				let nb = self.tarjan.neighbours[i];
 				self.tarjan.work_stack.last_mut().unwrap().i += 1;
 				if self.tarjan.dfs_index[nb] != 0 {
@@ -527,10 +529,10 @@ impl<I> IntUniqueDomain<I> {
 
 			// SCC root?
 			if self.tarjan.low_link[frame.node] == self.tarjan.dfs_index[frame.node] {
-				// Either we entered the DFS in the middle (low_link > 1) or some
-				// left nodes weren't reached from this root -> graph is not one
-				// single SCC. The counter avoids re-scanning `dfs_index` on every
-				// SCC-root pop.
+				// Either we entered the DFS in the middle (low_link > 1) or
+				// some left nodes weren't reached from this root -> graph
+				// is not one single SCC. The counter avoids re-scanning
+				// `dfs_index` on every SCC-root pop.
 				if self.tarjan.low_link[frame.node] > 1 || *n_left_visited < n_dcns {
 					*scc_split_detected = true;
 				}
@@ -699,14 +701,15 @@ impl<I> IntUniqueDomain<I> {
 		for &i in self.dirty_dcns.iter() {
 			let dcn = &self.graph.dcns[i];
 			let matched_val_index = self.graph.dcn_to_val[i];
-			// If the previously matched value is no longer in the domain, this decision is
-			// now unmatched.
+			// If the previously matched value is no longer in the domain, this
+			// decision is now unmatched.
 			if matched_val_index
 				.is_none_or(|val_idx| !dcn.in_domain(ctx, self.graph.value_at(val_idx)))
 			{
 				self.unmatched_dcns.insert(i);
 			}
-			// Fixed decisions: strip their fixed value from the rest of their SCC.
+			// Fixed decisions: strip their fixed value from the rest of their
+			// SCC.
 			if let Some(val) = self.graph.dcns[i].val(ctx) {
 				let scc_id = self.partition.block_root(i, ctx);
 				let scc_end = self.partition.block_end(scc_id, ctx);
@@ -717,8 +720,8 @@ impl<I> IntUniqueDomain<I> {
 						self.graph.dcns[idx].remove_val(ctx, val, |_, reason| {
 							reason.push(reason_lit.clone());
 						})?;
-						// If `val` was the matched value for decision at `idx`, then it is now
-						// unmatched.
+						// If `val` was the matched value for decision at `idx`,
+						// then it is now unmatched.
 						if self.graph.dcn_to_val[idx]
 							.is_none_or(|val_idx| val == self.graph.value_at(val_idx))
 						{
@@ -744,8 +747,9 @@ impl<I> IntUniqueDomain<I> {
 		I: IntSolverActions<E>,
 	{
 		self.changed_scc.clear();
-		// Detach the unmatched set so the loop body can take `&mut self` for the
-		// matching repair; restored below to keep its allocation across calls.
+		// Detach the unmatched set so the loop body can take `&mut self` for
+		// the matching repair; restored below to keep its allocation across
+		// calls.
 		let unmatched_dcns = mem::take(&mut self.unmatched_dcns);
 		for &i in unmatched_dcns.iter() {
 			let needs_augment = match self.graph.dcn_to_val[i] {
@@ -822,8 +826,8 @@ where
 		data: u64,
 		_event: IntEvent,
 	) -> bool {
-		// safe to unwrap: `card()` only returns `None` if the number of steps would
-		// overflow `usize`
+		// safe to unwrap: `card()` only returns `None` if the number of steps
+		// would overflow `usize`
 		let domain_size = self.graph.dcns[data as usize].domain(ctx).card().unwrap();
 		self.dirty_dcns.insert(data as usize);
 		domain_size < self.graph.n_dcns()
@@ -843,9 +847,9 @@ where
 		// decision set `H` provably confined to an equal-sized value set `V` in
 		// the current domains. Note that the raw SCC members alone are unsound:
 		// a member can still hold an out-of-SCC value (a cross-SCC edge that a
-		// downstream prune/backtrack left behind), making the Hall set non-tight and
-		// the nogood too weak. The closure absorbs every such escape so
-		// `|H| == |V|` by construction.
+		// downstream prune/backtrack left behind), making the Hall set
+		// non-tight and the nogood too weak. The closure absorbs every such
+		// escape so `|H| == |V|` by construction.
 		self.compute_scc_closure_for_explain(ctx, scc_id..scc_end);
 		debug_assert_eq!(
 			self.closure.dcns.len(),
@@ -857,8 +861,9 @@ where
 			atom
 		});
 		// Reset the membership marks (O(closure)) so the bitsets are clean for
-		// the next explain. The `dcns`/`vals` lists are the only record of which
-		// entries were marked, so this must run after the reason is built.
+		// the next explain. The `dcns`/`vals` lists are the only record of
+		// which entries were marked, so this must run after the reason is
+		// built.
 		self.closure.clear_marks();
 	}
 
@@ -954,9 +959,9 @@ mod tests {
 	#[traced_test]
 	fn test_domain_deep_chain() {
 		// Staircase that forces a long DFS over the residual graph: `x_i in
-		// {i, i+1}` for `i < N`, with the top pinned to `x_N = N`. All-different
-		// forces a downward cascade `x_i = i`, but reaching that fixpoint walks
-		// a chain whose length is proportional to `N`.
+		// {i, i+1}` for `i < N`, with the top pinned to `x_N = N`.
+		// All-different forces a downward cascade `x_i = i`, but reaching
+		// that fixpoint walks a chain whose length is proportional to `N`.
 		const N: IntVal = 300;
 		let mut slv = Solver::default();
 		let dcns: Vec<_> = (1..=N)
@@ -1008,14 +1013,16 @@ mod tests {
 	fn test_domain_interior_hole() {
 		// One test covering the distinguishing behaviours of the domain
 		// propagator at once:
-		// - The universe (1..=6) exceeds the decision count, so the matching leaves
-		//   free values (2, 5, 6) and the residual graph routes through the dummy node.
-		// - The Hall set {a, b} occupies {3, 4}, so domain consistency must remove the
-		//   *interior* values 3 and 4 from `e`, leaving the disconnected set {1, 2, 5,
-		//   6}. A bounds-consistent propagator could not do this: e's bounds stay (1,
+		// - The universe (1..=6) exceeds the decision count, so the matching
+		//   leaves free values (2, 5, 6) and the residual graph routes through
+		//   the dummy node.
+		// - The Hall set {a, b} occupies {3, 4}, so domain consistency must
+		//   remove the *interior* values 3 and 4 from `e`, leaving the
+		//   disconnected set {1, 2, 5, 6}. A bounds-consistent propagator could
+		//   not do this: e's bounds stay (1,
 		//   6) and only the holes change.
-		// - We assert the exact set of literals propagated, not just the resulting
-		//   domain.
+		// - We assert the exact set of literals propagated, not just the
+		//   resulting domain.
 		use crate::actions::{IntDecisionActions, IntInspectionActions};
 
 		let mut slv = Solver::default();

--- a/crates/huub/src/constraints/int_unique/value.rs
+++ b/crates/huub/src/constraints/int_unique/value.rs
@@ -66,26 +66,28 @@ where
 		data: u64,
 		event: IntEvent,
 	) -> bool {
-		// We remember that the decision at index `data` has been fixed to a value.
+		// We remember that the decision at index `data` has been fixed to a
+		// value.
 		debug_assert_eq!(event, IntEvent::Fixed);
 		self.action_list.push(data as usize);
 		true
 	}
 
 	fn initialize(&mut self, ctx: &mut E::InitializationContext<'_>) {
-		// Let the propagator be advised when each specific decision is fixed to a
-		// value, with the index of the decision.
+		// Let the propagator be advised when each specific decision is fixed to
+		// a value, with the index of the decision.
 		for (i, v) in self.vars.iter().enumerate() {
 			if self.vars[i].val(ctx).is_some() {
-				// If the variable is already fixed, then add it to the action list immediately.
+				// If the variable is already fixed, then add it to the action
+				// list immediately.
 				self.action_list.push(i);
 				ctx.enqueue_now(true);
 			} else {
 				v.advise_when(ctx, IntPropCond::Fixed, i as u64);
 			}
 		}
-		// Advise the propagator of backtracking to clear the list of fixed decision
-		// (indices).
+		// Advise the propagator of backtracking to clear the list of fixed
+		// decision (indices).
 		ctx.advise_on_backtrack();
 	}
 
@@ -103,8 +105,8 @@ where
 			let val = self.vars[i].val(ctx).unwrap();
 			let val_lit = self.vars[i].val_lit(ctx).unwrap();
 
-			// We now enforce that all other decisions (at different indices) are not
-			// equal to the fixed value.
+			// We now enforce that all other decisions (at different indices)
+			// are not equal to the fixed value.
 			for (j, v) in self.vars.iter().enumerate() {
 				if j != i {
 					v.remove_val(ctx, val, |_, reason| reason.push(val_lit.clone()))?;

--- a/crates/huub/src/constraints/int_value_precede.rs
+++ b/crates/huub/src/constraints/int_value_precede.rs
@@ -86,11 +86,13 @@ impl<I> IntSeqPrecedeChainBounds<I> {
 	{
 		move |ctx, reason| {
 			// Explain a lower bound via 3 cases:
-			// - Lower bound of var i is above k - This is the value that required the
-			//   earlier lower bound that is currently explained (end of recursion).
-			// - k is in the domain of var i - Go one step up and to the next variable.
-			// - k is not in the domain of var i - i can be anything else, go to next
+			// - Lower bound of var i is above k - This is the value that
+			//   required the earlier lower bound that is currently explained
+			//   (end of recursion).
+			// - k is in the domain of var i - Go one step up and to the next
 			//   variable.
+			// - k is not in the domain of var i - i can be anything else, go to
+			//   next variable.
 			{
 				let mut i = i + 1;
 				let mut k = k;
@@ -151,8 +153,8 @@ impl<I> IntSeqPrecedeChainBounds<I> {
 		// Forward pass to set upper bounds and capture the highest lower bound.
 		for (i, v) in self.vars.iter().enumerate() {
 			let mut ub_v = v.max(ctx);
-			// Upper bound can only increase by 1, set new bound if larger values are in the
-			// domain.
+			// Upper bound can only increase by 1, set new bound if larger
+			// values are in the domain.
 			if ub_v > up + 1 {
 				if v.in_domain(ctx, up + 1) {
 					ub_v = up + 1;
@@ -422,11 +424,13 @@ where
 				if lb > ctx.trailed(self.max_last) {
 					ctx.set_trailed(self.max_last, lb);
 				}
-				// If a repair is necessary, continue check where the repair ended.
+				// If a repair is necessary, continue check where the repair
+				// ended.
 				(i, k) = self.repair_lower(ctx, lb)?;
 				continue;
 			}
-			// Deal with moving the last possibility to have value k for the first.
+			// Deal with moving the last possibility to have value k for the
+			// first.
 			if ctx.trailed(self.last[k as usize]) == i && !self.vars[i as usize].in_domain(ctx, k) {
 				(i, k) = self.repair_lower(ctx, k)?;
 			}
@@ -450,20 +454,21 @@ impl<I> IntValuePrecedeChainValue<I> {
 	{
 		move |ctx, reason| {
 			// Explain a lower bound via 3 cases:
-			// - Current lower bound index is above k - This is the value that required the
-			//   earlier lower bound that is currently explained (end of recursion).
-			// - Index k is in the domain of var i - Go one step up and to the next
-			//   variable.
-			// - Index k is not in the domain of var i - i can be anything else, go to next
-			//   variable.
+			// - Current lower bound index is above k - This is the value that
+			//   required the earlier lower bound that is currently explained
+			//   (end of recursion).
+			// - Index k is in the domain of var i - Go one step up and to the
+			//   next variable.
+			// - Index k is not in the domain of var i - i can be anything else,
+			//   go to next variable.
 			{
 				let mut i = i + 1;
 				let mut j = j;
 
 				while j < self.values.len() {
-					// A lower bound is explained by stating that all untracked values are excluded
-					// (< min value, > max value, all holes), as well as all values with smaller
-					// indices.
+					// A lower bound is explained by stating that all untracked
+					// values are excluded (< min value, > max value, all
+					// holes), as well as all values with smaller indices.
 					if let Some(lb) = self.lowest_index(ctx, i).unwrap_or(Some(j + 1))
 						&& lb > j
 					{
@@ -536,8 +541,8 @@ impl<I> IntValuePrecedeChainValue<I> {
 
 		// Forward pass to set upper bounds and capture the highest lower bound.
 		for (i, v) in self.vars.iter().enumerate() {
-			// Upper bound can only increase by 1, set new bound if larger values are in the
-			// domain.
+			// Upper bound can only increase by 1, set new bound if larger
+			// values are in the domain.
 			self.propagate_max(ctx, i, up + 1)?;
 			// The current var is the first possibility to reach index up + 1.
 			if up < self.values.len() && v.in_domain(ctx, self.values[up]) {
@@ -638,7 +643,8 @@ impl<I> IntValuePrecedeChainValue<I> {
 			.collect();
 		let first_val = (0..vars.len()).map(|_| engine.new_trailed(0)).collect();
 		let max_last = engine.new_trailed(0);
-		// Set up some data structures to deal with holes in values more efficiently.
+		// Set up some data structures to deal with holes in values more
+		// efficiently.
 		let min_val = *values.iter().min().unwrap_or(&IntVal::MAX);
 		let max_val = *values.iter().max().unwrap_or(&IntVal::MIN);
 		let holes = (min_val..=max_val)
@@ -785,8 +791,9 @@ impl<I> IntValuePrecedeChainValue<I> {
 			// Hit boundary case, this will cause a conflict.
 			if i < 0 {
 				self.propagate_min(ctx, 0, k)?;
-				// Return Ok since the conflict is only detected during propagation
-				// (several domain elements are removed separately).
+				// Return Ok since the conflict is only detected during
+				// propagation (several domain elements are removed
+				// separately).
 				return Ok((0, k));
 			}
 		}
@@ -937,8 +944,8 @@ where
 			};
 			let li = self.lowest_index(ctx, i);
 			if li.is_err() {
-				// There is already a conflict waiting to propagate, no need for further
-				// propagation
+				// There is already a conflict waiting to propagate, no need for
+				// further propagation
 				return Ok(());
 			}
 			if let Ok(Some(lb)) = li {
@@ -949,12 +956,14 @@ where
 					if lb as IntVal > ctx.trailed(self.max_last) {
 						ctx.set_trailed(self.max_last, lb as IntVal);
 					}
-					// If a repair is necessary, continue check where the repair ended.
+					// If a repair is necessary, continue check where the repair
+					// ended.
 					(i, k) = self.repair_lower(ctx, lb)?;
 					continue;
 				}
 			}
-			// Deal with moving the last possibility to have value k for the first time.
+			// Deal with moving the last possibility to have value k for the
+			// first time.
 			if ctx.trailed(self.last[k]) == i as IntVal
 				&& !self.vars[i].in_domain(ctx, self.values[k - 1])
 			{

--- a/crates/huub/src/lower.rs
+++ b/crates/huub/src/lower.rs
@@ -333,8 +333,8 @@ impl GoalPolarity {
 			constraint_ids.sort_unstable_by_key(|con| con.index());
 			constraint_ids.dedup();
 			for &con in &constraint_ids {
-				// Never enqueue decisions from the constraint that enqueued this
-				// decision
+				// Never enqueue decisions from the constraint that enqueued
+				// this decision
 				if discovering == Some(con) {
 					continue;
 				}
@@ -400,10 +400,10 @@ impl GoalPolarity {
 		input: &Resolved<model::Decision<IntVal>>,
 		input_polarity: Polarity,
 	) {
-		// The denominator must be strictly positive or strictly negative for the
-		// division to be monotone in either argument. The result follows the
-		// numerator when the denominator is positive, and opposes it when the
-		// denominator is negative.
+		// The denominator must be strictly positive or strictly negative for
+		// the division to be monotone in either argument. The result follows
+		// the numerator when the denominator is positive, and opposes it when
+		// the denominator is negative.
 		let (den_lb, den_ub) = div.denominator.bounds(model);
 		if den_lb >= 1 {
 			self.record_relation(model, &[div.result, -div.numerator], input, input_polarity);
@@ -508,8 +508,8 @@ impl GoalPolarity {
 		else {
 			return;
 		};
-		// To push `input` in `input_polarity`, the other terms must be pushed in
-		// the opposite direction.
+		// To push `input` in `input_polarity`, the other terms must be pushed
+		// in the opposite direction.
 		let term_dir = if input_neg {
 			input_polarity
 		} else {
@@ -523,7 +523,8 @@ impl GoalPolarity {
 						continue;
 					}
 					model.observe_int_polarity(t, Tier::Objective, term_dir);
-					// The direction wanted for `w` is `term_dir` folded by `w`'s scale.
+					// The direction wanted for `w` is `term_dir` folded by
+					// `w`'s scale.
 					let w_dir = if lin.scale.get() < 0 {
 						!term_dir
 					} else {
@@ -1178,8 +1179,8 @@ impl LoweringMapBuilder {
 							Some(Polarity::Negative) => slv.sat.phase(!dcn.0),
 							None => {}
 						};
-						// Register the new solver literal based on a model Boolean
-						// decision.
+						// Register the new solver literal based on a model
+						// Boolean decision.
 						tracing::trace!(
 							target: "reverse_map",
 							model = idx as u64,
@@ -1607,7 +1608,8 @@ mod tests {
 		model.linear(a - b + c - x).eq(0).post().unwrap();
 		model.linear(d + e - c).eq(0).post().unwrap();
 
-		// Resolve each view to its decision index before lowering borrows `model`.
+		// Resolve each view to its decision index before lowering borrows
+		// `model`.
 		let idx = int_decision_index;
 		let (ai, bi, ci, di, ei) = (idx(a), idx(b), idx(c), idx(d), idx(e));
 

--- a/crates/huub/src/model.rs
+++ b/crates/huub/src/model.rs
@@ -587,7 +587,8 @@ impl Model {
 		let mut status = con_obj.simplify(&mut SimplificationContext(&mut *self));
 		self.cur_prop = None;
 
-		// Resolve a deferred conflict's clause while the propagator is available.
+		// Resolve a deferred conflict's clause while the propagator is
+		// available.
 		if let Err(Conflict(ConflictInner::Deferred {
 			subject,
 			propagator,

--- a/crates/huub/src/model/decision/integer.rs
+++ b/crates/huub/src/model/decision/integer.rs
@@ -394,7 +394,8 @@ impl Resolved<Decision<IntVal>> {
 		if let Some(event) = ctx.0.int_events.remove(&(idx as u32)) {
 			ctx.0.notify_int_event(idx as u32, event);
 		}
-		// Transfer any constraints from the aliased variable to the target variable
+		// Transfer any constraints from the aliased variable to the target
+		// variable
 		let constraints = mem::take(&mut ctx.0.int_vars[idx].constraints);
 		// Move subscriptions to target decision variable
 		match target.0 {

--- a/crates/huub/src/model/deserialize/flatzinc.rs
+++ b/crates/huub/src/model/deserialize/flatzinc.rs
@@ -1135,16 +1135,16 @@ impl<'a> FznModelBuilder<'a> {
 				if next_state == 0 {
 					continue;
 				}
-				// If the current state is the initial state, add the transition to start
-				// table
+				// If the current state is the initial state, add the transition
+				// to start table
 				if cur_state == init_state {
 					start.push(vec![input_read, next_state]);
 				}
-				// Add transition to the middle table (all valid transitions are allowed
-				// here)
+				// Add transition to the middle table (all valid transitions are
+				// allowed here)
 				middle.push(vec![cur_state, input_read, next_state]);
-				// If the resulting state is an accepting state, add the transition to the
-				// end table
+				// If the resulting state is an accepting state, add the
+				// transition to the end table
 				if accept_states.contains(&next_state) {
 					end.push(vec![cur_state, input_read]);
 				}
@@ -1264,14 +1264,16 @@ impl<'a> FznModelBuilder<'a> {
 					}
 				},
 				Entry::Vacant(e) => {
-					// Enforce the domain of the named (uncreated) variable on the view
+					// Enforce the domain of the named (uncreated) variable on
+					// the view
 					if let Type::Int(Some(dom)) = &var.ty {
 						let AnyView::Int(view) = view else {
 							unreachable!()
 						};
 						view.restrict_domain(&mut me.prb, dom, NO_REASON)?;
 					}
-					// Insert the view to use instead of a new variable for the name
+					// Insert the view to use instead of a new variable for the
+					// name
 					e.insert(view);
 				}
 			}
@@ -1516,8 +1518,8 @@ impl<'a> FznModelBuilder<'a> {
 					Type::Bool => {
 						let model = self.prb.bool_vars.len() as u64;
 						let view = AnyView::Bool(self.prb.new_bool_decision());
-						// Register the model Boolean decision against its FlatZinc
-						// variable.
+						// Register the model Boolean decision against its
+						// FlatZinc variable.
 						if tracing::enabled!(target: "reverse_map", tracing::Level::TRACE)
 							&& let Some(&fzn) = self.var_index.get(&var.cloned_key())
 						{
@@ -1545,8 +1547,8 @@ impl<'a> FznModelBuilder<'a> {
 								self.prb.new_int_decision(FULL_INT_DOMAIN).into()
 							}
 						};
-						// Register the model integer decision against its FlatZinc
-						// variable, unless it's a constant.
+						// Register the model integer decision against its
+						// FlatZinc variable, unless it's a constant.
 						if self.prb.int_vars.len() > before
 							&& tracing::enabled!(target: "reverse_map", tracing::Level::TRACE)
 							&& let Some(&fzn) = self.var_index.get(&var.cloned_key())
@@ -1743,13 +1745,15 @@ impl<'a> FznModelBuilder<'a> {
 					let [arr] = c.args.as_slice() else {
 						return num_args_err(1);
 					};
-					// Resolve every element to a model-level Boolean view, pairing
-					// each view with a human-readable label that the CLI can print
-					// when the assumption ends up in an UNSAT core.
+					// Resolve every element to a model-level Boolean view,
+					// pairing each view with a human-readable label that
+					// the CLI can print when the assumption ends up in an
+					// UNSAT core.
 					//
-					// For variables we use the FlatZinc identifier. For static `false`
-					// literals we keep the textual constant, so the user can see when a
-					// static `false` was passed in. `true` literals are ignored.
+					// For variables we use the FlatZinc identifier. For static
+					// `false` literals we keep the textual constant, so
+					// the user can see when a static `false` was passed
+					// in. `true` literals are ignored.
 					let arr = self.arg_array(arr)?;
 					self.assumptions.reserve(arr.len());
 					for l in arr {
@@ -2177,8 +2181,8 @@ impl<'a> FznModelBuilder<'a> {
 					let f = self.arg_par_set(f)?;
 					let f: FxHashSet<IntVal> = f.iter().flat_map(|r| r.into_iter()).collect();
 
-					// Convert regular constraint in to table constraints and add them to the
-					// model
+					// Convert regular constraint in to table constraints and
+					// add them to the model
 					self.convert_regular_to_tables(x, d, q0, f)
 						.map_err(FlatZincError::from)?;
 				}

--- a/crates/huub/src/model/expressions.rs
+++ b/crates/huub/src/model/expressions.rs
@@ -86,8 +86,9 @@ impl Model {
 			[] => return Ok(()),
 			_ => {}
 		}
-		// Post a model-level `IntUnique` since all successor values must be distinct
-		// (a permutation for `circuit`, a partial permutation for `subcircuit`).
+		// Post a model-level `IntUnique` since all successor values must be
+		// distinct (a permutation for `circuit`, a partial permutation for
+		// `subcircuit`).
 		self.post_constraint(IntUnique {
 			bounds_prop: IntUniqueBounds::new(vars.clone()),
 			value_prop: IntUniqueValue::new(vars.clone()),
@@ -312,8 +313,8 @@ impl Model {
 		#[builder(setters(name = rhs_internal, vis = ""))] rhs: IntLinearExp,
 		#[builder(setters(name = reif_internal, vis = ""))] reif: Option<Reification>,
 	) -> Result<(), Nogood<View<bool>>> {
-		// Subtract the RHS from the LHS to get a linear expression with a constant 0 on
-		// the RHS
+		// Subtract the RHS from the LHS to get a linear expression with a
+		// constant 0 on the RHS
 		expr -= rhs;
 
 		// Move the constant offset to the RHS
@@ -337,8 +338,9 @@ impl Model {
 
 		if terms.is_empty() {
 			// All variable terms cancelled out, so the constraint reduces to a
-			// comparison between the constant `0` and the (constant) `rhs`. Evaluate
-			// it directly, then either enforce it or fix the reification literal.
+			// comparison between the constant `0` and the (constant) `rhs`.
+			// Evaluate it directly, then either enforce it or fix the
+			// reification literal.
 			let satisfied = match comparator {
 				Comparator::NotEqual => 0 != rhs,
 				Comparator::Equal => 0 == rhs,
@@ -627,14 +629,15 @@ impl Model {
 			return Ok(());
 		}
 		if let Some(values) = values {
-			// If the list of values doesn't contain at least two values, then the
-			// constraint is trivially satisfied.
+			// If the list of values doesn't contain at least two values, then
+			// the constraint is trivially satisfied.
 			if values.len() <= 1 {
 				return Ok(());
 			}
-			// If the values are not consecutive or if the largest value does not cover the
-			// full decision variable domain, then we need the general value
-			// precede chain constraint that tracks the explicit values.
+			// If the values are not consecutive or if the largest value does
+			// not cover the full decision variable domain, then we need the
+			// general value precede chain constraint that tracks the
+			// explicit values.
 			if !values.iter().tuple_windows().all(|(&x, &y)| x + 1 == y)
 				|| *values.last().unwrap() < vars.iter().map(|v| v.max(self)).max().unwrap()
 			{
@@ -643,9 +646,10 @@ impl Model {
 				let con = IntValuePrecedeChainValue::new(self, values.into_iter().collect(), vars);
 				return self.post_constraint(con).map(|_| ());
 			}
-			// Otherwise this is a sequential precede chain constraint, and we can
-			// normalize it to start at 1. The `values` array might not have started
-			// at 1, calculate the offset to subtract from the decision variables.
+			// Otherwise this is a sequential precede chain constraint, and we
+			// can normalize it to start at 1. The `values` array might not
+			// have started at 1, calculate the offset to subtract from the
+			// decision variables.
 			offset = values[0] - 1;
 		}
 
@@ -1025,8 +1029,8 @@ mod tests {
 
 	#[test]
 	fn test_empty_linear_implied_false() {
-		// `0 == 5` is false, so the half-reification literal `r` must be fixed to
-		// false (the model stays satisfiable).
+		// `0 == 5` is false, so the half-reification literal `r` must be fixed
+		// to false (the model stays satisfiable).
 		let mut prb = Model::default();
 		let x = prb.new_int_decision(1..=5);
 		let r = prb.new_bool_decision();
@@ -1036,8 +1040,8 @@ mod tests {
 
 	#[test]
 	fn test_empty_linear_reified_false() {
-		// `0 == 5` is false, so the reification literal `r` must be fixed to false
-		// and the model must remain satisfiable.
+		// `0 == 5` is false, so the reification literal `r` must be fixed to
+		// false and the model must remain satisfiable.
 		let mut prb = Model::default();
 		let x = prb.new_int_decision(1..=5);
 		let r = prb.new_bool_decision();
@@ -1047,7 +1051,8 @@ mod tests {
 
 	#[test]
 	fn test_empty_linear_reified_true() {
-		// `0 == 0` is true, so the reification literal `r` must be fixed to true.
+		// `0 == 0` is true, so the reification literal `r` must be fixed to
+		// true.
 		let mut prb = Model::default();
 		let x = prb.new_int_decision(1..=5);
 		let r = prb.new_bool_decision();

--- a/crates/huub/src/model/expressions/element.rs
+++ b/crates/huub/src/model/expressions/element.rs
@@ -127,8 +127,8 @@ impl ElementConstraint for bool {
 		index: View<IntVal>,
 		result: Self::Result,
 	) -> Result<(), Nogood<View<bool>>> {
-		// Convert array of boolean values to a set literals of the indices where
-		// the value is true
+		// Convert array of boolean values to a set literals of the indices
+		// where the value is true
 		let mut ranges = Vec::new();
 		let mut start = None;
 		for (i, b) in array.iter().enumerate() {

--- a/crates/huub/src/model/initilization_context.rs
+++ b/crates/huub/src/model/initilization_context.rs
@@ -477,7 +477,8 @@ impl IntInitActions<ModelInitContext<'_>> for Resolved<View<IntVal>> {
 						return;
 					}
 					BoolView::Const(_) => {
-						// Value does not change, so no advisor will ever be called
+						// Value does not change, so no advisor will ever be
+						// called
 						return;
 					}
 					BoolView::IntEq(iv, v) => (iv, IntLitMeaning::Eq(v), IntPropCond::Domain),
@@ -515,7 +516,8 @@ impl IntInitActions<ModelInitContext<'_>> for Resolved<View<IntVal>> {
 						return ctx.cancel_bool_advisor(lit.idx(), data);
 					}
 					BoolView::Const(_) => {
-						// A constant never subscribed, so there is nothing to cancel.
+						// A constant never subscribed, so there is nothing to
+						// cancel.
 						return;
 					}
 					BoolView::IntEq(iv, _) | BoolView::IntNotEq(iv, _) => (iv, IntPropCond::Domain),

--- a/crates/huub/src/model/resolved.rs
+++ b/crates/huub/src/model/resolved.rs
@@ -134,7 +134,8 @@ impl View<bool> {
 				break;
 			}
 		}
-		// If the current literal is an integer view, check whether it is already fixed.
+		// If the current literal is an integer view, check whether it is
+		// already fixed.
 		match result.0 {
 			IntEq(iv, val) => {
 				let (lb, ub) = iv.bounds(model);

--- a/crates/huub/src/model/view/boolean.rs
+++ b/crates/huub/src/model/view/boolean.rs
@@ -123,7 +123,8 @@ impl Resolved<View<bool>> {
 				debug_assert_eq!(store.alias, None);
 				store.alias = Some(if x.is_negated() { !y } else { y });
 
-				// Move subscriptions from aliased variable to the new primary variable
+				// Move subscriptions from aliased variable to the new primary
+				// variable
 				let constraints = mem::take(&mut store.constraints);
 				match y.0 {
 					// Move subscriptions to another Boolean decision
@@ -151,8 +152,8 @@ impl Resolved<View<bool>> {
 										.add(ActivationAction::Advise(adv), event);
 								}
 								me @ ActivationAction::Enqueue(_) => {
-									// TODO: This triggers even when the Boolean Condition does not
-									// change value
+									// TODO: This triggers even when the Boolean
+									// Condition does not change value
 									model.int_vars[j.idx()].constraints.add(me, event);
 								}
 							}
@@ -398,8 +399,8 @@ mod tests {
 		assert_eq!(x.eq(4).val(&prb), Some(false));
 		assert_eq!(x.ne(4).val(&prb), Some(true));
 
-		// Tightening the lower bound entails the threshold comparisons while `x`
-		// (now in 3, 5) stays unfixed.
+		// Tightening the lower bound entails the threshold comparisons while
+		// `x` (now in 3, 5) stays unfixed.
 		x.tighten_min(&mut prb, 3, NO_REASON).unwrap();
 		assert_eq!(x.val(&prb), None);
 		assert_eq!(x.geq(3).val(&prb), Some(true));

--- a/crates/huub/src/model/view/integer.rs
+++ b/crates/huub/src/model/view/integer.rs
@@ -194,7 +194,8 @@ impl Resolved<View<IntVal>> {
 
 				// Perform the transformation and add the aliasing domain to x:
 				// x_scale * x + x_scale = y_scale * y + y_offset
-				// === x = (y_scale / x_scale) * y + ((y_offset - x_offset) / x_scale)
+				// === x = (y_scale / x_scale) * y + ((y_offset - x_offset) /
+				// x_scale)
 				let scale = NonZero::new(lin_y.scale.get() / lin_x.scale.get()).unwrap();
 				let offset = (lin_y.offset - lin_x.offset) / lin_x.scale.get();
 				let target = View(Linear(LinearView::new(scale, offset, lin_y.var)));
@@ -558,7 +559,8 @@ impl View<IntVal> {
 			Linear(lin) => match lin.reverse_meaning(IntLitMeaning::Eq(v)) {
 				Ok(IntLitMeaning::Eq(val)) => View(BoolView::IntEq(lin.var, val)),
 				Err(b) => {
-					// After the transformation, the value `v` does not remain an integer.
+					// After the transformation, the value `v` does not remain
+					// an integer.
 					debug_assert!(!b);
 					false.into()
 				}

--- a/crates/huub/src/solver.rs
+++ b/crates/huub/src/solver.rs
@@ -737,8 +737,9 @@ where
 			return (status, obj);
 		}
 
-		// Continue to look for all other solutions with the same objective value.
-		// Solutions already visited are added as (permanent) no-good clauses.
+		// Continue to look for all other solutions with the same objective
+		// value. Solutions already visited are added as (permanent) no-good
+		// clauses.
 		let vars = all_solutions.unwrap();
 		let BoolView::Lit(opt_lit) = objective
 			.lit(solver, IntLitMeaning::Eq(obj_curr.unwrap()))
@@ -1305,8 +1306,8 @@ impl<Sat: ExternalPropagation> Solver<Sat> {
 		if let OrderStorage::Eager { storage, .. } = engine.state.int_vars[iv.idx()].order_encoding
 		{
 			// Apply phase hints to the (eager) order literals according to the
-			// polarity. Note that the positive literal represents `x < val`, so a
-			// positive polarity (prefer large values) phases the negation.
+			// polarity. Note that the positive literal represents `x < val`, so
+			// a positive polarity (prefer large values) phases the negation.
 			match polarity {
 				Some(Polarity::Positive) => {
 					for l in storage {

--- a/crates/huub/src/solver/activation_list.rs
+++ b/crates/huub/src/solver/activation_list.rs
@@ -232,8 +232,8 @@ impl ActivationList {
 		condition: IntPropCond,
 		mut matches: impl FnMut(ActivationActionS) -> bool,
 	) -> bool {
-		// The index just past the last activation of each block, in the order in
-		// which the blocks are stored.
+		// The index just past the last activation of each block, in the order
+		// in which the blocks are stored.
 		let ends = [
 			self.lower_bound_idx,
 			self.upper_bound_idx,
@@ -254,10 +254,11 @@ impl ActivationList {
 			return false;
 		};
 
-		// The activations within a block are unordered, so the activation can be
-		// swapped with the last one of its own block. That leaves it at the end
-		// of the block, from where the same swap with the next block moves it
-		// along, until it reaches the end of the list and can be removed.
+		// The activations within a block are unordered, so the activation can
+		// be swapped with the last one of its own block. That leaves it at
+		// the end of the block, from where the same swap with the next block
+		// moves it along, until it reaches the end of the list and can be
+		// removed.
 		let mut hole = pos as usize;
 		for &end in &ends[block..] {
 			let last = end as usize - 1;
@@ -463,8 +464,8 @@ mod tests {
 			}
 
 			for &&(prop, cond) in &order {
-				// An activation is only ever found in the block of the condition
-				// it subscribed with.
+				// An activation is only ever found in the block of the
+				// condition it subscribed with.
 				for &(_, other) in props.iter().filter(|&&(_, c)| c != cond) {
 					assert!(!full.clone().remove(other, |a| a == target(prop)));
 				}

--- a/crates/huub/src/solver/branchers.rs
+++ b/crates/huub/src/solver/branchers.rs
@@ -175,7 +175,8 @@ pub struct WarmStartBrancher {
 /// of values.
 fn domain_median(dom: &IntSet) -> IntVal {
 	if let Some(card) = dom.card() {
-		// The lower median is the value at this (zero-based) index in the domain.
+		// The lower median is the value at this (zero-based) index in the
+		// domain.
 		let mut index = (card - 1) / 2;
 		for interval in dom.iter() {
 			let len = (*interval.end() - *interval.start() + 1) as usize;
@@ -194,8 +195,8 @@ fn domain_median(dom: &IntSet) -> IntVal {
 /// preferring the smaller value when two are equally close.
 fn domain_middle(dom: &IntSet) -> IntVal {
 	// The largest domain value at or below the mean, and the smallest one above
-	// it. As the decision variable is unfixed, `mid < max`, so the latter always
-	// exists.
+	// it. As the decision variable is unfixed, `mid < max`, so the latter
+	// always exists.
 	let min = *dom.min().unwrap();
 	let max = *dom.max().unwrap();
 	let mid = min + (max - min) / 2;
@@ -239,10 +240,11 @@ impl BoolBrancher {
 			})
 			.collect();
 
-		// A Boolean domain `{false, true}` has `false` as its lower value, median,
-		// and middle, and forms a single interval, so every strategy that prefers
-		// the smaller value branches on `false` first, and those that prefer the
-		// larger value or exclude the median branch on `true` first.
+		// A Boolean domain `{false, true}` has `false` as its lower value,
+		// median, and middle, and forms a single interval, so every strategy
+		// that prefers the smaller value branches on `false` first, and those
+		// that prefer the larger value or exclude the median branch on `true`
+		// first.
 		let value = match val_sel {
 			DomainSelection::IndomainMax
 			| DomainSelection::OutdomainMin
@@ -279,8 +281,9 @@ where
 			return Directive::Exhausted;
 		}
 
-		// Boolean decision selection currently selects the first unfixed decision
-		// variable, regardless of the configured decision selection strategy.
+		// Boolean decision selection currently selects the first unfixed
+		// decision variable, regardless of the configured decision selection
+		// strategy.
 		let mut loc = None;
 		for (i, &var) in self.vars.iter().enumerate().skip(begin) {
 			if var.val(ctx).is_none() {
@@ -297,7 +300,8 @@ where
 			return Directive::Exhausted;
 		};
 
-		// Branch on the selected decision variable using the precomputed polarity.
+		// Branch on the selected decision variable using the precomputed
+		// polarity.
 		Directive::Select(if self.value { var } else { !var }.into())
 	}
 }
@@ -353,9 +357,9 @@ impl IntBrancher {
 		}
 
 		// Only the occurrence-based strategies use the degree of a decision
-		// variable. The degree is captured here, when the brancher is installed,
-		// at which point all constraints (and therefore all propagators) have
-		// been posted.
+		// variable. The degree is captured here, when the brancher is
+		// installed, at which point all constraints (and therefore all
+		// propagators) have been posted.
 		let degree = matches!(
 			var_sel,
 			DecisionSelection::Occurrence
@@ -391,8 +395,8 @@ where
 
 		// Score a decision variable for the current strategy as a
 		// `(primary, secondary)` pair; the secondary component is only used by
-		// `MostConstrained` and `DomWDeg`, which require the decision variable's
-		// `degree` (its number of attached propagators).
+		// `MostConstrained` and `DomWDeg`, which require the decision
+		// variable's `degree` (its number of attached propagators).
 		let score = |var: View<IntVal>, degree: u32| -> (IntVal, IntVal) {
 			match self.var_sel {
 				DecisionSelection::AntiFirstFail | DecisionSelection::FirstFail => {
@@ -404,7 +408,8 @@ where
 				DecisionSelection::Smallest => (var.min(actions), 0),
 				DecisionSelection::Occurrence => (IntVal::from(degree), 0),
 				DecisionSelection::MaxRegret => {
-					// The difference between the two smallest values in the domain.
+					// The difference between the two smallest values in the
+					// domain.
 					let Some((first, second)) =
 						var.domain(actions).iter().flatten().take(2).collect_tuple()
 					else {
@@ -434,8 +439,8 @@ where
 			}
 			DecisionSelection::DomWDeg => {
 				// Smallest domain size divided by degree, treating a degree of
-				// zero as an infinite ratio so such decision variables are selected
-				// last.
+				// zero as an infinite ratio so such decision variables are
+				// selected last.
 				// The ratios are compared by cross-multiplication, widened to
 				// `i128` to avoid overflow.
 				match (incumbent.1, candidate.1) {
@@ -455,8 +460,8 @@ where
 		let mut selection = None;
 		for i in begin..self.vars.len() {
 			if self.vars[i].min(actions) == self.vars[i].max(actions) {
-				// Move the fixed decision variable to the front, keeping `degree`
-				// aligned with `vars` when it is populated.
+				// Move the fixed decision variable to the front, keeping
+				// `degree` aligned with `vars` when it is populated.
 				self.vars.swap(first_unfixed, i);
 				if !self.degree.is_empty() {
 					self.degree.swap(first_unfixed, i);
@@ -464,8 +469,8 @@ where
 				first_unfixed += 1;
 			} else {
 				let var = self.vars[i];
-				// `degree` is empty (and thus the degree zero) for the strategies
-				// that do not use it.
+				// `degree` is empty (and thus the degree zero) for the
+				// strategies that do not use it.
 				let new_score = score(var, self.degree.get(i).copied().unwrap_or(0));
 				if let Some((_, sel_score)) = selection {
 					if is_better(sel_score, new_score) {
@@ -488,7 +493,8 @@ where
 		// update the next decision to the index of the first unfixed decision
 		actions.set_trailed(self.next, first_unfixed);
 
-		// select the next value to branch on based on the value selection strategy
+		// select the next value to branch on based on the value selection
+		// strategy
 		let view = next_var.lit(
 			actions,
 			match self.val_sel {
@@ -525,7 +531,8 @@ where
 						.next()
 						.expect("the domain of an unfixed decision variable is non-empty");
 					if intervals.next().is_some() {
-						// Several contiguous intervals: reduce to the first interval.
+						// Several contiguous intervals: reduce to the first
+						// interval.
 						IntLitMeaning::Less(*first.end() + 1)
 					} else {
 						// A single interval: bisect as `indomain_split`.
@@ -572,8 +579,8 @@ impl WarmStartBrancher {
 	/// # Ok::<(), Box<dyn std::error::Error>>(())
 	/// ```
 	pub fn new_in(solver: &mut impl BrancherInitActions, decisions: Vec<View<bool>>) {
-		// Filter out the decisions that are already satisfied or are known to cause
-		// a conflict
+		// Filter out the decisions that are already satisfied or are known to
+		// cause a conflict
 		let mut filtered_decision = Vec::new();
 		for d in decisions {
 			match d.0 {

--- a/crates/huub/src/solver/decision/integer.rs
+++ b/crates/huub/src/solver/decision/integer.rs
@@ -258,8 +258,8 @@ impl IntExplanationActions<State> for Decision<IntVal> {
 		);
 
 		let var_def = &ctx.int_vars[self.idx()];
-		// If we are looking for a not-equal literal, try and find it. Return it if we
-		// find it, otherwise defer to an order literal.
+		// If we are looking for a not-equal literal, try and find it. Return it
+		// if we find it, otherwise defer to an order literal.
 		if let IntLitMeaning::NotEq(v) = meaning {
 			if let Some((bv, _)) = var_def.try_lit(meaning) {
 				return (bv, IntLitMeaning::NotEq(v));
@@ -713,8 +713,8 @@ impl IntDecision {
 		let lb = *self.domain.min().unwrap();
 		let ub = *self.domain.max().unwrap();
 
-		// Use the order literals when requesting an equality literal of the global
-		// bounds.
+		// Use the order literals when requesting an equality literal of the
+		// global bounds.
 		let mut lit_req = match lit_req {
 			IntLitMeaning::Eq(i) if i == lb => IntLitMeaning::Less(lb + 1),
 			IntLitMeaning::NotEq(i) if i == lb => IntLitMeaning::GreaterEq(lb + 1),
@@ -985,8 +985,8 @@ impl IntDecision {
 		let lb = *self.domain.min().unwrap();
 		let ub = *self.domain.max().unwrap();
 
-		// Use the order literals when requesting an equality literal of the global
-		// bounds.
+		// Use the order literals when requesting an equality literal of the
+		// global bounds.
 		let mut lit_req = match lit_req {
 			IntLitMeaning::Eq(i) if i == lb => IntLitMeaning::Less(lb + 1),
 			IntLitMeaning::NotEq(i) if i == lb => IntLitMeaning::GreaterEq(lb + 1),
@@ -1550,7 +1550,8 @@ mod tests {
 				assert!(!x.in_domain(state, 4));
 			}
 
-			// Scenario 2: tighten the maximum to remove the original upper bound.
+			// Scenario 2: tighten the maximum to remove the original upper
+			// bound.
 			{
 				let (mut slv, x) = make_solver();
 				let (mut actions, mut engine) = slv.as_parts_mut();

--- a/crates/huub/src/solver/engine.rs
+++ b/crates/huub/src/solver/engine.rs
@@ -310,8 +310,8 @@ impl Engine {
 				if l == lit {
 					continue;
 				}
-				// Get the value of the original reason lit by negating again: ¬¬a
-				// gives a
+				// Get the value of the original reason lit by negating again:
+				// ¬¬a gives a
 				let val = Decision::<bool>(!l).val(&self.state.trail);
 				if !val.unwrap_or(false) {
 					tracing::error!(
@@ -415,7 +415,8 @@ impl PropagatorExtension for Engine {
 		use crate::actions::IntDecisionActions;
 
 		// Solver should not be in a failed state (no propagator conflict should
-		// exist), and any conflict should have been communicated to the SAT solver.
+		// exist), and any conflict should have been communicated to the SAT
+		// solver.
 		debug_assert!(!self.state.failed);
 		debug_assert!(self.state.conflict.is_none());
 		// All propagation should have been communicated to the SAT solver.
@@ -440,10 +441,11 @@ impl PropagatorExtension for Engine {
 					OrderStorage::Lazy(_)
 				));
 
-				// Fix the unfixed variable to the bound preferred by its polarity:
-				// a positive polarity fixes to the upper bound (by raising the
-				// lower bound), otherwise to the lower bound (by lowering the upper
-				// bound). Either way the required lazy literal is created.
+				// Fix the unfixed variable to the bound preferred by its
+				// polarity: a positive polarity fixes to the upper bound
+				// (by raising the lower bound), otherwise to the lower
+				// bound (by lowering the upper bound). Either way the
+				// required lazy literal is created.
 				match ctx.state.int_vars[r.idx()].polarity {
 					Some(Polarity::Positive) => {
 						let lb_lit = r.lit(&mut ctx, IntLitMeaning::GreaterEq(ub));
@@ -529,7 +531,8 @@ impl PropagatorExtension for Engine {
 							lit.val(&ctx).is_none(),
 							"brancher yielded an already fixed literal"
 						);
-						// The current brancher has selected a literal, return it as our decision
+						// The current brancher has selected a literal, return
+						// it as our decision
 						debug!(target: "solver", lit = i32::from(lit.0), "decide");
 						self.state.statistics.user_search_directives += 1;
 						return SearchDecision::Assign(lit.0);
@@ -540,11 +543,13 @@ impl PropagatorExtension for Engine {
 						ctx.set_trailed(Trail::CURRENT_BRANCHER, current);
 					}
 					Directive::Consumed => {
-						// The current brancher has signaled to never yield decisions again. Remove
-						// the brancher from the queue permanently.
+						// The current brancher has signaled to never yield
+						// decisions again. Remove the brancher from the
+						// queue permanently.
 						//
-						// Note that this shifts all subsequent branchers (so we don't need to
-						// increment current), but has bad complexity. However, due to the low
+						// Note that this shifts all subsequent branchers (so we
+						// don't need to increment current), but has bad
+						// complexity. However, due to the low
 						// number of branchers, this is (likely) acceptable.
 						self.branchers.remove(current);
 					}
@@ -556,15 +561,15 @@ impl PropagatorExtension for Engine {
 	}
 
 	fn explain_propagation(&mut self, propagated_lit: RawLit, mut clause: ClauseBuilder<'_>) {
-		// Find the stored reason, if any. When there is none, the reason clause is
-		// the unit clause `{propagated_lit}`; otherwise `EngineReason::explain`
-		// the full clause.
+		// Find the stored reason, if any. When there is none, the reason clause
+		// is the unit clause `{propagated_lit}`; otherwise
+		// `EngineReason::explain` the full clause.
 		let Some(r) = self.state.reason_map.remove(&propagated_lit) else {
 			clause.push(propagated_lit);
 			return;
 		};
-		// If the reason is lazy, restore the current state to the state when the
-		// propagation happened before explaining.
+		// If the reason is lazy, restore the current state to the state when
+		// the propagation happened before explaining.
 		if let EngineReason::Lazy { .. } = r {
 			self.state.trail.goto_assign_lit(propagated_lit);
 		}
@@ -649,9 +654,10 @@ impl PropagatorExtension for Engine {
 					IntLitMeaning::Eq(val) if val < lb || val > ub => {
 						// Notified of invalid assignment, do nothing.
 						//
-						// Although we do not expect this to happen, it seems that CaDiCaL
-						// chronological backtracking might send notifications before
-						// additional propagation.
+						// Although we do not expect this to happen, it seems
+						// that CaDiCaL chronological backtracking might
+						// send notifications before additional
+						// propagation.
 						trace!(
 							target: "solver",
 							lit = i32::from(lit),
@@ -664,8 +670,9 @@ impl PropagatorExtension for Engine {
 					IntLitMeaning::Eq(val) => {
 						#[cfg(debug_assertions)]
 						{
-							// (DEBUG ONLY) Push the integer variable and its value to check
-							// that its bounds were updated before propagation occurs.
+							// (DEBUG ONLY) Push the integer variable and its
+							// value to check that its bounds were
+							// updated before propagation occurs.
 							self.state.check_int_fixed.push((iv, val));
 						}
 						if val > lb {
@@ -750,14 +757,15 @@ impl PropagatorExtension for Engine {
 
 	fn notify_new_decision_level(&mut self) {
 		// Solver should not be in a failed state (no propagator conflict should
-		// exist), and any conflict should have been communicated to the SAT solver.
+		// exist), and any conflict should have been communicated to the SAT
+		// solver.
 		debug_assert!(!self.state.failed);
 		debug_assert!(self.state.conflict.is_none());
 		// All propagation should have been communicated to the SAT solver.
 		debug_assert!(self.state.propagation_queue.is_empty());
-		// Note that `self.state.clauses` may not be empty because [`Self::decide`]
-		// might have introduced a new literal, which would in turn add its defining
-		// clauses to `self.state.clauses`.
+		// Note that `self.state.clauses` may not be empty because
+		// [`Self::decide`] might have introduced a new literal, which would
+		// in turn add its defining clauses to `self.state.clauses`.
 
 		trace!(target: "solver", "new decision level");
 		self.state.notify_new_decision_level();
@@ -786,8 +794,8 @@ impl PropagatorExtension for Engine {
 			{
 				use crate::actions::{BoolInspectionActions, IntInspectionActions};
 
-				// (DEBUG ONLY) Check that all integers that where fixed by equality
-				// literals had their bound literals set to match.
+				// (DEBUG ONLY) Check that all integers that where fixed by
+				// equality literals had their bound literals set to match.
 				for (iv, i) in mem::take(&mut self.state.check_int_fixed) {
 					debug_assert_eq!(iv.val(&self.state), Some(i));
 					let lb_lit = iv
@@ -801,7 +809,8 @@ impl PropagatorExtension for Engine {
 			// If there are no previous changes, run propagators
 			SolvingContext::new(slv, &mut self.state).run_propagators(&mut self.propagators);
 		}
-		// Check whether there are new clauses that need to be communicated first
+		// Check whether there are new clauses that need to be communicated
+		// first
 		if !self.state.clauses.is_empty() {
 			return None;
 		}
@@ -813,8 +822,8 @@ impl PropagatorExtension for Engine {
 			self.state.register_reason(lit, reason);
 			#[cfg(debug_assertions)]
 			{
-				// (DEBUG ONLY) Ensure the literal's explanation is valid in its trail
-				// position.
+				// (DEBUG ONLY) Ensure the literal's explanation is valid in its
+				// trail position.
 				self.debug_check_reason(lit);
 			}
 			self.state.last_propagated = Some((lit, event));
@@ -1077,8 +1086,8 @@ impl State {
 		| SearchStrategy::Transition(SwitchTrigger::Conflicts(cfl)) = self.search_strategy
 		{
 			self.search_trigger += 1;
-			// Change search strategy if the counted number of conflicts exceeds the
-			// threshold
+			// Change search strategy if the counted number of conflicts exceeds
+			// the threshold
 			if self.search_trigger >= cfl {
 				self.sat_search = !self.sat_search;
 				self.search_trigger = 0;
@@ -1088,7 +1097,8 @@ impl State {
 					conflicts = self.statistics.conflicts,
 					"change search strategy after reaching conflict threshold"
 				);
-				// Transition has been completed. Strategy has permanently switched to SAT.
+				// Transition has been completed. Strategy has permanently
+				// switched to SAT.
 				if let SearchStrategy::Transition(_) = self.search_strategy {
 					self.search_strategy = SearchStrategy::Sat;
 				}
@@ -1104,8 +1114,8 @@ impl State {
 			| SearchStrategy::Transition(SwitchTrigger::Restarts(rst)) = self.search_strategy
 			{
 				self.search_trigger += 1;
-				// Change search strategy if the counted number of restarts exceeds the
-				// threshold
+				// Change search strategy if the counted number of restarts
+				// exceeds the threshold
 				if self.search_trigger >= rst {
 					self.sat_search = !self.sat_search;
 					self.search_trigger = 0;
@@ -1115,7 +1125,8 @@ impl State {
 						restarts = self.statistics.restarts,
 						"change search strategy after reaching restart threshold"
 					);
-					// Transition has been completed. Strategy has permanently switched to SAT.
+					// Transition has been completed. Strategy has permanently
+					// switched to SAT.
 					if let SearchStrategy::Transition(_) = self.search_strategy {
 						self.search_strategy = SearchStrategy::Sat;
 					}
@@ -1270,16 +1281,16 @@ mod tests {
 		slv.add_clause([(!imply).into(), ge_view]).unwrap();
 
 		let (mut actions, mut engine) = slv.as_parts_mut();
-		// Running propagate once communicates only the first consequence back to
-		// SAT. The lower-bound propagation remains queued, but its bound update is
-		// already visible in the integer trail.
+		// Running propagate once communicates only the first consequence back
+		// to SAT. The lower-bound propagation remains queued, but its bound
+		// update is already visible in the integer trail.
 		let propagated = ExternalPropagator::propagate(&mut *engine, &mut actions);
 		assert_eq!(propagated, Some(imply.0));
 		assert_eq!(engine.state.propagation_queue.len(), 1);
 		assert_eq!(engine.state.propagation_queue[0].lit, ge.0);
 
-		// SAT now reports both literals together. The queued lower-bound event must
-		// survive this path so the advisor is still notified.
+		// SAT now reports both literals together. The queued lower-bound event
+		// must survive this path so the advisor is still notified.
 		ExternalPropagator::notify_assignment(&mut *engine, &[imply.0, ge.0]);
 		assert_eq!(*notifications.borrow(), 1);
 

--- a/crates/huub/src/solver/initialization_context.rs
+++ b/crates/huub/src/solver/initialization_context.rs
@@ -65,7 +65,8 @@ fn is_advisor_of(
 impl BoolInitActions<InitializationContext<'_>> for Decision<bool> {
 	fn advise_when_fixed(&self, ctx: &mut InitializationContext<'_>, data: u64) {
 		if self.val(ctx.state).is_some() {
-			// The literal will never change, so we don't need to add an advisor.
+			// The literal will never change, so we don't need to add an
+			// advisor.
 			return;
 		}
 		// Otherwise, add the advisor to the engine
@@ -123,8 +124,8 @@ impl IntInitActions<InitializationContext<'_>> for Decision<IntVal> {
 	fn enqueue_when(&self, ctx: &mut InitializationContext<'_>, condition: IntPropCond) {
 		if self.val(ctx.state).is_some() {
 			ctx.semantic_enqueue = true;
-			// No further change will happen, so we don't need to the propagator to any
-			// activation lists.
+			// No further change will happen, so we don't need to the propagator
+			// to any activation lists.
 			return;
 		}
 		if condition != IntPropCond::Fixed {
@@ -303,8 +304,8 @@ impl<'a> InitializationContext<'a> {
 impl InitActions for InitializationContext<'_> {
 	fn advise_on_backtrack(&mut self) {
 		// Registering is idempotent, since a propagator is allowed to run its
-		// initialization actions again after it has been posted, and a duplicate
-		// entry would advise it of every backtrack twice.
+		// initialization actions again after it has been posted, and a
+		// duplicate entry would advise it of every backtrack twice.
 		if !self.state.notify_of_backtrack.contains(&self.prop) {
 			self.state.notify_of_backtrack.push(self.prop);
 		}

--- a/crates/huub/src/solver/solving_context.rs
+++ b/crates/huub/src/solver/solving_context.rs
@@ -147,10 +147,11 @@ impl IntDecisionActions<SolvingContext<'_>> for Decision<IntVal> {
 		let new_var = |def: LazyLitDef| {
 			// Create new variable
 			let v = ctx.slv.new_observed_var();
-			// Apply a phase hint to newly created (lazy) order literals according
-			// to the variable's polarity. The positive literal represents
-			// `x < val`, so a positive polarity (prefer large values) phases the
-			// negation. Direct (equality) literals are left unphased.
+			// Apply a phase hint to newly created (lazy) order literals
+			// according to the variable's polarity. The positive literal
+			// represents `x < val`, so a positive polarity (prefer large
+			// values) phases the negation. Direct (equality) literals are
+			// left unphased.
 			if matches!(def.meaning, IntLitMeaning::Less(_)) {
 				match polarity {
 					Some(Polarity::Positive) => ctx.slv.phase(!Into::<RawLit>::into(v)),
@@ -316,8 +317,8 @@ impl<'a> SolvingContext<'a> {
 		reason: impl FnOnce(&mut Self, &mut SolvingReasonSink<'_>),
 	) -> Result<(), Conflict<Decision<bool>>> {
 		let (lb, ub) = self.state.int_vars[iv.idx()].bounds(self);
-		// Check whether a change is redundant, conflicting, or new with respect to
-		// the bounds of an integer variable
+		// Check whether a change is redundant, conflicting, or new with respect
+		// to the bounds of an integer variable
 		let check = match change_req {
 			ChangeRequest::SetValue(i) if lb == i && ub == i => ChangeType::Redundant,
 			ChangeRequest::SetValue(i) if i < lb || i > ub => ChangeType::Conflicting,
@@ -334,8 +335,8 @@ impl<'a> SolvingContext<'a> {
 			return Ok(());
 		}
 
-		// Find the right literal, required whether we want to propagate, or raise a
-		// conflict
+		// Find the right literal, required whether we want to propagate, or
+		// raise a conflict
 		let new_var = |def: LazyLitDef| {
 			// Create new variable
 			let v = self.slv.new_observed_var();

--- a/crates/huub/src/solver/trail.rs
+++ b/crates/huub/src/solver/trail.rs
@@ -266,16 +266,16 @@ impl Trail {
 	/// Return the index for `sat_store` based on a [`RawVar`].
 	#[inline]
 	fn sat_index(var: RawVar) -> usize {
-		// TODO: Consider grounding (either always deduct 1 because there is no var
-		// 0, or at the least observed var)
+		// TODO: Consider grounding (either always deduct 1 because there is no
+		// var 0, or at the least observed var)
 		i32::from(var) as usize
 	}
 
 	/// Get the current assigned value for a literal (if any).
 	pub(crate) fn sat_value(&self, lit: impl Into<RawLit>) -> Option<bool> {
 		let lit = lit.into();
-		// Note that this doesn't use direct indexing as some operations might check
-		// the value of the variable before it is observed by the solver
+		// Note that this doesn't use direct indexing as some operations might
+		// check the value of the variable before it is observed by the solver
 		self.sat_store
 			.get(Self::sat_index(lit.var()))
 			.and_then(|store| store.value)

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-huub-cli = { path = "../crates/huub-cli" }
+humantime = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/xtask/src/completion.rs
+++ b/xtask/src/completion.rs
@@ -5,7 +5,7 @@ use std::{fs, path::PathBuf};
 use clap::{CommandFactory, Parser};
 use clap_complete::{Shell, generate};
 
-use crate::default_stage_dir;
+use crate::{cli::Cli, default_stage_dir};
 
 /// Arguments for completion generation.
 #[derive(Parser)]
@@ -24,7 +24,7 @@ impl CompletionsArgs {
 	pub(crate) fn run(self) {
 		let shells = self.selected_shells();
 
-		let mut command = huub_cli::Cli::<'static>::command();
+		let mut command = Cli::<'static>::command();
 		let command_name = command.get_name().to_owned();
 
 		for (shell, path) in shells {
@@ -88,11 +88,11 @@ mod tests {
 	use clap::CommandFactory;
 	use clap_complete::generate;
 
-	use crate::completion::Shell;
+	use crate::{cli::Cli, completion::Shell};
 
 	#[test]
 	fn bash_completion_contains_flags() {
-		let mut command = huub_cli::Cli::<'static>::command();
+		let mut command = Cli::<'static>::command();
 		let command_name = command.get_name().to_owned();
 		let mut completion = Vec::new();
 		generate(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,17 @@
 //! Workspace automation tasks for the Huub repository.
 
+// The Huub command-line interface is compiled into `xtask` directly, rather
+// than depended upon through the `huub-cli` crate, so that generating the shell
+// completions and the MiniZinc solver configuration does not require building
+// the solver. `cli.rs` is kept free of any dependency on the `huub` library for
+// this reason.
+#[path = "../../crates/huub-cli/src/cli.rs"]
+#[expect(
+	dead_code,
+	unreachable_pub,
+	reason = "xtask only inspects the interface, it never parses arguments with it"
+)]
+mod cli;
 mod completion;
 mod mzn_config;
 mod stage;

--- a/xtask/src/mzn_config.rs
+++ b/xtask/src/mzn_config.rs
@@ -6,7 +6,7 @@ use clap::{Arg, ArgAction, Command, CommandFactory, Parser};
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::default_stage_dir;
+use crate::{cli::Cli, default_stage_dir};
 
 /// Serialized MiniZinc extra flag entry.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -155,7 +155,7 @@ fn public_args(command: &Command) -> impl Iterator<Item = &Arg> {
 
 /// Build the MiniZinc solver configuration from the Clap command metadata.
 fn solver_config() -> SolverConfig {
-	let command = huub_cli::Cli::<'static>::command();
+	let command = Cli::<'static>::command();
 	SolverConfig {
 		name: "Huub".to_owned(),
 		version: env!("CARGO_PKG_VERSION"),


### PR DESCRIPTION
Depending on `huub-cli` pulled in `huub`, and with it a full CaDiCaL build, just
to read Clap's command metadata. `xtask` now compiles `cli.rs` through `#[path]`
instead, which requires moving the `Lowerer` defaults, the tracing helpers, and
the `ReduceType` conversion out of that module.
